### PR TITLE
Adding explicit widths to NOC direction for Verilator compatibility

### DIFF
--- a/bsg_noc/bsg_noc_pkg.v
+++ b/bsg_noc/bsg_noc_pkg.v
@@ -3,7 +3,7 @@
 
 // direction type
 package bsg_noc_pkg;
-  typedef enum logic[2:0] {P=0, W, E, N, S} Dirs;
+  typedef enum logic[2:0] {P=3'd0, W=3'd1, E=3'd2, N=3'd3, S=3'd4} Dirs;
 endpackage
 
 `endif

--- a/bsg_noc/bsg_noc_pkg.v
+++ b/bsg_noc/bsg_noc_pkg.v
@@ -3,7 +3,9 @@
 
 // direction type
 package bsg_noc_pkg;
-  typedef enum logic[2:0] {P=3'd0, W=3'd1, E=3'd2, N=3'd3, S=3'd4} Dirs;
+  // Explictly sizing enum values (P=3'd0, not P=0) is necessary per Verilator 4.015
+  // https://www.veripool.org/issues/1442-Verilator-Enum-values-without-explicit-widths-are-considered-unsized
+  typedef enum logic[2:0] {P=3'd0, W, E, N, S} Dirs;
 endpackage
 
 `endif


### PR DESCRIPTION
No functional change, but if you leave enum values unsized, it causes issues in concatenations involving them