### PR TITLE
Changing wormhole router to use bsg_noc_links instead of ready-valid

### DIFF
--- a/testing/bsg_noc/bsg_wormhole_router_adapter_in/Makefile
+++ b/testing/bsg_noc/bsg_wormhole_router_adapter_in/Makefile
@@ -1,4 +1,5 @@
 INCDIR = +incdir+$(BSG_IP_CORES_DIR)/bsg_misc
+INCDIR += +incdir+$(BSG_IP_CORES_DIR)/bsg_noc
 
 .PHONY: sim dve all
 
@@ -9,7 +10,7 @@ bsg_trace_rom.v: trace.tr
 		> bsg_trace_rom.v
 
 sim: bsg_trace_rom.v
-	vcs +v2k -R +lint=all,noSVA-UA,noSVA-NSVU,noVCDE -sverilog -full64 -f sv.include $(INCDIR) \
+	vcs -R +lint=all,noSVA-UA,noSVA-NSVU,noVCDE -sverilog -full64 -f sv.include $(INCDIR) \
 		-debug_pp -timescale=1ps/1ps +vcs+vcdpluson
 
 dve:

--- a/testing/bsg_noc/bsg_wormhole_router_adapter_in/sv.include
+++ b/testing/bsg_noc/bsg_wormhole_router_adapter_in/sv.include
@@ -1,5 +1,10 @@
 $BSG_IP_CORES_DIR/bsg_misc/bsg_defines.v
 $BSG_IP_CORES_DIR/bsg_misc/bsg_mux.v
+$BSG_IP_CORES_DIR/bsg_misc/bsg_circular_ptr.v
+$BSG_IP_CORES_DIR/bsg_dataflow/bsg_fifo_1r1w_small.v
+$BSG_IP_CORES_DIR/bsg_dataflow/bsg_fifo_tracker.v
+$BSG_IP_CORES_DIR/bsg_mem/bsg_mem_1r1w.v
+$BSG_IP_CORES_DIR/bsg_mem/bsg_mem_1r1w_synth.v
 $BSG_IP_CORES_DIR/bsg_test/bsg_nonsynth_clock_gen.v
 $BSG_IP_CORES_DIR/bsg_test/bsg_nonsynth_reset_gen.v
 $BSG_IP_CORES_DIR/bsg_noc/bsg_wormhole_router_adapter_in.v

--- a/testing/bsg_noc/bsg_wormhole_router_adapter_in/testbench.v
+++ b/testing/bsg_noc/bsg_wormhole_router_adapter_in/testbench.v
@@ -1,5 +1,7 @@
 module testbench();
-  
+ 
+  `include "bsg_noc_links.vh"
+
   parameter x_cord_width_p = 2;
   parameter y_cord_width_p = 2;
   parameter max_payload_width_p = 17;
@@ -33,7 +35,17 @@ module testbench();
   logic v_li, ready_lo;
   logic [flit_width_lp-1:0] data_lo;
   logic v_lo, ready_li;
- 
+
+  `declare_bsg_ready_and_link_sif_s(flit_width_lp, bsg_ready_and_link_sif_s);
+  bsg_ready_and_link_sif_s link_lo, link_li;
+
+  assign data_lo = link_lo.data;
+  assign v_lo    = link_lo.v;
+
+  assign link_li.v = '0;
+  assign link_li.data = '0;
+  assign link_li.ready_and_rev = ready_li;
+
   bsg_wormhole_router_adapter_in #(
     .max_num_flit_p(max_num_flit_p)
     ,.max_payload_width_p(max_payload_width_p)
@@ -47,15 +59,37 @@ module testbench();
     ,.v_i(v_li)
     ,.ready_o(ready_lo)
 
-    ,.data_o(data_lo)
-    ,.v_o(v_lo)
-    ,.ready_i(ready_li)
+    ,.link_o(link_lo)
+    ,.link_i(link_li)
   );
+
+  logic [flit_width_lp-1:0] fifo_data_lo;
+  logic fifo_yumi_li;
+  logic fifo_v_lo;
+  logic fifo_ready_lo;
+
+  bsg_fifo_1r1w_small #(
+    .width_p(flit_width_lp)
+    ,.els_p(16)
+  ) fifo_out (
+    .clk_i(clk)
+    ,.reset_i(reset)
+
+    ,.v_i(v_lo)
+    ,.data_i(data_lo)
+    ,.ready_o(fifo_ready_lo)
+
+    ,.data_o(fifo_data_lo)
+    ,.v_o(fifo_v_lo)
+    ,.yumi_i(fifo_yumi_li)
+  );
+  assign ready_li = fifo_ready_lo;
 
   parameter rom_addr_width_p = 10;
   logic [rom_addr_width_p-1:0] rom_addr;
   logic [max_packet_width_lp+4-1:0] rom_data;
   logic done;
+  logic tr_ready_lo;
 
   bsg_fsb_node_trace_replay #(
     .ring_width_p(max_packet_width_lp)
@@ -63,11 +97,11 @@ module testbench();
   ) tr (
     .clk_i(clk)
     ,.reset_i(reset)
-    ,.en_i(~reset)
+    ,.en_i(1'b1)
 
-    ,.v_i(v_lo)
-    ,.data_i({{(max_packet_width_lp-flit_width_lp){1'b0}}, data_lo})
-    ,.ready_o(ready_li)
+    ,.v_i(fifo_v_lo)
+    ,.data_i({{(max_packet_width_lp-flit_width_lp){1'b0}}, fifo_data_lo})
+    ,.ready_o(tr_ready_lo)
   
     ,.v_o(v_li)
     ,.data_o(data_li)
@@ -80,6 +114,8 @@ module testbench();
     ,.error_o()
   );
 
+  assign fifo_yumi_li = fifo_v_lo & tr_ready_lo;
+
   bsg_trace_rom #(
     .width_p(max_packet_width_lp+4)
     ,.addr_width_p(rom_addr_width_p)
@@ -90,6 +126,9 @@ module testbench();
 
   initial begin
     wait(done);
+    //for (integer i =0; i < 1000; i++) begin
+    //  @(posedge clk);
+    //end
     $finish;
   end 
 

--- a/testing/bsg_noc/bsg_wormhole_router_adapter_out/Makefile
+++ b/testing/bsg_noc/bsg_wormhole_router_adapter_out/Makefile
@@ -1,4 +1,5 @@
 INCDIR = +incdir+$(BSG_IP_CORES_DIR)/bsg_misc
+INCDIR += +incdir+$(BSG_IP_CORES_DIR)/bsg_noc
 
 .PHONY: sim dve all
 

--- a/testing/bsg_noc/bsg_wormhole_router_adapter_out/testbench.v
+++ b/testing/bsg_noc/bsg_wormhole_router_adapter_out/testbench.v
@@ -27,11 +27,19 @@ module testbench();
     ,.async_reset_o(reset)
   );
 
+  `declare_bsg_ready_and_link_sif_s(flit_width_lp, bsg_ready_and_link_sif_s);
+  bsg_ready_and_link_sif_s link_lo, link_li;
+
   logic [max_packet_width_lp-1:0] data_li;
   logic v_li, ready_lo;
   logic [max_packet_width_lp-1:0] data_lo;
   logic v_lo, ready_li;
  
+  assign link_li.data = data_li[0+:flit_width_lp];
+  assign link_li.v    = v_li;
+  assign link_li.ready_and_rev = 1'b0;
+
+  assign ready_lo = link_lo.ready_and_rev;
 
   bsg_wormhole_router_adapter_out #(
     .max_num_flit_p(max_num_flit_p)
@@ -42,9 +50,8 @@ module testbench();
     .clk_i(clk)
     ,.reset_i(reset)
     
-    ,.data_i(data_li[0+:flit_width_lp])
-    ,.v_i(v_li)
-    ,.ready_o(ready_lo)
+    ,.link_i(link_li)
+    ,.link_o(link_lo)
 
     ,.data_o(data_lo)
     ,.v_o(v_lo)


### PR DESCRIPTION
This PR changes the wormhole_router and _adapters to use bsg_noc links on the network side. The testbenches have been updated to work with the new interface and I've tested the whole system with new links on BlackParrot in a separate branch there.