### PR TITLE
set default max_step_p of bsg_counter_up_down in bsg_flow_counter to 1

### DIFF
--- a/bsg_dataflow/bsg_flow_counter.v
+++ b/bsg_dataflow/bsg_flow_counter.v
@@ -44,6 +44,7 @@ generate
     // the max value it can reach. 
     bsg_counter_up_down #( .max_val_p(els_p)  
                          , .init_val_p(els_p) 
+                         , .max_step_p(1)
                          ) counter
     
         ( .clk_i(clk_i)
@@ -57,6 +58,7 @@ generate
    end else begin: gen_blk_0
     bsg_counter_up_down #( .max_val_p(els_p)  
                          , .init_val_p(0) 
+                         , .max_step_p(1)
                          ) counter
     
         ( .clk_i(clk_i)


### PR DESCRIPTION
This change sets the max_step_p parameter to have a value of 1 for bsg_counter_up_down inside bsg_flow_counter. This eliminates a width mismatch warning from VCS and DC.

The bsg_flow_counter only ever increments or decrements by 1 since it is used to count tokens or credits of a single module between a r&v and valid-yumi input/output pair.