### PR TITLE
Wormhole Network Standalone

### DIFF
--- a/bsg_dataflow/bsg_serial_in_parallel_out_full_buffered.v
+++ b/bsg_dataflow/bsg_serial_in_parallel_out_full_buffered.v
@@ -1,0 +1,103 @@
+/**
+ *  bsg_serial_in_parallel_out_full_buffered.v
+ *
+ *  This is a simpler version of bsg_serial_in_parallel_out.
+ *  Output is only valid, when the output vector is fully assembled.
+ *  This version has zero bubble.
+ *
+ */
+
+module bsg_serial_in_parallel_out_full_buffered
+
+ #(parameter width_p     ="inv"
+  ,parameter els_p       ="inv"
+  ,parameter msb_first_p = 0
+  )
+  
+  (input clk_i
+  ,input reset_i
+    
+  ,input                                 v_i
+  ,output logic                          ready_o
+  ,input [width_p-1:0]                   data_i
+
+  ,output logic [els_p-1:0][width_p-1:0] data_o
+  ,output logic                          v_o
+  ,input                                 yumi_i
+  );
+  
+  localparam lg_els_lp     = `BSG_SAFE_CLOG2(els_p);
+  localparam end_count_lp  = (msb_first_p == 0)? els_p-1 : 0;
+  localparam init_count_lp = (msb_first_p == 0)? 0 : els_p-1;
+  
+  genvar i;
+  
+  logic [lg_els_lp-1:0] counter_r, counter_lo;
+  // fix bsg_decode evaluate to Z
+  assign counter_lo = counter_r;
+  
+  logic [els_p-1:0] fifo_valid_li, fifo_ready_lo;
+  logic [els_p-1:0] fifo_valid_lo, counter_decode_lo;
+  
+  assign ready_o = fifo_ready_lo[counter_lo];
+  assign v_o     = & fifo_valid_lo;
+  
+  bsg_decode
+ #(.num_out_p(els_p)
+  ) bd
+  (.i(counter_lo)
+  ,.o(counter_decode_lo)
+  );
+  
+  for (i = 0; i < els_p; i++) 
+  begin: fifos
+    
+    assign fifo_valid_li[i] = counter_decode_lo[i] & v_i;
+  
+    bsg_two_fifo
+    #(.width_p(width_p)
+    ) fifo
+    (.clk_i  (clk_i)
+    ,.reset_i(reset_i)
+
+    ,.ready_o(fifo_ready_lo[i])
+    ,.data_i (data_i)
+    ,.v_i    (fifo_valid_li[i])
+
+    ,.v_o    (fifo_valid_lo[i])
+    ,.data_o (data_o[i])
+    ,.yumi_i (yumi_i)
+    );
+    
+  end
+  
+  logic end_count_lo, count_up_lo, count_down_lo;
+  
+  always_comb 
+  begin
+    end_count_lo  = 1'b0;
+    count_up_lo   = 1'b0;
+    count_down_lo = 1'b0;
+    if (v_i & ready_o)
+        if (counter_decode_lo[end_count_lp])
+            end_count_lo = 1'b1;
+        else
+            if (msb_first_p == 0) 
+                count_up_lo = 1'b1;
+            else 
+                count_down_lo = 1'b1;
+  end
+  
+  bsg_counter_up_down 
+ #(.max_val_p(els_p-1)
+  ,.init_val_p(init_count_lp)
+  ,.max_step_p(1)
+  ) counter
+  (.clk_i  (clk_i)
+  ,.reset_i(reset_i | end_count_lo)
+  ,.up_i   (count_up_lo)
+  ,.down_i (count_down_lo)
+  ,.count_o(counter_r)
+  );
+
+endmodule

--- a/bsg_link/bsg_link_iddr_phy.v
+++ b/bsg_link/bsg_link_iddr_phy.v
@@ -1,0 +1,41 @@
+
+//
+// Paul Gao 03/2019
+//
+// This is an input DDR PHY
+// Posedge data are always registered before negedge data
+// Outside module should receive on posedge of clk_i for 2x wide data
+//
+// Note that the input clock and data wires need length match
+// Need input delay constraint(s) to ensure clock and data delay are same
+//
+//
+
+module bsg_link_iddr_phy
+
+ #(parameter width_p = "inv")
+
+  (input                  clk_i
+  ,input [width_p-1:0]    data_i
+  ,output [2*width_p-1:0] data_o
+  );
+  
+  logic [2*width_p-1:0] data_r;
+  logic [width_p-1:0] data_n_r, data_p_r;
+  
+  assign data_o = data_r;
+
+  always_ff @(posedge clk_i) 
+  begin
+    // First buffer posedge data into data_p_r
+    data_p_r <= data_i;
+    // Finally output to the data_r flop
+    // data_p_r occurs logically earlier in time than data_n_r
+    data_r <= {data_n_r, data_p_r};
+  end
+  
+  always_ff @(negedge clk_i)
+    // Then buffer negedge data into data_n_r
+    data_n_r <= data_i;
+
+endmodule

--- a/bsg_link/bsg_link_oddr_phy.v
+++ b/bsg_link/bsg_link_oddr_phy.v
@@ -1,0 +1,50 @@
+
+//
+// Paul Gao 03/2019
+//
+// This is an output DDR PHY
+// Input data must be synchronous to posedge of 1x clock (generated from 2x clock)
+// Output clock is center-aligned to output data
+//
+// Note that the output clock and data wires need length match
+// Need output delay constraint(s) to ensure clock and data delay are same
+//
+//
+
+module bsg_link_oddr_phy
+
+ #(parameter width_p = "inv")
+
+  (input                      reset_i
+  ,input                      clk_2x_i
+  ,input [2*width_p-1:0]      data_i
+  ,output logic [width_p-1:0] data_r_o
+  ,output logic               clk_r_o
+  );
+  
+  logic odd_r, clk_r;
+  
+  always_ff @(negedge clk_2x_i) 
+  begin
+    if (reset_i)
+        clk_r <= 1'b0;
+    else 
+        clk_r <= ~clk_r;
+    // Clock output flop
+    clk_r_o <= clk_r;
+  end
+    
+  always_ff @(posedge clk_2x_i)
+    if (reset_i) 
+        odd_r <= 1'b1;
+    else 
+        odd_r <= ~odd_r;
+
+  // Data output flop
+  always_ff @(posedge clk_2x_i)
+    if (odd_r) 
+        data_r_o <= data_i[0+:width_p];
+    else 
+        data_r_o <= data_i[width_p+:width_p];
+
+endmodule

--- a/bsg_link/bsg_link_source_sync_downstream.v
+++ b/bsg_link/bsg_link_source_sync_downstream.v
@@ -1,0 +1,274 @@
+// MBT 7/24/2014
+//
+// Updated by Paul Gao 02/2019
+//
+// DDR or center/edge-aligned SDR source synchronous input channel
+//
+// this implements:
+//     incoming source-synchronous capture flops
+//     async fifo to go from source-synchronous domain to core domain
+//     outgoing token channel to go from core domain deque to out of chip
+//     outgoing source-synchronous launch flops for token
+//
+// note, the default FIFO depth is set to 2^6 based on experiments on FPGA
+// Below is a rough calculation:
+//
+// 2 clks for channel crossing
+// 3 clks for receive fifo crossing
+// 1 clk for deque
+// 3 clks for receive token fifo crossing
+// 4 clks for token decimation
+// 2 clks for channel crossing
+// 3 clks for sender token fifo crossing
+// 1 clk  for sender credit counter adjust
+// -----------
+// 19 clks
+//
+// This leaves us with 45 elements of margin
+// for FPGA inefficiency. Since the FPGA may run
+// at 4X slower, this is equivalent to 3 FPGA cycles.
+//
+// Aside: SERDES make bandwidth-delay product much worse
+// because they simultaneously increase bandwidth and delay!
+//
+// io_*: signals synchronous to io_clk_i
+// core_*: signals synchronous to core_clk_i
+//
+
+module bsg_link_source_sync_downstream 
+
+ #(parameter channel_width_p                 = 16
+  ,parameter lg_fifo_depth_p                 = 6
+  ,parameter lg_credit_to_token_decimation_p = 3
+  
+  // Reset pattern is 0xF*
+  // This is a soft reset from link_upstream to link_downstream
+  // When channel data bits are in reset pattern, downstream link is on reset
+  // Note that this pattern must be the same for upstream and downstream links
+  
+  ,parameter reset_pattern_p = {channel_width_p {1'b1}}
+  )
+  
+  (// control signals
+   input                        core_clk_i
+  ,input                        core_link_reset_i
+
+  // source synchronous input channel; coming from chip edge
+  ,input                        io_clk_i     // sdi_sclk
+  ,input  [channel_width_p-1:0] io_data_i    // sdi_data
+  ,input                        io_valid_i   // sdi_valid
+  ,output                       io_token_r_o // sdi_token; output registered
+
+  // going into core; uses core clock
+  ,output [channel_width_p-1:0] core_data_o
+  ,output                       core_valid_o
+  ,input                        core_yumi_i
+  );
+  
+  
+  // local reset from core clock to io clock
+  logic io_reset_lo;
+  
+  bsg_launch_sync_sync 
+ #(.width_p(1)
+  ) local_reset_lss
+  (.iclk_i      (core_clk_i)
+  ,.iclk_reset_i(1'b0)
+  ,.oclk_i      (io_clk_i)
+  ,.iclk_data_i (core_link_reset_i)
+  ,.iclk_data_o ()
+  ,.oclk_data_o (io_reset_lo)
+  );
+  
+     
+  // internal reset signal
+  logic core_link_internal_reset_lo;
+  logic io_link_internal_reset_n, io_link_internal_reset_lo;
+  
+  // Soft reset signal coming from bsg_link_source_sync_upstream
+  assign io_link_internal_reset_n = (io_data_i==reset_pattern_p && ~io_valid_i);
+  
+  // Actual reset = remote_soft_reset | local_core_link_reset
+  // This is very useful when a link channel is left unused or physical IO
+  // pins are left floating (remote reset not available in these cases)
+  bsg_launch_sync_sync 
+ #(.width_p(1)
+  ) internal_reset_lss
+  (.iclk_i      (io_clk_i)
+  ,.iclk_reset_i(1'b0)
+  ,.oclk_i      (core_clk_i)
+  ,.iclk_data_i (io_link_internal_reset_n | io_reset_lo)
+  ,.iclk_data_o (io_link_internal_reset_lo)
+  ,.oclk_data_o (core_link_internal_reset_lo)
+  );
+                                 
+
+   // ******************************************
+   // clock-crossing async fifo (with DDR interface)
+   //
+   // Note that this async fifo also serves as receive buffer
+   // The buffer size depends on lg_fifo_depth_p (must match bsg_link_source_sync_upstream)
+   //
+   // With token based flow control, fifo should never overflow
+   // io_async_fifo_full signal is only for debugging purposes
+   //
+
+   wire   io_async_fifo_full;
+   wire   io_async_fifo_enq = io_valid_i; // enque if either valid bit set
+
+   // synopsys translate_off
+
+   always_ff @(negedge io_clk_i)
+     assert(!(io_async_fifo_full===1 && io_async_fifo_enq===1))
+       else $error("attempt to enque on full async fifo");
+
+   // synopsys translate_on
+
+
+   wire   core_actual_deque;
+   wire   core_valid_o_tmp;
+   logic [channel_width_p-1:0]   core_data_lo;
+
+  bsg_async_fifo 
+ #(.lg_size_p(lg_fifo_depth_p)
+  ,.width_p(channel_width_p)
+  ) baf
+  (.w_clk_i  (io_clk_i)
+  ,.w_reset_i(io_link_internal_reset_lo)
+  
+  ,.w_enq_i  (io_async_fifo_enq)
+  ,.w_data_i (io_data_i)
+  ,.w_full_o (io_async_fifo_full)
+
+  ,.r_clk_i  (core_clk_i)
+  ,.r_reset_i(core_link_internal_reset_lo)
+
+  ,.r_deq_i  (core_actual_deque)
+  ,.r_data_o (core_data_lo)
+  ,.r_valid_o(core_valid_o_tmp));
+
+
+   wire core_valid_o_pre_twofer = core_valid_o_tmp; // remove inout warning from lint
+   wire core_twofer_ready;
+
+  // Oct 17, 2014
+  // we insert a minimal fifo here for two purposes;
+  // first, this reduces critical
+  // paths causes by excessive access times of the async fifo.
+  //
+  // second, it ensures that asynchronous paths end inside of this module
+  // and do not propogate out to other modules that may be attached, complicating
+  // timing assertions.
+  //
+  bsg_two_fifo 
+ #(.width_p(channel_width_p)
+  ) twofer
+  (.clk_i  (core_clk_i)
+  ,.reset_i(core_link_internal_reset_lo)
+
+  // we feed this into the local yumi, but only if it is valid
+  ,.ready_o(core_twofer_ready)
+  ,.data_i (core_data_lo)
+  ,.v_i    (core_valid_o_pre_twofer)
+
+  ,.v_o    (core_valid_o)
+  ,.data_o (core_data_o)
+  ,.yumi_i (core_yumi_i)
+  );
+
+
+   // a word was transferred to the two input fifo if ...
+   wire core_transfer_success = core_valid_o_tmp & core_twofer_ready;
+   assign core_actual_deque = core_transfer_success;
+
+
+// **********************************************
+// credit return
+//
+// these are credits coming from the receive end of the async fifo in the core clk
+//  domain and passing to the io clk domain and out of the chip.
+//
+    
+
+   logic [lg_fifo_depth_p+1-1:0] core_credits_gray_r_iosync
+                                 , core_credits_binary_r_iosync
+                                 , io_credits_sent_r, io_credits_sent_r_gray
+                                 , io_credits_sent_r_p1, io_credits_sent_r_p2;
+
+   bsg_async_ptr_gray #(.lg_size_p(lg_fifo_depth_p+1)) bapg
+   (.w_clk_i   (core_clk_i)
+    ,.w_reset_i(core_link_internal_reset_lo)
+    ,.w_inc_i  (core_transfer_success)
+    ,.r_clk_i  (io_clk_i)
+    ,.w_ptr_binary_r_o() // not needed
+    ,.w_ptr_gray_r_o()   // not needed
+    ,.w_ptr_gray_r_rsync_o(core_credits_gray_r_iosync)
+    );
+
+   // this logic allows us to return two credits at a time
+   // note: generally relies on power-of-twoness of io_credits_sent_r
+   // to do correct wrap around.
+
+   assign io_credits_sent_r_p1 = io_credits_sent_r + (lg_fifo_depth_p+1)'(1);
+   assign io_credits_sent_r_p2 = io_credits_sent_r + (lg_fifo_depth_p+1)'(2);
+
+   // which bit of the io_credits_sent_r counter we use determines
+   // the value of the token line in credits
+   //
+   //
+   // this signal's register should be placed right next to the I/O pad:
+   //   glitch sensitive.
+
+   assign io_token_r_o = io_credits_sent_r[lg_credit_to_token_decimation_p];
+
+   // we actually absorb credits one or two at a time rather as fast as we can.
+   // this because otherwise we would not be slowing transition rates on the token
+   // signal, which is the whole point of tokens! this is slightly suboptimal,
+   // because if enough cycles have passed from the last
+   // time we sent a token, we could actually acknowledge things faster if we
+   // absorbed more than one credit at a time.
+   // that's okay. we skip this optimization.
+
+   // during token bypass mode, we hardwire the credit signal to the trigger mode signals;
+   // this gives the output channel control over the credit signal which
+   // allows it to toggle and reset the credit logic.
+
+   // the use of this trigger signal means that we should avoid the use of these
+   // two signals for calibration codes, so that we do not mix calibration codes
+   // when reset goes low with token reset operation, which would be difficult to avoid
+   // since generally we cannot control the timing of these reset signals when
+   // they cross asynchronous boundaries
+
+   // this is an optimized token increment system
+   // we actually gray code two options and compare against
+   // the incoming greycoded pointer. this is because it's cheaper
+   // to grey code than to de-gray code. moreover, we theorize it's cheaper
+   // to compute an incremented gray code than to add one to a pointer.
+   
+   assign io_credits_sent_r_gray = (io_credits_sent_r >> 1) ^ io_credits_sent_r;
+
+   logic [lg_fifo_depth_p+1-1:0] io_credits_sent_p1_r_gray;
+   
+   bsg_binary_plus_one_to_gray #(.width_p(lg_fifo_depth_p+1)) bsg_bp1_2g
+     (.binary_i(io_credits_sent_r)
+      ,.gray_o(io_credits_sent_p1_r_gray)
+      );
+   
+   wire empty_1 = (core_credits_gray_r_iosync != io_credits_sent_p1_r_gray);
+   wire empty_0 = (core_credits_gray_r_iosync != io_credits_sent_r_gray);
+
+   always_ff @(posedge io_clk_i)
+     begin
+        if (io_link_internal_reset_lo)
+          io_credits_sent_r <= { lg_fifo_depth_p+1 { 1'b0 } };
+        else
+          // we absorb up to two credits per cycles, since we receive at DDR,
+          // we need this to rate match the incoming data
+
+      // code is written like this because empty_1 is late relative to empty_0
+          io_credits_sent_r <= (empty_1
+                                ? (empty_0 ? io_credits_sent_r_p2 : io_credits_sent_r)
+                                : (empty_0 ? io_credits_sent_r_p1 : io_credits_sent_r));
+     end
+
+endmodule // bsg_source_sync_input

--- a/bsg_link/bsg_link_source_sync_upstream.v
+++ b/bsg_link/bsg_link_source_sync_upstream.v
@@ -37,7 +37,7 @@ module bsg_link_source_sync_upstream
        , parameter inactive_pattern_p = {channel_width_p { 2'b10 } }
        
        // Reset pattern is 0xF*
-       // This is a soft reset from link_upstream to link_downstream
+       // This is a remote reset from link_upstream to link_downstream
        // When channel data bits are in reset pattern, downstream link is on reset
        // Note that this pattern must be the same for upstream and downstream links
        
@@ -192,6 +192,8 @@ module bsg_link_source_sync_upstream
 
    always_ff @(posedge io_master_clk_i)
      begin
+        // remote reset signal going to bsg_link_source_sync_downstream
+        // This is asserted when core_link_reset_i=1 OR core_link_enable_i=0
         if (io_internal_reset_lo)
           {io_valid_r_o, io_data_r_o} <= {1'b0, reset_pattern_p[0+:channel_width_p]};
         else
@@ -219,6 +221,7 @@ module bsg_link_source_sync_upstream
     // **************************************************************
     // As shown above, token_reset_lo signal has a 0->1->0 pattern, where the
     // posedge (0->1) resets the token counter.
+    //
     
     logic token_reset_lo;
     assign token_reset_lo = ~io_reset_lo & ~io_enable_lo;

--- a/bsg_link/bsg_link_source_sync_upstream.v
+++ b/bsg_link/bsg_link_source_sync_upstream.v
@@ -1,0 +1,325 @@
+// MBT 7/24/2014
+//
+// Updated by Paul Gao 02/2019
+//
+//
+// this implements:
+//     - outgoing source-synchronous launch flops
+//     - outgoing token channel to go from core domain deque to out of chip
+//     - outgoing source-synchronous launch flops for token
+//     - center-aligned DDR source sync output clock
+//
+//
+// Note, for token clock reset, there is a certain pattern that must be asserted
+// and deasserted during io reset.
+//
+
+
+module bsg_link_source_sync_upstream
+     #(  parameter channel_width_p                 = 16
+       , parameter lg_fifo_depth_p                 = 6
+       , parameter lg_credit_to_token_decimation_p = 3
+
+       // we explicit set the "inactive pattern"
+       // on data lines when valid bit is not set
+       //  to (10)+ = 0xA*
+       //
+       // the inactive pattern should balance the current
+       // across I/O V33 and VZZ pads, reducing
+       // electromigration for the common case of not
+       // sending.
+       //
+       // for example, in TSMC 250, the EM limit is 41 mA
+       // and the ratio of signal to I/O V33 and VZZ is
+       // 4:1:1.
+       //
+
+       , parameter inactive_pattern_p = {channel_width_p { 2'b10 } }
+       
+       // Reset pattern is 0xF*
+       // This is a soft reset from link_upstream to link_downstream
+       // When channel data bits are in reset pattern, downstream link is on reset
+       // Note that this pattern must be the same for upstream and downstream links
+       
+       , parameter reset_pattern_p = {channel_width_p {1'b1} }
+       
+       )
+       
+   (// control signals  
+      input                         core_clk_i
+    , input                         core_link_reset_i
+    , input                         core_link_enable_i
+    
+    , input                         io_master_clk_i
+    , output                        io_reset_o
+    
+    // Input from chip core
+    , input [channel_width_p-1:0]   core_data_i
+    , input                         core_valid_i
+    , output                        core_ready_o  
+
+    // source synchronous output channel; going to chip edge
+    , output logic  [channel_width_p-1:0] io_data_r_o  // sdo_data
+    , output logic                        io_valid_r_o // sdo_valid
+    , input                               token_clk_i  // sdo_token; input clk
+   );
+
+   
+  // reset signal
+  logic core_link_reset_lo, io_reset_lo;
+  logic core_link_enable_lo, io_enable_lo;
+  assign io_reset_o = io_reset_lo;
+   
+  bsg_launch_sync_sync
+ #(.width_p(1)
+  ) reset_blss
+  (.iclk_i      (core_clk_i)
+  ,.iclk_reset_i(1'b0)
+  ,.oclk_i      (io_master_clk_i)
+  ,.iclk_data_i (core_link_reset_i)
+  ,.iclk_data_o (core_link_reset_lo)
+  ,.oclk_data_o (io_reset_lo)
+  );
+  
+  bsg_launch_sync_sync
+ #(.width_p(1)
+  ) enable_blss
+  (.iclk_i      (core_clk_i)
+  ,.iclk_reset_i(1'b0)
+  ,.oclk_i      (io_master_clk_i)
+  ,.iclk_data_i (core_link_enable_i)
+  ,.iclk_data_o (core_link_enable_lo)
+  ,.oclk_data_o (io_enable_lo)
+  );
+
+
+  // internal reset signal
+  logic core_internal_reset_lo, io_internal_reset_lo;
+  
+  // Internal reset mode if reset asserted or link not enabled
+  assign core_internal_reset_lo = ~core_link_enable_lo | core_link_reset_lo;
+  assign io_internal_reset_lo   = ~io_enable_lo        | io_reset_lo;
+
+
+  logic core_fifo_valid, core_fifo_yumi;
+  logic [channel_width_p-1:0] core_fifo_data;
+
+  // MBT: we insert a two-element fifo here to
+  // decouple the async fifo logic which can be on the critical
+  // path in some cases. possibly this is being overly conservative
+  // and may introduce too much latency. but certainly in the
+  // case of the bsg_comm_link code, it is necessary.
+  // fixme: possibly make it a parameter as to whether we instantiate
+  // this fifo
+   
+  bsg_two_fifo
+ #(.width_p(channel_width_p)
+  ) core_fifo
+  (.clk_i  (core_clk_i)
+  ,.reset_i(core_internal_reset_lo)
+  
+  ,.ready_o(core_ready_o)
+  ,.data_i (core_data_i)
+  ,.v_i    (core_valid_i)
+
+  ,.v_o    (core_fifo_valid)
+  ,.data_o (core_fifo_data)
+  ,.yumi_i (core_fifo_yumi)
+  );
+  
+  
+  logic core_fifo_full;
+  assign core_fifo_yumi = core_fifo_valid & ~core_fifo_full;
+  
+  logic io_fifo_valid, io_fifo_yumi;
+  logic [channel_width_p-1:0] io_fifo_data;
+  
+  // ******************************************
+  // clock-crossing async fifo
+  // this is just an output fifo and does not
+  // need to cover the round trip latency
+  // of the channel; just the clock domain crossing
+  //
+  // Assuming (A and B are registers with the corresponding clocks)
+  // this is the structure of the roundtrip path:
+  //
+  //                 /--  B <-- B <-- A <--\
+  //                |                      |
+  //                 \--> B --> A --> A ---/
+  //
+  // Suppose we have cycleTimeA and cycleTimeB, with cycleTimeA > cycleTimeB
+  // the bandwidth*delay product of the roundtrip is:
+  //
+  //   3 * (cycleTimeA + cycleTimeB) * min(1/cycleTimeA, 1/cycleTimeB)
+  // = 3 + 3 * cycleTimeB / cycleTimeA
+  //
+  // w.c. is cycleTimeB == cycleTimeA
+  //
+  // --> 6 elements
+  //
+  // however, for the path from A to B and B to A
+  // we need to clear not only the cycle time of A/B
+  // but the two setup times, which are guaranteed to
+  // be less than a cycle each. So we get 8 elements total.
+  //
+   
+  bsg_async_fifo
+ #(.lg_size_p(3)
+  ,.width_p(channel_width_p)
+  ) async_fifo
+  (.w_clk_i  (core_clk_i)
+  ,.w_reset_i(core_internal_reset_lo)
+
+  ,.w_enq_i  (core_fifo_yumi)
+  ,.w_data_i (core_fifo_data)
+  ,.w_full_o (core_fifo_full)
+
+  ,.r_clk_i  (io_master_clk_i)
+  ,.r_reset_i(io_internal_reset_lo)
+
+  ,.r_deq_i  (io_fifo_yumi)
+  ,.r_data_o (io_fifo_data)
+  ,.r_valid_o(io_fifo_valid)
+  );
+  
+
+   // ******************************************
+   // launch registers;
+   //
+   // set_dont_touch these and apply the
+   // static timing rules
+
+
+   always_ff @(posedge io_master_clk_i)
+     begin
+        if (io_internal_reset_lo)
+          {io_valid_r_o, io_data_r_o} <= {1'b0, reset_pattern_p[0+:channel_width_p]};
+        else
+          begin
+             io_valid_r_o <= io_fifo_yumi;
+             if (io_fifo_yumi)
+               io_data_r_o <= io_fifo_data;
+             else
+               io_data_r_o <= inactive_pattern_p [0+:channel_width_p];
+          end
+     end
+   
+   
+    //
+    // token async reset rules:
+    //
+    // Token counters use asynchronous reset signal, which means write clock 
+    // token_clk_i CANNOT oscillate during reset (constant 0).
+    // Token reset procedure:
+    // **************************************************************
+    //                   io_reset_lo   io_enable_lo   token_reset_lo
+    //    Initial value       1              0              0
+    //    Step 1              0              0              1
+    //    Step 2              0              1              0    
+    // **************************************************************
+    // As shown above, token_reset_lo signal has a 0->1->0 pattern, where the
+    // posedge (0->1) resets the token counter.
+    
+    logic token_reset_lo;
+    assign token_reset_lo = ~io_reset_lo & ~io_enable_lo;
+    
+
+   // we need to track whether the credits are coming from
+   // posedge or negedge tokens.
+
+   // high bit indicates which counter we are grabbing from
+   logic [lg_credit_to_token_decimation_p+1-1:0] token_alternator_r;
+
+   always_ff @(posedge io_master_clk_i)
+     begin
+        if (io_internal_reset_lo)
+          // this will start us on the posedge token
+          token_alternator_r <= '0;
+        else
+          if (io_fifo_yumi)
+            token_alternator_r <= token_alternator_r + (lg_credit_to_token_decimation_p+1)'(1);
+     end
+
+   // high bit set means we have exceeded number of posedge credits
+   // and are doing negedge credits
+   wire on_negedge_token = token_alternator_r[lg_credit_to_token_decimation_p];
+
+   logic io_negedge_credits_avail, io_posedge_credits_avail;
+
+   wire io_credit_avail = on_negedge_token
+        ? io_negedge_credits_avail
+        : io_posedge_credits_avail;
+
+   // we send if we have both data to send and credits to send with
+   assign io_fifo_yumi = io_credit_avail & io_fifo_valid;
+
+   wire io_negedge_credits_deque = io_fifo_yumi & on_negedge_token;
+   wire io_posedge_credits_deque = io_fifo_yumi & ~on_negedge_token;
+
+   // **********************************************
+   // token channel
+   //
+   // these are tokens coming from off chip that need to
+   // cross into the io clock domain.
+   //
+   // note that we are a little unconventional here; we use the token
+   // itself as a clock. this because we don't know the phase of the
+   // token signal coming in.
+   //
+   // we count both edges of the token separately, and assume that they
+   // will alternate in lock-step. we use two separate counters to do this.
+   //
+   // an alternative would be to use
+   // dual-edged flops, but they are not available in most ASIC libraries
+   // and although you can synthesize these out of XOR'd flops, they
+   // violate the async maxim that all signals crossing clock boundaries
+   // must come from a launch flop.
+
+   bsg_async_credit_counter
+     #(// half the credits will be positive edge tokens
+       .max_tokens_p(2**(lg_fifo_depth_p-1-lg_credit_to_token_decimation_p))
+       ,.lg_credit_to_token_decimation_p(lg_credit_to_token_decimation_p)
+       ,.count_negedge_p(1'b0)
+       // we enable extra margin in case downstream module wants more tokens
+       ,.extra_margin_p(2)
+       ,.start_full_p(1)
+       ,.use_async_w_reset_p(1'b1)
+       ) pos_credit_ctr
+       (
+        .w_clk_i   (token_clk_i)
+        ,.w_inc_token_i(1'b1)
+        ,.w_reset_i(token_reset_lo)
+
+        // the I/O clock domain is responsible for tabulating tokens
+        ,.r_clk_i  (io_master_clk_i)
+        ,.r_reset_i(io_internal_reset_lo)
+        ,.r_dec_credit_i      (io_posedge_credits_deque)
+        ,.r_infinite_credits_i(io_internal_reset_lo)
+        ,.r_credits_avail_o   (io_posedge_credits_avail)
+        );
+
+   bsg_async_credit_counter
+     #(// half the credits will be negative edge tokens
+       .max_tokens_p(2**(lg_fifo_depth_p-1-lg_credit_to_token_decimation_p))
+       ,.lg_credit_to_token_decimation_p(lg_credit_to_token_decimation_p)
+       ,.count_negedge_p(1'b1)
+       // we enable extra margin in case downstream module wants more tokens
+       ,.extra_margin_p(2)
+       ,.start_full_p(1)
+       ,.use_async_w_reset_p(1'b1)
+       ) neg_credit_ctr
+       (
+        .w_clk_i   (token_clk_i)
+        ,.w_inc_token_i(1'b1)
+        ,.w_reset_i(token_reset_lo)
+
+        // the I/O clock domain is responsible for tabulating tokens
+        ,.r_clk_i             (io_master_clk_i         )
+        ,.r_reset_i           (io_internal_reset_lo       )
+        ,.r_dec_credit_i      (io_negedge_credits_deque)
+        ,.r_infinite_credits_i(io_internal_reset_lo)
+        ,.r_credits_avail_o   (io_negedge_credits_avail)
+        );
+
+
+endmodule

--- a/bsg_misc/bsg_counter_dynamic_start_en_down.v
+++ b/bsg_misc/bsg_counter_dynamic_start_en_down.v
@@ -1,0 +1,38 @@
+
+//
+// Paul Gao 06/2019
+//
+// This is a count-down counter that supports dynamic start value
+// It counts down to last_val_p, then reset to start_i value
+// Counter is updated only if en_i is asserted
+// start_i must be of correct value when is_last_val_o is asserted
+//
+//
+
+module bsg_counter_dynamic_start_en_down
+
+ #(parameter width_p = "inv"
+  ,parameter last_val_p = "inv"
+  )
+
+  (input                      clk_i
+  ,input                      reset_i
+
+  ,input                      en_i
+  ,input        [width_p-1:0] start_i
+  ,output logic [width_p-1:0] counter_o
+  ,output                     is_last_val_o
+  );
+
+  assign is_last_val_o = (counter_o == last_val_p);
+  
+  always_ff @ (posedge clk_i)
+    if (reset_i)
+        counter_o <= last_val_p;
+    else if (en_i)
+        if (is_last_val_o) 
+            counter_o <= start_i;
+        else
+            counter_o <= counter_o - width_p'(1);
+
+endmodule

--- a/bsg_noc/bsg_noc_links.vh
+++ b/bsg_noc/bsg_noc_links.vh
@@ -31,4 +31,18 @@
       logic [in_data_width-1:0] data;                                     \
   } in_struct_name
 
+
+// bsg_noc_wormhole
+`define bsg_wormhole_packet_width(reserved_width_p, x_cord_width_p, y_cord_width_p, len_width_p, data_width_p) \
+  (reserved_width_p+x_cord_width_p+y_cord_width_p+len_width_p+data_width_p)
+  
+`define declare_bsg_wormhole_packet_s(width_p, reserved_width_p, x_cord_width_p, y_cord_width_p, len_width_p, in_struct_name) \
+  typedef struct packed {                                               \
+    logic [reserved_width_p-1:0] reserved;                              \
+    logic [x_cord_width_p-1:0] x_cord;                                  \
+    logic [y_cord_width_p-1:0] y_cord;                                  \
+    logic [len_width_p-1:0] len;                                        \
+    logic [width_p-reserved_width_p-x_cord_width_p-y_cord_width_p-len_width_p-1:0] data; \
+  } in_struct_name
+
  `endif // BSG_NOC_LINKS_VH


### PR DESCRIPTION
Pull request for standalone modules:

Modifying 1 current files:
bsg_noc_links.vh: Add wormhole packet data structure.

Adding 6 files:
bsg_serial_in_parallel_out_full_buffered.v: This de-serializer has 0 bubble in transition. It utilizes bsg_two_fifos inside as memory.
bsg_link_source_sync_downstream.v and bsg_link_source_sync_upstream.v: The new "common-link" modules, utilizing async-reset on token.
bsg_link_iddr_phy.v and bsg_link_oddr_phy.v: The DDR PHY for ASIC.
bsg_counter_dynamic_start_en_down.v: New count-down counter that has dynamic start value.

The corresponding testbench is on bsg_manycore repo: bsg_manycore/testbenches/manycore_loopback_ddr_link