### PR TITLE
Wormhole Packet Definition

### DIFF
--- a/bsg_noc/bsg_noc_links.vh
+++ b/bsg_noc/bsg_noc_links.vh
@@ -31,6 +31,9 @@
       logic [in_data_width-1:0] data;                                     \
   } in_struct_name
 
+`define bsg_ready_and_link_sif_s_cast(link_i, link_o, link_i_cast, link_o_cast) \
+  assign link_i_cast = link_i;                                                  \
+  assign link_o = link_o_cast // no semicolon
 
 /******************* bsg wormhole packet definition ******************/
 

--- a/bsg_noc/bsg_noc_links.vh
+++ b/bsg_noc/bsg_noc_links.vh
@@ -31,4 +31,18 @@
       logic [in_data_width-1:0] data;                                     \
   } in_struct_name
 
+
+// bsg_noc_wormhole
+`define bsg_wormhole_packet_width(reserved_width_p, x_cord_width_p, y_cord_width_p, len_width_p, data_width_p) \
+  (reserved_width_p+x_cord_width_p+y_cord_width_p+len_width_p+data_width_p)
+  
+`define declare_bsg_wormhole_packet_s(width_p, reserved_width_p, x_cord_width_p, y_cord_width_p, len_width_p, in_struct_name) \
+  typedef struct packed {                                               \
+    logic [reserved_width_p-1:0] reserved;                              \
+    logic [x_cord_width_p-1:0] x_cord;                                  \
+    logic [y_cord_width_p-1:0] y_cord;                                  \
+    logic [len_width_p-1:0] len;                                        \
+    logic [width_p-reserved_width_p-x_cord_width_p-y_cord_width_p-len_width_p-1:0] data; \
+  } in_struct_name
+
  `endif // BSG_NOC_LINKS_VH

--- a/bsg_noc/bsg_noc_links.vh
+++ b/bsg_noc/bsg_noc_links.vh
@@ -33,16 +33,25 @@
 
 
 // bsg_noc_wormhole
-`define bsg_wormhole_packet_width(reserved_width_p, x_cord_width_p, y_cord_width_p, len_width_p, data_width_p) \
-  (reserved_width_p+x_cord_width_p+y_cord_width_p+len_width_p+data_width_p)
+`define bsg_wormhole_packet_width(reserved_width, x_cord_width, y_cord_width, len_width, data_width) \
+  (reserved_width+x_cord_width+y_cord_width+len_width+data_width)
+ 
+`define declare_bsg_wormhole_packet_s(width, reserved_width, x_cord_width, y_cord_width, len_width, in_struct_name) \
+  typedef struct packed {                                                      \
+    logic [width-reserved_width-x_cord_width-y_cord_width-len_width-1:0] data; \
+    logic [reserved_width-1:0] reserved;                                       \
+    logic [len_width-1:0]      len;                                            \
+    logic [y_cord_width-1:0]   y_cord;                                         \
+    logic [x_cord_width-1:0]   x_cord;                                         \
+  } in_struct_name
   
-`define declare_bsg_wormhole_packet_s(width_p, reserved_width_p, x_cord_width_p, y_cord_width_p, len_width_p, in_struct_name) \
-  typedef struct packed {                                               \
-    logic [reserved_width_p-1:0] reserved;                              \
-    logic [x_cord_width_p-1:0] x_cord;                                  \
-    logic [y_cord_width_p-1:0] y_cord;                                  \
-    logic [len_width_p-1:0] len;                                        \
-    logic [width_p-reserved_width_p-x_cord_width_p-y_cord_width_p-len_width_p-1:0] data; \
+`define declare_bsg_channel_tunnel_wormhole_packet_s(width, reserved_width, x_cord_width, y_cord_width, len_width, in_struct_name) \
+  typedef struct packed {                                                      \
+    logic [reserved_width-1:0] reserved;                                       \
+    logic [width-reserved_width-x_cord_width-y_cord_width-len_width-1:0] data; \
+    logic [len_width-1:0]      len;                                            \
+    logic [y_cord_width-1:0]   y_cord;                                         \
+    logic [x_cord_width-1:0]   x_cord;                                         \
   } in_struct_name
 
  `endif // BSG_NOC_LINKS_VH

--- a/bsg_noc/bsg_noc_links.vh
+++ b/bsg_noc/bsg_noc_links.vh
@@ -48,6 +48,14 @@
 
 /******************* bsg wormhole header flit definition ******************/
 
+`define declare_bsg_header_flit_no_reserved_s(width, x_cord_width, y_cord_width, len_width, in_struct_name) \
+  typedef struct packed {                                                      \
+    logic [width-x_cord_width-y_cord_width-len_width-1:0] data_and_reserved;   \
+    logic [len_width-1:0]      len;                                            \
+    logic [y_cord_width-1:0]   y_cord;                                         \
+    logic [x_cord_width-1:0]   x_cord;                                         \
+  } in_struct_name
+
 `define declare_bsg_header_flit_s(width, reserved_width, x_cord_width, y_cord_width, len_width, in_struct_name) \
   typedef struct packed {                                                      \
     logic [width-reserved_width-x_cord_width-y_cord_width-len_width-1:0] data; \

--- a/bsg_noc/bsg_noc_links.vh
+++ b/bsg_noc/bsg_noc_links.vh
@@ -32,11 +32,23 @@
   } in_struct_name
 
 
-// bsg_noc_wormhole
+/******************* bsg wormhole packet definition ******************/
+
 `define bsg_wormhole_packet_width(reserved_width, x_cord_width, y_cord_width, len_width, data_width) \
   (reserved_width+x_cord_width+y_cord_width+len_width+data_width)
- 
-`define declare_bsg_wormhole_packet_s(width, reserved_width, x_cord_width, y_cord_width, len_width, in_struct_name) \
+
+`define declare_bsg_wormhole_packet_s(reserved_width, x_cord_width, y_cord_width, len_width,  data_width, in_struct_name) \
+  typedef struct packed {                                                      \
+    logic [data_width-1:0]     data;                                           \
+    logic [reserved_width-1:0] reserved;                                       \
+    logic [len_width-1:0]      len;                                            \
+    logic [y_cord_width-1:0]   y_cord;                                         \
+    logic [x_cord_width-1:0]   x_cord;                                         \
+  } in_struct_name
+
+/******************* bsg wormhole header flit definition ******************/
+
+`define declare_bsg_header_flit_s(width, reserved_width, x_cord_width, y_cord_width, len_width, in_struct_name) \
   typedef struct packed {                                                      \
     logic [width-reserved_width-x_cord_width-y_cord_width-len_width-1:0] data; \
     logic [reserved_width-1:0] reserved;                                       \
@@ -45,7 +57,7 @@
     logic [x_cord_width-1:0]   x_cord;                                         \
   } in_struct_name
   
-`define declare_bsg_channel_tunnel_wormhole_packet_s(width, reserved_width, x_cord_width, y_cord_width, len_width, in_struct_name) \
+`define declare_bsg_channel_tunnel_header_flit_s(width, reserved_width, x_cord_width, y_cord_width, len_width, in_struct_name) \
   typedef struct packed {                                                      \
     logic [reserved_width-1:0] reserved;                                       \
     logic [width-reserved_width-x_cord_width-y_cord_width-len_width-1:0] data; \


### PR DESCRIPTION
This definition is a little bit tricky:

1. wormhole_packet_width: Given a payload data packet, what is the minimum bits needed for the full wormhole packet (including both header and payload). 
2. wormhole_packet_s: Given a pre-calculated full packet width (which is multiple of wormhole channel width), define the wormhole packet struct. 