### PR TITLE
Use extra data bit in bsg link ddr

### DIFF
--- a/bsg_link/bsg_link_ddr_downstream.v
+++ b/bsg_link/bsg_link_ddr_downstream.v
@@ -94,6 +94,9 @@ module bsg_link_ddr_downstream
     //synopsys translate_off
     always_ff @ (negedge io_clk_i[i]) 
       begin
+      // Do not assert when either one evaluates to X, Z, or both evaluate to 0
+      // Also do not assert when reset signal evaluates to X or Z
+      if ((io_iddr_v_1 | io_iddr_v_0) & (io_link_reset_i[i] | ~io_link_reset_i[i]))
         assert ((io_iddr_v_1==io_iddr_v_0) | io_link_reset_i[i])
         else
           begin

--- a/bsg_link/bsg_link_ddr_upstream.v
+++ b/bsg_link/bsg_link_ddr_upstream.v
@@ -30,6 +30,7 @@ module bsg_link_ddr_upstream
 
  #(// Core data width
   // MUST be multiple of (2*channel_width_p*num_channels_p) 
+  // When use_extra_data_bit_p=1, must be multiple of ((2*channel_width_p+1)*num_channels_p) 
    parameter width_p         = "inv"
   // Number of IO pins per physical IO channels
   ,parameter channel_width_p = 8
@@ -45,7 +46,14 @@ module bsg_link_ddr_upstream
   // Default value comes from child module
   // Refer to bsg_link_source_sync_downstream for more detail on this parameter
   ,parameter lg_credit_to_token_decimation_p = 3
-  ,localparam ddr_width_lp = channel_width_p*2
+  // There are (channel_width_p+1) physical wires available (1 wire for valid bit)
+  // With DDR clock, we can handle 2*channel_width_p+2 bits each cycle
+  // By default the link has 2*channel_width_p data bits and 1 valid bit, 1 bit is unused
+  // Set use_extra_data_bit_p=1 to utilize this extra bit
+  // MUST MATCH paired bsg_link_ddr_downstream setting
+  ,parameter use_extra_data_bit_p = 0
+  ,localparam ddr_width_lp = (use_extra_data_bit_p==0)? channel_width_p*2 
+                                                      : channel_width_p*2+1
   ,localparam piso_ratio_lp = width_p/(ddr_width_lp*num_channels_p)
   )
 
@@ -97,7 +105,10 @@ module bsg_link_ddr_upstream
   begin: ch
     
     logic io_oddr_valid_li, io_oddr_ready_lo;
-    logic [channel_width_p-1:0] io_oddr_data_0, io_oddr_data_1;
+    // data_0 width is fixed
+    logic [channel_width_p-1:0] io_oddr_data_0;
+    // data_1 width is determined by use_extra_data_bit_p setting
+    logic [ddr_width_lp-1:channel_width_p] io_oddr_data_1;
 
     bsg_link_source_sync_upstream
    #(.channel_width_p(ddr_width_lp)
@@ -129,8 +140,8 @@ module bsg_link_ddr_upstream
     ) oddr_phy
     (.reset_i (io_link_reset_i)
     ,.clk_i   (io_clk_i)
-    ,.data_i  ({{io_oddr_valid_li, io_oddr_data_1},
-                {io_oddr_valid_li, io_oddr_data_0}}) // copy the valid bit for both words
+    ,.data_i  ({{(channel_width_p+1)'(io_oddr_data_1)},
+                {io_oddr_valid_li, io_oddr_data_0}}) // valid signal is sent out in first cycle
     ,.ready_o (io_oddr_ready_lo)
     ,.data_r_o({io_valid_r_o[i], io_data_r_o[i]})
     ,.clk_r_o (io_clk_r_o[i])
@@ -145,14 +156,14 @@ module bsg_link_ddr_upstream
     assert (piso_ratio_lp > 0)
     else 
       begin 
-        $error("BaseJump STL ERROR %m: width_p should be larger than or equal to (2*channel_width_p*num_channels_p)");
+        $error("BaseJump STL ERROR %m: width_p should be larger than or equal to (ddr_width_lp*num_channels_p)");
         $finish;
       end
       
     assert (piso_ratio_lp*(ddr_width_lp*num_channels_p) == width_p)
     else 
       begin 
-        $error("BaseJump STL ERROR %m: width_p should be multiple of (2*channel_width_p*num_channels_p)");
+        $error("BaseJump STL ERROR %m: width_p should be multiple of (ddr_width_lp*num_channels_p)");
         $finish;
       end
   end


### PR DESCRIPTION
During simulation, this assertion is falsely triggered because initial value of reset_i, v_0 and v_1 are all X... Do not assert when reset signal is X or Z, when v_0 and v_1 is X, Z or both zero.
