### PR TITLE
Hotfix BSG Unconcentrate Static for Synthesis

### DIFF
--- a/bsg_misc/bsg_defines.v
+++ b/bsg_misc/bsg_defines.v
@@ -19,9 +19,9 @@
 `endif
 
 `ifdef SYNTHESIS
-`define BSG_DISCONNECT 1'b0
+`define BSG_DISCONNECTED 1'b0
 `else
-`define BSG_DISCONNECT 1'bz
+`define BSG_DISCONNECTED 1'bz
 `endif
 
 // using C-style shifts instead of a[i] allows the parameter of BSG_GET_BIT to be a parameter subrange                                                                                                                                                                               

--- a/bsg_misc/bsg_defines.v
+++ b/bsg_misc/bsg_defines.v
@@ -19,9 +19,9 @@
 `endif
 
 `ifdef SYNTHESIS
-`define BSG_DISCONNECTED 1'b0
+`define BSG_DISCONNECTED_IN_SIM 1'b0
 `else
-`define BSG_DISCONNECTED 1'bz
+`define BSG_DISCONNECTED_IN_SIM 1'bz
 `endif
 
 // using C-style shifts instead of a[i] allows the parameter of BSG_GET_BIT to be a parameter subrange                                                                                                                                                                               

--- a/bsg_misc/bsg_defines.v
+++ b/bsg_misc/bsg_defines.v
@@ -18,6 +18,12 @@
 `define BSG_UNDEFINED_IN_SIM(val) ('X)
 `endif
 
+`ifdef SYNTHESIS
+`define BSG_DISCONNECT 1'b0
+`else
+`define BSG_DISCONNECT 1'bz
+`endif
+
 // using C-style shifts instead of a[i] allows the parameter of BSG_GET_BIT to be a parameter subrange                                                                                                                                                                               
 // e.g., parameter[4:1][1], which DC 2016.12 does not allow                                                                                                                                                                                                                          
 

--- a/bsg_misc/bsg_defines.v
+++ b/bsg_misc/bsg_defines.v
@@ -19,9 +19,9 @@
 `endif
 
 `ifdef SYNTHESIS
-`define BSG_DISCONNECTED_IN_SIM 1'b0
+`define BSG_DISCONNECTED_IN_SIM(val) (val)
 `else
-`define BSG_DISCONNECTED_IN_SIM 1'bz
+`define BSG_DISCONNECTED_IN_SIM(val) ('z)
 `endif
 
 // using C-style shifts instead of a[i] allows the parameter of BSG_GET_BIT to be a parameter subrange                                                                                                                                                                               

--- a/bsg_misc/bsg_unconcentrate_static.v
+++ b/bsg_misc/bsg_unconcentrate_static.v
@@ -11,14 +11,14 @@ module bsg_unconcentrate_static #(pattern_els_p="inv"
    if (pattern_els_p[0])
      assign o[0] = i[0];
    else
-     assign o[0] = `BSG_DISCONNECTED_IN_SIM;
+     assign o[0] = `BSG_DISCONNECTED_IN_SIM(1'b0);
 
    for (j = 1; j < $bits(pattern_els_p); j=j+1)
      begin: rof
              if (pattern_els_p[j])
                assign o[j] = i[`BSG_COUNTONES_SYNTH(pattern_els_p[j-1:0])];
              else
-               assign o[j] = `BSG_DISCONNECTED_IN_SIM;
+               assign o[j] = `BSG_DISCONNECTED_IN_SIM(1'b0);
      end
 
 endmodule

--- a/bsg_misc/bsg_unconcentrate_static.v
+++ b/bsg_misc/bsg_unconcentrate_static.v
@@ -11,14 +11,14 @@ module bsg_unconcentrate_static #(pattern_els_p="inv"
    if (pattern_els_p[0])
      assign o[0] = i[0];
    else
-     assign o[0] = `BSG_DISCONNECTED;
+     assign o[0] = `BSG_DISCONNECTED_IN_SIM;
 
    for (j = 1; j < $bits(pattern_els_p); j=j+1)
      begin: rof
              if (pattern_els_p[j])
                assign o[j] = i[`BSG_COUNTONES_SYNTH(pattern_els_p[j-1:0])];
              else
-               assign o[j] = `BSG_DISCONNECTED;
+               assign o[j] = `BSG_DISCONNECTED_IN_SIM;
      end
 
 endmodule

--- a/bsg_misc/bsg_unconcentrate_static.v
+++ b/bsg_misc/bsg_unconcentrate_static.v
@@ -10,15 +10,19 @@ module bsg_unconcentrate_static #(pattern_els_p="inv"
 
    if (pattern_els_p[0])
      assign o[0] = i[0];
+   // synopsys translate_off
    else
      assign o[0] = 'z;
+   // synopsys translate_on
 
    for (j = 1; j < $bits(pattern_els_p); j=j+1)
      begin: rof
              if (pattern_els_p[j])
                assign o[j] = i[`BSG_COUNTONES_SYNTH(pattern_els_p[j-1:0])];
+             // synopsys translate_off
              else
                assign o[j] = 'z;
+             // synopsys translate_on
      end
 
 endmodule

--- a/bsg_misc/bsg_unconcentrate_static.v
+++ b/bsg_misc/bsg_unconcentrate_static.v
@@ -10,19 +10,15 @@ module bsg_unconcentrate_static #(pattern_els_p="inv"
 
    if (pattern_els_p[0])
      assign o[0] = i[0];
-   // synopsys translate_off
    else
-     assign o[0] = 'z;
-   // synopsys translate_on
+     assign o[0] = `BSG_DISCONNECT;
 
    for (j = 1; j < $bits(pattern_els_p); j=j+1)
      begin: rof
              if (pattern_els_p[j])
                assign o[j] = i[`BSG_COUNTONES_SYNTH(pattern_els_p[j-1:0])];
-             // synopsys translate_off
              else
-               assign o[j] = 'z;
-             // synopsys translate_on
+               assign o[j] = `BSG_DISCONNECT;
      end
 
 endmodule

--- a/bsg_misc/bsg_unconcentrate_static.v
+++ b/bsg_misc/bsg_unconcentrate_static.v
@@ -11,14 +11,14 @@ module bsg_unconcentrate_static #(pattern_els_p="inv"
    if (pattern_els_p[0])
      assign o[0] = i[0];
    else
-     assign o[0] = `BSG_DISCONNECT;
+     assign o[0] = `BSG_DISCONNECTED;
 
    for (j = 1; j < $bits(pattern_els_p); j=j+1)
      begin: rof
              if (pattern_els_p[j])
                assign o[j] = i[`BSG_COUNTONES_SYNTH(pattern_els_p[j-1:0])];
              else
-               assign o[j] = `BSG_DISCONNECT;
+               assign o[j] = `BSG_DISCONNECTED;
      end
 
 endmodule


### PR DESCRIPTION
'z will get synthesized into tri-state (not disconnect as it is intended here). Therefore, I surrounded the 'z assigns in translate off/on pragmas so that DC simply leaves them disconnected.