### PR TITLE
Added XILINX attributes to eliminate FPU timing loops/warnings

### DIFF
--- a/bsg_fpu/bsg_fpu_add_sub.v
+++ b/bsg_fpu/bsg_fpu_add_sub.v
@@ -96,10 +96,18 @@ module bsg_fpu_add_sub
 
   assign larger_exp = (exp_a_less ? exp_b : exp_a) + 1'b1;
 
-  assign exp_diff = exp_a_less 
-    ? exp_b - exp_a
-    : exp_a - exp_b;
+  // The following KEEP attribute prevents the following warning in the Xilinx
+  // toolchain. It may stop the tool from inferring a timing loop in the FPU: 
+  // [Synth 8-5818] HDL ADVISOR - The operator resource <adder> is
+  // shared. To prevent sharing consider applying a KEEP on the output of the
+  // operator [<path>/bsg_fpu_add_sub.v:104].
+  /* keep = "true" */ logic [e_p-1:0] diff_ab, diff_ba;
 
+  assign diff_ab = exp_a - exp_b;
+  assign diff_ba = exp_b - exp_a;
+    
+  assign exp_diff = exp_a_less ? diff_ba : diff_ab;
+    
   // hidden bit of mantissa
   // filtered out denormalized input
   logic [m_p:0] man_a_norm, man_b_norm;

--- a/bsg_fpu/bsg_fpu_add_sub.v
+++ b/bsg_fpu/bsg_fpu_add_sub.v
@@ -100,7 +100,7 @@ module bsg_fpu_add_sub
   // toolchain. It may stop the tool from inferring a timing loop in the FPU: 
   // [Synth 8-5818] HDL ADVISOR - The operator resource <adder> is
   // shared. To prevent sharing consider applying a KEEP on the output of the
-  // operator [<path>/bsg_fpu_add_sub.v:104].
+  // operator [<path>/bsg_fpu_add_sub.v:104]. (Xilinx Vivado 2018.2)
   /* keep = "true" */ logic [e_p-1:0] diff_ab, diff_ba;
 
   assign diff_ab = exp_a - exp_b;

--- a/bsg_fpu/bsg_fpu_i2f.v
+++ b/bsg_fpu/bsg_fpu_i2f.v
@@ -52,7 +52,7 @@ module bsg_fpu_i2f
   // The following KEEP attribute prevents the following warning in the Xilinx
   // toolchain: [Synth 8-3936] Found unconnected internal register
   // 'chosen_abs_1_r_reg' and it is trimmed from '32' to '31'
-  // bits. [<path>/bsg_fpu_i2f.v:98]
+  // bits. [<path>/bsg_fpu_i2f.v:98] (Xilinx Vivado 2018.2)
   /* keep = "true" */ logic [width_lp-1:0] chosen_abs;
 
   bsg_abs #(
@@ -84,7 +84,7 @@ module bsg_fpu_i2f
   // The following KEEP attribute prevents the following warning in the Xilinx
   // toolchain: [Synth 8-3936] Found unconnected internal register
   // 'chosen_abs_1_r_reg' and it is trimmed from '32' to '31'
-  // bits. [<path>/bsg_fpu_i2f.v:98]
+  // bits. [<path>/bsg_fpu_i2f.v:98] (Xilinx Vivado 2018.2)
   /* keep = "true" */ logic [width_lp-1:0] chosen_abs_1_r;
   logic [`BSG_SAFE_CLOG2(width_lp)-1:0] shamt_1_r;
   logic sign_1_r;

--- a/bsg_fpu/bsg_fpu_i2f.v
+++ b/bsg_fpu/bsg_fpu_i2f.v
@@ -48,9 +48,12 @@ module bsg_fpu_i2f
     : 1'b0;
 
   // calculate absolute value
-  //
   logic [width_lp-1:0] abs;
-  logic [width_lp-1:0] chosen_abs;
+  // The following KEEP attribute prevents the following warning in the Xilinx
+  // toolchain: [Synth 8-3936] Found unconnected internal register
+  // 'chosen_abs_1_r_reg' and it is trimmed from '32' to '31'
+  // bits. [<path>/bsg_fpu_i2f.v:98]
+  /* keep = "true" */ logic [width_lp-1:0] chosen_abs;
 
   bsg_abs #(
     .width_p(width_lp)
@@ -78,7 +81,11 @@ module bsg_fpu_i2f
 
   /////////// first pipeline stage /////////////
 
-  logic [width_lp-1:0] chosen_abs_1_r;
+  // The following KEEP attribute prevents the following warning in the Xilinx
+  // toolchain: [Synth 8-3936] Found unconnected internal register
+  // 'chosen_abs_1_r_reg' and it is trimmed from '32' to '31'
+  // bits. [<path>/bsg_fpu_i2f.v:98]
+  /* keep = "true" */ logic [width_lp-1:0] chosen_abs_1_r;
   logic [`BSG_SAFE_CLOG2(width_lp)-1:0] shamt_1_r;
   logic sign_1_r;
   logic all_zero_1_r;


### PR DESCRIPTION
These added attributes solve warnings in the Xilinx tool chain related to: 
* Unused registers (Trimmed)
* Resource Sharing

The latter prevents a timing loop from being inferred in the toolchain, or at
least prevents the messages from occurring.

This is preliminary. We don't have a failure case (yet), but we do have the warnings.