### PR TITLE
Converting bsg_mem_xr1w.v assertions to pure logical expressions

### DIFF
--- a/bsg_mem/bsg_mem_1r1w.v
+++ b/bsg_mem/bsg_mem_1r1w.v
@@ -48,7 +48,7 @@ module bsg_mem_1r1w #(parameter width_p=-1
           assert ((w_reset_i === 'X) || (w_reset_i === 1'b1) || (w_addr_i < els_p))
             else $error("Invalid address %x to %m of size %x (w_reset_i=%b, w_v_i=%b)\n", w_addr_i, els_p, w_reset_i, w_v_i);
 
-          assert ((w_reset_i === 'X) || (w_reset_i === 1'b1) || ~(r_addr_i == w_addr_i && w_v_i && r_v_i && !read_write_same_addr_p))
+          assert ((w_reset_i === 'X) || (w_reset_i === 1'b1) || !(r_addr_i == w_addr_i && w_v_i && r_v_i && !read_write_same_addr_p))
             else $error("%m: Attempt to read and write same address %x (w_v_i = %b, w_reset_i = %b)",w_addr_i,w_v_i,w_reset_i);
        end
 

--- a/bsg_mem/bsg_mem_2r1w.v
+++ b/bsg_mem/bsg_mem_2r1w.v
@@ -42,10 +42,10 @@ module bsg_mem_2r1w #(parameter width_p=-1
           assert (w_addr_i < els_p)
             else $error("Invalid address %x to %m of size %x\n", w_addr_i, els_p);
 
-          assert (~(r0_addr_i == w_addr_i && w_v_i && r0_v_i && !read_write_same_addr_p))
+          assert (!(r0_addr_i == w_addr_i && w_v_i && r0_v_i && !read_write_same_addr_p))
             else $error("%m: Attempt to read and write same address");
 
-          assert (~(r1_addr_i == w_addr_i && w_v_i && r1_v_i && !read_write_same_addr_p))
+          assert (!(r1_addr_i == w_addr_i && w_v_i && r1_v_i && !read_write_same_addr_p))
             else $error("%m: Attempt to read and write same address");
        end
 

--- a/bsg_mem/bsg_mem_3r1w.v
+++ b/bsg_mem/bsg_mem_3r1w.v
@@ -46,13 +46,13 @@ module bsg_mem_3r1w #(parameter width_p=-1
           assert (w_addr_i < els_p)
             else $error("Invalid address %x to %m of size %x\n", w_addr_i, els_p);
 
-          assert (~(r0_addr_i == w_addr_i && w_v_i && r0_v_i && !read_write_same_addr_p))
+          assert (!(r0_addr_i == w_addr_i && w_v_i && r0_v_i && !read_write_same_addr_p))
             else $error("%m: Attempt to read and write same address");
 
-          assert (~(r1_addr_i == w_addr_i && w_v_i && r1_v_i && !read_write_same_addr_p))
+          assert (!(r1_addr_i == w_addr_i && w_v_i && r1_v_i && !read_write_same_addr_p))
             else $error("%m: Attempt to read and write same address");
 
-          assert (~(r2_addr_i == w_addr_i && w_v_i && r2_v_i && !read_write_same_addr_p))
+          assert (!(r2_addr_i == w_addr_i && w_v_i && r2_v_i && !read_write_same_addr_p))
             else $error("%m: Attempt to read and write same address");
 //synopsys translate_on
 


### PR DESCRIPTION
#144 #145 #146 

I was unable to parse this part of the style guide

>Purely logical operators for purely non-bitvector inputs. Here you have a bunch of word values that you that you are trying to combine together, C-style into logical boolean expressions. The expression will have a bunch of numerical values that you are testing for equality, less than, greater than, or zero/non-zeroness. You can not have any of the inputs to the expression be bitvector values.  In this case, it is permissible to use logical boolean operators (i.e. &&, ||, if, !), but you should not use any bitwise operators (i.e., &, |, ^), especially the bitwise ~ operator. This is consistent with C usage.

Is using w_v_i and r_v_i in mixed logical expressions permitted? w_v_i == 1'b1 seems verbose