### PR TITLE
move low level timing constraints from bsg_designs to basejump_stl

### DIFF
--- a/constraints/bsg_async/bsg_async.constraints.tcl
+++ b/constraints/bsg_async/bsg_async.constraints.tcl
@@ -1,0 +1,35 @@
+puts "Info: Start script [info script]\n"
+
+############################################
+#
+# cdc timing assertions
+#
+# this is a general procedure for constraining all the cdc paths in a design
+# metastability issues should be fixed by synchronizers (two-stage dff) in the design
+# a timing path between a clock and its generated clock is a synchronous path
+# read http://www.zimmerdesignservices.com/mydownloads/no_mans_land_20130328.pdf for 
+# motivation and more details
+proc bsg_async {} {
+  # find all clocks in the design
+  set clocks [all_clocks]
+  foreach_in_collection launch_clk $clocks {
+    # the source clock and its generated clocks should be put into the same launch clock group
+    if { [get_attribute $launch_clk is_generated] } {
+      set launch_group [get_generated_clocks -filter "master_clock_name==[get_attribute $launch_clk master_clock_name]"]
+      append_to_collection launch_group [get_attribute $launch_clk master_clock]
+    } else {
+      set launch_group [get_generated_clocks -filter "master_clock_name==[get_attribute $launch_clk name]"]
+      append_to_collection launch_group $launch_clk
+    }
+    # the latch clock should be a clock which is not in the launch clock group
+    foreach_in_collection latch_clk [remove_from_collection $clocks $launch_group] {
+      set launch_period [get_attribute $launch_clk period]
+      set latch_period [get_attribute $latch_clk period]
+      set max_delay_ps [expr min($launch_period,$latch_period)/2]
+      set_max_delay $max_delay_ps -from $launch_clk -to $latch_clk -ignore_clock_latency
+      set_min_delay 0             -from $launch_clk -to $latch_clk -ignore_clock_latency
+    }
+  }
+}
+
+puts "Info: Completed script [info script]\n"

--- a/constraints/bsg_clk_gen/bsg_clk_gen.constraints.tcl
+++ b/constraints/bsg_clk_gen/bsg_clk_gen.constraints.tcl
@@ -1,0 +1,53 @@
+puts "Info: Start script [info script]\n"
+
+############################################
+#
+# bsg_clk_gen timing assertions
+#
+proc bsg_clk_gen_clock_create { osc_path clk_name clk_gen_period_int clk_gen_period_ext osc_uncertainty ds_uncertainty clk_uncertainty} {
+  # very little is actually timed with this domain; just the receive
+  # side of the bsg_tag_client and the downsampler.
+  #
+  # Although the fastest target period of the oscillator itself is below
+  # this, we don't want this support logic to not be able to keep up
+  # in the event that oscillator runs faster than the tools say
+  #
+
+  # this is for the output of the downsampler, goes to the clock selection mux
+  set clk_gen_period_ds [expr $clk_gen_period_int * 2.0]
+
+  # this is for the output of the oscillator, which goes to the downsampler
+  create_clock -period $clk_gen_period_int -name ${clk_name}_osc [get_pins -leaf -of_objects [get_nets ${osc_path}osc_clk_out] -filter "pin_direction==out"]
+  set_clock_uncertainty $osc_uncertainty [get_clocks ${clk_name}_osc]
+
+  # it would be nice to remove the following version detection scripts if they are deprecated
+  # we always use version 2 of bsg_clk_gen in recent tapeouts
+  echo "Detecting Version 1/2 of bsg_clk_gen"
+  set buf_btc_o_search [sizeof_collection [get_pins ${osc_path}clk_gen_osc_inst/fdt/buf_btc_o]]
+  echo $buf_btc_o_search
+  # for version 1 bsg_clk_gen
+  if { $buf_btc_o_search } {
+    echo "Detected Version 1 of bsg_clk_gen"
+    # this is for the output of the oscillator, which goes to the osc's bt client
+    create_clock -period $clk_gen_period_int -name ${clk_name}_btc [get_pins ${osc_path}clk_gen_osc_inst/fdt/buf_btc_o]
+    # clock domains being crossed into via bsg_tag
+    bsg_tag_add_client_cdc_timing_constraints $bsg_tag_clk_name ${clk_name}_btc
+  } else {
+    echo "Detected Version 2 of bsg_clk_gen"
+    # if we do this, it adds lots of buffers which is a big problem.
+    #create_clock -period $clk_gen_period_int -name ${clk_name}_btc [get_pins ${osc_path}/clk_gen_osc_inst/fdt/o]
+    # clock domains being crossed into via bsg_tag
+    #bsg_tag_add_client_cdc_timing_constraints $bsg_tag_clk_name ${clk_name}_btc
+  }
+
+  # these are generated clocks; we call them clocks to get preferred shielding and routing
+  # nothing is actually timed with these
+  create_clock -period $clk_gen_period_ds -name ${clk_name}_osc_ds [get_pins -leaf -of_objects [get_nets ${osc_path}ds_clk_out] -filter "pin_direction==out"]
+  set_clock_uncertainty $ds_uncertainty [get_clocks ${clk_name}_osc_ds]
+
+  # the output of the mux is the externally visible bonafide clock
+  create_clock -period $clk_gen_period_ext -name ${clk_name} [get_pins -leaf -of_objects [get_nets ${osc_path}clk_o] -filter "pin_direction==out"]
+  set_clock_uncertainty $clk_uncertainty [get_clocks ${clk_name}]
+}
+
+puts "Info: Completed script [info script]\n"

--- a/constraints/bsg_clk_gen/bsg_dram_clk_gen.constraints.tcl
+++ b/constraints/bsg_clk_gen/bsg_dram_clk_gen.constraints.tcl
@@ -1,0 +1,52 @@
+puts "Info: Start script [info script]\n"
+
+############################################
+#
+# bsg_dram_clk_gen timing assertions
+#
+proc bsg_dram_clk_gen_clock_create { osc_path clk_name clk_gen_period_int } {
+  # very little is actually timed with this domain; just the receive
+  # side of the bsg_tag_client and the downsampler.
+  #
+  # Although the fastest target period of the oscillator itself is below
+  # this, we don't want this support logic to not be able to keep up
+  # in the event that oscillator runs faster than the tools say
+  #
+
+  # this is for the output of the downsampler, goes to the clock selection mux
+  set clk_gen_period_ds [expr $clk_gen_period_int * 2.0]
+
+  # this is for the output of the oscillator, which goes to the downsampler
+  create_clock -period $clk_gen_period_int -name ${clk_name}_osc [get_pins -leaf -of_objects [get_nets ${osc_path}osc_clk_o] -filter "pin_direction==out"]
+
+  # it would be nice to remove the following version detection scripts if they are deprecated
+  # we always use version 2 of bsg_clk_gen in recent tapeouts
+  echo "Detecting Version 1/2 of bsg_clk_gen"
+  set buf_btc_o_search [sizeof_collection [get_pins ${osc_path}clk_gen_osc_inst/fdt/buf_btc_o]]
+  echo $buf_btc_o_search
+  # for version 1 bsg_clk_gen
+  if { $buf_btc_o_search } {
+    echo "Detected Version 1 of bsg_clk_gen"
+    # this is for the output of the oscillator, which goes to the osc's bt client
+    create_clock -period $clk_gen_period_int -name ${clk_name}_btc [get_pins ${osc_path}clk_gen_osc_inst/fdt/buf_btc_o]
+    # clock domains being crossed into via bsg_tag
+    bsg_tag_add_client_cdc_timing_constraints $bsg_tag_clk_name ${clk_name}_btc
+  } else {
+    echo "Detected Version 2 of bsg_clk_gen"
+    # if we do this, it adds lots of buffers which is a big problem.
+    #create_clock -period $clk_gen_period_int -name ${clk_name}_btc [get_pins ${osc_path}/clk_gen_osc_inst/fdt/o]
+    # clock domains being crossed into via bsg_tag
+    #bsg_tag_add_client_cdc_timing_constraints $bsg_tag_clk_name ${clk_name}_btc
+  }
+
+  # the downsample clock is defined as generated clock because it will going to drive sequential devices inside dram controller
+  # it needs to be balanced pretty well with its master clock and this can be easily achieved during clock tree synthesis in pnr tools
+  create_generated_clock -name ${clk_name}_osc_ds \
+                         -divide_by 2 \
+                         -source [get_attribute [get_clocks ${clk_name}_osc] sources] \
+                         [get_pins -leaf -of_objects [get_nets ${osc_path}div_clk_o] -filter "pin_direction==out"]
+  # compared to normal clock generators, the dram clock generator doesn't have the output clock multiplexer
+  # both the master clock and downsample clock will output to drive logic in dram controller and phy
+}
+
+puts "Info: Completed script [info script]\n"

--- a/constraints/bsg_comm_link/bsg_comm_link.constraints.tcl
+++ b/constraints/bsg_comm_link/bsg_comm_link.constraints.tcl
@@ -1,0 +1,92 @@
+puts "Info: Start script [info script]\n"
+
+############################################
+#
+# bsg_comm_link timing assertions
+#
+proc bsg_comm_link_timing_constraints { \
+  iom_clk_name                          \
+  ch_idx                                \
+  ch_in_clk_port                        \
+  ch_in_dv_port                         \
+  ch_in_tkn_port                        \
+  ch_out_clk_port                       \
+  ch_out_dv_port                        \
+  ch_out_tkn_port                       \
+  input_cell_rise_fall_difference       \
+  output_cell_rise_fall_difference      \
+  uncertainty                           \
+} {
+  # determin the clock period of io master clock, io clock and token clock
+  set iom_clk_period [get_attribute [get_clocks $iom_clk_name] period]
+  set io_clk_period  [expr $iom_clk_period * 2.0]
+  set tkn_clk_period $io_clk_period
+
+  set max_io_skew_percent 2.5
+  set max_io_skew_time [expr $max_io_skew_percent * $io_clk_period / 100.0]
+
+  # create input io clock
+  set sdi_clk sdi_${ch_idx}_clk
+  create_clock -period $io_clk_period -name $sdi_clk $ch_in_clk_port
+  set_clock_uncertainty $uncertainty [get_clocks $sdi_clk]
+
+  # create input token clock
+  set sdo_tkn_clk sdo_${ch_idx}_tkn_clk
+  create_clock -period $tkn_clk_period -name $sdo_tkn_clk $ch_out_tkn_port
+  set_clock_uncertainty $uncertainty [get_clocks $sdo_tkn_clk]
+
+  # determin the max and min input delay
+  set max_input_delay [expr ($io_clk_period / 2.0) - $max_io_skew_time]
+  set min_input_delay $max_io_skew_time
+
+  # "set_input_delay -clock" will assume data is edge aligned with clock by default
+  # but in our case, the input clock is actually center aligned with data
+  # we use the input delay values to determin the worst skew between clock and data
+  # after they propagate through PCB traces and bond wires so that the data can be 
+  # sampled correctly at the input registers (first level)
+  # max_input_delay means data lags $max_input_delay-quarter($io_clk_period) behind clock
+  # min_input_delay means clock lags quarter($io_clk_period)-$min_input_delay behind data
+  set_input_delay -clock $sdi_clk -max $max_input_delay $ch_in_dv_port 
+  set_input_delay -clock $sdi_clk -max $max_input_delay $ch_in_dv_port -add_delay -clock_fall
+  set_input_delay -clock $sdi_clk -min $min_input_delay $ch_in_dv_port
+  set_input_delay -clock $sdi_clk -min $min_input_delay $ch_in_dv_port -add_delay -clock_fall
+
+  # basically we have two approaches to constrain the output paths
+  # the approach of set_data_check is silicon proven while the other of
+  # set_output_delay is not
+  set USE_GENERATED_CLOCK 0
+  if { $USE_GENERATED_CLOCK } {
+    # create generated output io clock based on the edges of io master clock
+    set sdo_clk sdo_${ch_idx}_clk
+    create_generated_clock -edges {2 4 6} -master_clock $iom_clk_name -source [get_attribute [get_clocks $iom_clk_name] sources] -name $sdo_clk $ch_out_clk_port
+  
+    # determine max and min output delay
+    set max_output_delay [expr ($io_clk_period / 4.0) - $max_io_skew_time]
+    set min_output_delay [expr $max_io_skew_time - ($io_clk_period / 4.0)]
+  
+    # similarly we use the output delay values to determin the worst skew between clock and data
+    # after they propagate through PCB traces and bond wires so that the data can be sampled
+    # correctly at the virtual registers outside the chip
+    # max_output_delay means data lags $max_output_delay behind clock
+    # min_input_delay means clock lags |$min_input_delay| behind data
+    set_output_delay -clock $sdo_clk -max $max_output_delay $ch_out_dv_port 
+    set_output_delay -clock $sdo_clk -max $max_output_delay $ch_out_dv_port -add_delay -clock_fall
+    set_output_delay -clock $sdo_clk -min $min_output_delay $ch_out_dv_port 
+    set_output_delay -clock $sdo_clk -min $min_output_delay $ch_out_dv_port -add_delay -clock_fall
+  } else {
+    # output timing constraints
+    # source synchronous output constraints
+    foreach_in_collection obj $ch_out_dv_port {
+      # ideally output clock is center aligned with output data, so the clock has (-25%, +25%) of clock cycle time as the sampling window
+      # we check if the clock if the clock edge is in the center +/- $max_io_skew_time of the data
+      set_data_check -from $ch_out_clk_port -to $obj -setup [expr $io_clk_period / 4.0 - $max_io_skew_time]
+      set_data_check -from $ch_out_clk_port -to $obj -hold  [expr $io_clk_period / 4.0 - $max_io_skew_time]
+      # set_data_check has a default zero cycle checking behavior which need to overcome in this case
+      # please take solvnet #024664 as a reference
+      set_multicycle_path -end   -setup 1 -to $obj
+      set_multicycle_path -start -hold  0 -to $obj
+    }
+  }
+}
+
+puts "Info: Completed script [info script]\n"

--- a/constraints/bsg_dmc/bsg_dmc.constraints.tcl
+++ b/constraints/bsg_dmc/bsg_dmc.constraints.tcl
@@ -1,0 +1,79 @@
+puts "Info: Start script [info script]\n"
+
+############################################
+#
+# bsg_dmc datapath timing assertions
+#
+proc bsg_dmc_data_timing_constraints { \
+  grp_idx                              \
+  dfi_clk_1x_name                      \
+  dfi_clk_2x_name                      \
+  dqs_i                                \
+  dqs_o                                \
+  dm_o                                 \
+  dq_i                                 \
+  dq_o                                 \
+} {
+  # dfi_clk_1x and dfi_clk_2x are defined inside bsg_dram_clk_gen
+  # we use their sources and cycle time to derive other dram-related clocks
+  set dfi_clk_period [expr [get_attribute [get_clocks $dfi_clk_2x_name] period] * 2.0]
+  set dfi_clk_source [get_attribute [get_clocks $dfi_clk_1x_name] sources]
+  # create input dqs clock
+  create_clock -period $dfi_clk_period \
+               -name dqs_${grp_idx}    \
+               $dqs_i
+
+  set quarter_cycle [expr [get_attribute [get_clocks dqs0] period] / 4.0]
+  # create 90-degree shifted clock on the output of delay line
+  create_generated_clock -name dqs_${grp_idx}_dly \
+                         -edges {1 2 3} \
+                         -edge_shift [list $quarter_cycle $quarter_cycle $quarter_cycle] \
+                         -source [get_pins -of_objects [get_cells -of_objects [get_nets -of_objects [get_attribute [get_clocks dqs_${grp_idx}] sources]]] -filter "direction==out"]  \
+                         [get_pins -leaf -of_objects [get_nets -hierarchical dly_clk_o[${grp_idx}]] -filter "direction==out"]
+
+  # input timing constraints
+  # input data (dq) is edge aligned with input clock (dqs) after getting out of dram chips
+  # we set 5% of the clock cycle time to account for the misalignment when the signals propagate through the pcb traces and bond wires
+  set_input_delay  [expr  [get_attribute [get_clocks dqs_${grp_idx}] period] * 0.05] $dq_i -clock [get_clocks dqs_${grp_idx}] -max
+  set_input_delay  [expr -[get_attribute [get_clocks dqs_${grp_idx}] period] * 0.05] $dq_i -clock [get_clocks dqs_${grp_idx}] -min
+
+  # output timing constraints
+  # source synchronous output constraints, similar to comm_link output channels
+  foreach_in_collection from_obj $dqs_o {
+    foreach_in_collection to_obj [concat $dq_o $dm_o] {
+      # ideally output clock is center aligned with output data, so the clock has (-25%, +25%) of clock cycle time as the sampling window
+      # we deduct 20% from the margin and check if the clock is in the scope of (-5%, +5%) of the data center
+      set_data_check -from $from_obj -to $to_obj [expr $dfi_clk_period * 0.2]
+      # set_data_check has a default zero cycle checking behavior which need to overcome in this case
+      # please take solvnet #024664 as a reference
+      set_multicycle_path -end -setup 1 -to $to_obj
+      set_multicycle_path -start -hold 0 -to $to_obj
+    }
+  }
+}
+
+############################################
+#
+# bsg_dmc address and command path timing assertions
+#
+proc bsg_dmc_ctrl_timing_constraints { \
+  dfi_clk_1x_name                      \
+  dfi_clk_2x_name                      \
+  ck_p                                 \
+  ck_n                                 \
+  ctrl_signals                         \
+} {
+  # dfi_clk_1x and dfi_clk_2x are defined inside bsg_dram_clk_gen
+  # we use their sources and cycle time to derive other dram-related clocks
+  set dfi_clk_period [expr [get_attribute [get_clocks $dfi_clk_2x_name] period] * 2.0]
+  set dfi_clk_source [get_attribute [get_clocks $dfi_clk_1x_name] sources]
+  # create generated clocks to drive dram device, all the address and command signals are synchronous to these clocks
+  create_generated_clock -name ddr_ck_p -divide_by 1         -source $dfi_clk_source -master_clock [get_clocks $dfi_clk_1x_name] $ck_p
+  create_generated_clock -name ddr_ck_n -divide_by 1 -invert -source $dfi_clk_source -master_clock [get_clocks $dfi_clk_1x_name] $ck_n
+  # all the address and command signals are registered outputs which are aligned well with clock edges
+  # we give it a 10% margin to account for the misalignment caused by PCB traces and bond wires
+  set_output_delay [expr  $dfi_clk_period * 0.1] $ctrl_signals -clock [get_clocks ddr_ck_p] -max
+  set_output_delay [expr -$dfi_clk_period * 0.1] $ctrl_signals -clock [get_clocks ddr_ck_p] -min
+}
+
+puts "Info: Completed script [info script]\n"

--- a/constraints/bsg_tag/bsg_tag.constraints.tcl
+++ b/constraints/bsg_tag/bsg_tag.constraints.tcl
@@ -1,0 +1,21 @@
+puts "Info: Start script [info script]\n"
+
+############################################
+#
+# bsg_tag timing assertions
+#
+proc bsg_tag_clock_create { clk_name clk_source tag_data tag_attach period } {
+    # define the clock at the source port/pin
+    create_clock -period $period -name $clk_name $clk_source
+
+    # we set the input delay of these pins to be half the bsg_tag clock period; we launch on the negative edge and clock and
+    # data travel in parallel, so should be about right
+    set_input_delay [expr $period / 2.0] -clock $clk_name $tag_data -max
+    set_input_delay 0.0 -clock $clk_name $tag_data -min
+
+    # this signal is relative to the bsg_tag_clk, but is used in the bsg_tag_client in a CDC kind of way
+    set_input_delay [expr $period / 2.0] -clock $clk_name $tag_attach -max
+    set_input_delay 0.0 -clock $clk_name $tag_attach -min
+}
+
+puts "Info: Completed script [info script]\n"


### PR DESCRIPTION
Put low level timing constraints for clock generation, io paths and cdc paths in basejump_stl/constraints. Chip designers can develop chip level timing constraints by calling these low level procedures.