### PR TITLE
Flattened always_ff logic tree in bsg_cache

### DIFF
--- a/bsg_cache/bsg_cache.v
+++ b/bsg_cache/bsg_cache.v
@@ -216,6 +216,11 @@ module bsg_cache
   always_ff @ (posedge clk_i) begin
     if (reset_i) begin
       v_v_r <= 1'b0;
+    end else if (v_we) begin
+        v_v_r <= v_tl_r;
+    end
+
+    if (reset_i) begin
       {mask_v_r
       ,decode_v_r
       ,addr_v_r
@@ -223,21 +228,15 @@ module bsg_cache
       ,valid_v_r
       ,lock_v_r
       ,tag_v_r} <= '0;
-    end
-    else begin
-      if (v_we) begin
-        v_v_r <= v_tl_r;
-        if (v_tl_r) begin
-          mask_v_r <= mask_tl_r;
-          decode_v_r <= decode_tl_r;
-          addr_v_r <= addr_tl_r;
-          data_v_r <= data_tl_r;
-          valid_v_r <= valid_tl;
-          tag_v_r <= tag_tl;
-          lock_v_r <= lock_tl;
-          ld_data_v_r <= data_mem_data_lo;
-        end
-      end
+    end else if (v_we & v_tl_r) begin
+      mask_v_r <= mask_tl_r;
+      decode_v_r <= decode_tl_r;
+      addr_v_r <= addr_tl_r;
+      data_v_r <= data_tl_r;
+      valid_v_r <= valid_tl;
+      tag_v_r <= tag_tl;
+      lock_v_r <= lock_tl;
+      ld_data_v_r <= data_mem_data_lo;
     end
   end
 


### PR DESCRIPTION
Makes FPGA compilation correctly infer output register for BRAM

This is a pretty mild optimization. I didn't change any functionality, and I didn't change any logic. However, sometimes the Xilinx synthesis tool struggles to infer output BRAM registers when a certain pattern isn't found. So, I fixed it. I think.

I'd appreciate if someone can run manycore regression with this...