### PR TITLE
fix the bug with dma evict data read disrupted by incoming load

### DIFF
--- a/bsg_cache/bsg_cache.v
+++ b/bsg_cache/bsg_cache.v
@@ -402,6 +402,7 @@ module bsg_cache
   logic [lg_sets_lp+lg_block_size_in_words_lp-1:0] dma_data_mem_addr_lo;
   logic [ways_p-1:0][data_mask_width_lp-1:0] dma_data_mem_w_mask_lo;
   logic [ways_p-1:0][data_width_p-1:0] dma_data_mem_data_lo;
+  logic dma_evict_lo;
 
   bsg_cache_dma #(
     .addr_width_p(addr_width_p)
@@ -439,6 +440,8 @@ module bsg_cache
     ,.data_mem_w_mask_o(dma_data_mem_w_mask_lo)
     ,.data_mem_data_o(dma_data_mem_data_lo)
     ,.data_mem_data_i(data_mem_data_lo)
+    
+    ,.dma_evict_o(dma_evict_lo)
   ); 
 
   // store buffer
@@ -692,7 +695,7 @@ module bsg_cache
   // 4) tl_stage is recovering from tag_miss
   logic tl_ready;
   assign tl_ready = miss_v
-    ? (~(decode.tagst_op & v_i) & ~miss_tag_mem_v_lo & ~dma_data_mem_v_lo & ~recover_lo)
+    ? (~(decode.tagst_op & v_i) & ~miss_tag_mem_v_lo & ~dma_data_mem_v_lo & ~recover_lo & ~dma_evict_lo)
     : 1'b1;
   assign ready_o = v_tl_r
     ? (v_we & tl_ready)

--- a/bsg_cache/bsg_cache_dma.v
+++ b/bsg_cache/bsg_cache_dma.v
@@ -4,6 +4,7 @@
  *  DMA engine.
  *
  *  @author tommy
+ *
  */
 
 module bsg_cache_dma
@@ -51,6 +52,8 @@ module bsg_cache_dma
     ,output logic [ways_p-1:0][data_mask_width_lp-1:0] data_mem_w_mask_o
     ,output logic [ways_p-1:0][data_width_p-1:0] data_mem_data_o
     ,input [ways_p-1:0][data_width_p-1:0] data_mem_data_i
+
+    ,output logic dma_evict_o // data eviction in progress
   );
 
   // localparam
@@ -191,6 +194,8 @@ module bsg_cache_dma
     counter_clear = 1'b0;
     counter_up = 1'b0;
 
+    dma_evict_o = 1'b0;
+
     case (dma_state_r)
 
       // wait for dma_cmd from bsg_cache_miss.
@@ -276,6 +281,8 @@ module bsg_cache_dma
         data_mem_v_o = out_fifo_ready_lo & ~counter_evict_max;
 
         done_o = counter_evict_max & out_fifo_ready_lo;
+
+        dma_evict_o = 1'b1;
       end
 
       default: begin

--- a/testing/bsg_cache/common/bsg_nonsynth_dma_model.v
+++ b/testing/bsg_cache/common/bsg_nonsynth_dma_model.v
@@ -9,6 +9,12 @@ module bsg_nonsynth_dma_model
     ,parameter data_width_p="inv"
     ,parameter block_size_in_words_p="inv"
     ,parameter els_p="inv"
+    
+    ,parameter read_delay_p=16
+    ,parameter write_delay_p=12
+  
+    ,parameter lg_read_delay_lp=`BSG_SAFE_CLOG2(read_delay_p)
+    ,parameter lg_write_delay_lp=`BSG_SAFE_CLOG2(write_delay_p)
 
     ,parameter data_mask_width_lp=(data_width_p>>3)
     ,parameter lg_data_mask_width_lp=`BSG_SAFE_CLOG2(data_mask_width_lp)
@@ -42,6 +48,7 @@ module bsg_nonsynth_dma_model
 
   typedef enum logic [1:0] {
     WAIT
+    ,DELAY
     ,BUSY
   } state_e;
 
@@ -56,6 +63,7 @@ module bsg_nonsynth_dma_model
   logic [addr_width_p-1:0] read_addr_r, read_addr_n;
   state_e read_state_r, read_state_n;
   logic [lg_block_size_in_words_lp-1:0] read_counter_r, read_counter_n;
+  logic [lg_read_delay_lp-1:0] read_delay_r, read_delay_n;
 
   logic [lg_els_lp-lg_block_size_in_words_lp-1:0] read_upper_addr;
   assign read_upper_addr = read_addr_r[lg_data_mask_width_lp+lg_block_size_in_words_lp+:lg_els_lp-lg_block_size_in_words_lp];
@@ -64,6 +72,8 @@ module bsg_nonsynth_dma_model
   always_comb begin
     dma_data_v_o = 1'b0;
     read_addr_n = read_addr_r;
+    read_delay_n = read_delay_r;
+    read_counter_n = read_counter_r;
 
     case (read_state_r)
       WAIT: begin
@@ -74,9 +84,18 @@ module bsg_nonsynth_dma_model
           ? '0
           : read_counter_r;
         read_state_n = start_read
-          ? BUSY
+          ? DELAY
           : WAIT;
+        read_delay_n = '0;
       end
+
+      DELAY: begin
+        read_delay_n = read_delay_r + 1;
+        read_state_n = read_delay_r == (read_delay_p-1)
+          ? BUSY
+          : DELAY;
+      end
+
       BUSY: begin
         dma_data_v_o = 1'b1;
         read_counter_n = dma_data_ready_i
@@ -94,12 +113,15 @@ module bsg_nonsynth_dma_model
   logic [addr_width_p-1:0] write_addr_r, write_addr_n;
   state_e write_state_r, write_state_n;
   logic [lg_block_size_in_words_lp-1:0] write_counter_r, write_counter_n;
+  logic [lg_write_delay_lp-1:0] write_delay_r, write_delay_n;
 
   logic [lg_els_lp-lg_block_size_in_words_lp-1:0] write_upper_addr;
   assign write_upper_addr = write_addr_r[lg_data_mask_width_lp+lg_block_size_in_words_lp+:lg_els_lp-lg_block_size_in_words_lp];
 
   always_comb begin
     write_addr_n = write_addr_r;
+    write_delay_n = write_delay_r;
+    write_counter_n = write_counter_r;
     dma_data_yumi_o = 1'b0;
 
     case (write_state_r)
@@ -111,8 +133,16 @@ module bsg_nonsynth_dma_model
           ? '0
           : write_counter_r;
         write_state_n = start_write
-          ? BUSY
+          ? DELAY
           : WAIT;
+        write_delay_n = '0;
+      end
+
+      DELAY: begin
+        write_delay_n = write_delay_r + 1;
+        write_state_n = write_delay_r == (write_delay_p-1)
+          ? BUSY
+          : DELAY;
       end
       
       BUSY: begin
@@ -138,9 +168,11 @@ module bsg_nonsynth_dma_model
       read_state_r <= WAIT;
       read_addr_r <= '0;
       read_counter_r <= '0;
+      read_delay_r <= '0;
       write_state_r <= WAIT;
       write_addr_r <= '0;
       write_counter_r <= '0;
+      write_delay_r <= '0;
       for (integer i = 0; i < els_p; i++) begin
         mem[i] <= '0;
       end
@@ -149,9 +181,11 @@ module bsg_nonsynth_dma_model
       read_state_r <= read_state_n;
       read_addr_r <= read_addr_n;
       read_counter_r <= read_counter_n;
+      read_delay_r <= read_delay_n;
       write_state_r <= write_state_n;
       write_addr_r <= write_addr_n;
       write_counter_r <= write_counter_n;
+      write_delay_r <= write_delay_n;
     
       if (write_state_r == BUSY & dma_data_v_i) begin
         mem[{write_upper_addr, write_counter_r}] <= dma_data_i;


### PR DESCRIPTION
The bug is that when the DMA engine evicts a block, it reads a word and wait for the read word to be accepted by the evict FIFO, before it reads the next word. If the evict FIFO is not ready, and the incoming load takes the empty spot in TL stage (reading tag/data_mem), it disturbs the output of the data_mem, before it is accepted by the evict FIFO. This bug went undetected, because in the previous test setup, the evict FIFO was always able to drain without getting stalled. It was discovered when I added delays between receiving the dma_request and starting accepting/sending main memory data in bsg_nonsynth_dma_model.

The fix is to block the incoming requests when the eviction is in progress. I added a signal dma_evict_o to DMA engine which says the eviction is in progress.