### PR TITLE
efficient implementation of lru_encode

### DIFF
--- a/bsg_misc/bsg_lru_pseudo_tree_encode.v
+++ b/bsg_misc/bsg_lru_pseudo_tree_encode.v
@@ -1,64 +1,46 @@
 /**
- *  Name:
  *    bsg_lru_pseudo_tree_encode.v
  *
- *  Description:
- *    Pseudo-Tree-LRU decode unit.
- *    Given the LRU bits, traverses the pseudo-LRU tree and returns the LRU way_id.
+ *    Pseudo-Tree-LRU encode unit.
+ *    Given the LRU bits, traverses the pseudo-LRU tree and returns the
+ *    LRU way_id.
+ *    Only power of 2 ways.
+ *
+ *    @author tommy
+ *
  */
 
 module bsg_lru_pseudo_tree_encode
-  #(parameter ways_p       = "inv"
-    ,localparam lg_ways_lp = `BSG_SAFE_CLOG2(ways_p)
+  #(parameter ways_p = "inv"
+    , parameter lg_ways_lp = `BSG_SAFE_CLOG2(ways_p)
   )
   (
     input [ways_p-2:0] lru_i
     , output logic [lg_ways_lp-1:0] way_id_o
   );
 
-  logic [ways_p-2:0]                     mask;
-  logic [lg_ways_lp-1:0][ways_p-2:0]     pe_i;
-  logic [lg_ways_lp-1:0][lg_ways_lp-1:0] pe_o;
-  
-  
-  genvar i;
-  generate 
-    for(i=0; i<ways_p-1; i++) begin: rof
-      if(i == 0) begin: fi
-	    assign mask[i] = 1'b1;
-	  end
-	  else if(i%2 == 1) begin: fi
-	    assign mask[i] = mask[(i-1)/2] & ~lru_i[(i-1)/2];
-	  end
-	  else begin: fi
-	    assign mask[i] = mask[(i-2)/2] & lru_i[(i-2)/2];
-	  end
+
+  for (genvar i = 0; i < lg_ways_lp; i++) begin: rank
+
+    if (i == 0) begin: z
+
+      assign way_id_o[lg_ways_lp-1] = lru_i[0];  // root
+
     end
-    
-    
-    for(i=0; i<lg_ways_lp; i++) begin: rof2
-    
-      assign way_id_o[lg_ways_lp-1-i] = lru_i[pe_o[i]];
-    
-	  if(i == 0) begin: fi2
-	    assign pe_i[i] = mask;
-	    assign pe_o[i] = '0;
-	  end
-	  else begin: fi2
-        assign pe_i[i] = pe_i[i-1] ^ ({{(ways_p-2){1'b0}}, 1'b1} << pe_o[i-1]);
-	  end
-	  
-      if(i != 0) begin: fi3
-	    bsg_priority_encode 
-          #(.width_p(ways_p-1)
-            ,.lo_to_hi_p(1'b1)
-          ) pe 
-          (.i(pe_i[i])
-           ,.addr_o(pe_o[i])
-           ,.v_o()
-          );
-	  end
+    else begin: nz
+
+      bsg_mux #(
+        .width_p(1)
+        ,.els_p(2**i)
+      ) mux (
+        .data_i(lru_i[((2**i)-1)+:(2**i)])
+        ,.sel_i(way_id_o[lg_ways_lp-1-:i])
+        ,.data_o(way_id_o[lg_ways_lp-1-i])
+      );
+
     end
-  endgenerate
-  
+  end
+
+
 endmodule
+

--- a/bsg_misc/bsg_lru_pseudo_tree_encode.v
+++ b/bsg_misc/bsg_lru_pseudo_tree_encode.v
@@ -4,7 +4,23 @@
  *    Pseudo-Tree-LRU encode unit.
  *    Given the LRU bits, traverses the pseudo-LRU tree and returns the
  *    LRU way_id.
- *    Only power of 2 ways.
+ *    Only for power-of-2 ways.
+ *
+ *    --------------------
+ *    Example (ways_p=8)
+ *    --------------------
+ *    lru_i       way_id_o
+ *    -----       --------
+ *    xxx_0x00        0
+ *    xxx_1x00        1
+ *    xx0 xx10        2
+ *    xx1 xx10        3
+ *    x0x x0x1        4
+ *    x1x x0x1        5
+ *    0xx x1x1        6
+ *    1xx x1x1        7
+ *    --------------------
+ *    'x' means don't care.
  *
  *    @author tommy
  *

--- a/testing/bsg_misc/bsg_lru_pseudo_tree_encode/Makefile
+++ b/testing/bsg_misc/bsg_lru_pseudo_tree_encode/Makefile
@@ -1,11 +1,15 @@
 #
 #		Makefile
 #
+	
+include ../../../../bsg_cadenv/cadenv.mk
 
-include $(BSG_CADENV_DIR)/cadenv.mk
+export BASEJUMP_STL_DIR = $(abspath ../../..)
+
+INCDIR = +incdir+$(BASEJUMP_STL_DIR)/bsg_misc
 
 sim:
-	vcs +v2k -R +lint=all -sverilog -full64 -f sv.include $(INCDIR) \
+	vcs +v2k -R +lint=all,noSVA-UA,noSVA-NSVU,noVCDE  -sverilog -full64 -f sv.include $(INCDIR) \
 		-debug_pp -timescale=1ps/1ps +vcs+vcdpluson
 
 dve:

--- a/testing/bsg_misc/bsg_lru_pseudo_tree_encode/sv.include
+++ b/testing/bsg_misc/bsg_lru_pseudo_tree_encode/sv.include
@@ -1,12 +1,4 @@
-$BSG_IP_CORES_DIR/bsg_misc/bsg_defines.v
-$BSG_IP_CORES_DIR/bsg_misc/bsg_lru_pseudo_tree_encode.v
-$BSG_IP_CORES_DIR/bsg_misc/bsg_priority_encode.v
-$BSG_IP_CORES_DIR/bsg_misc/bsg_encode_one_hot.v
-$BSG_IP_CORES_DIR/bsg_misc/bsg_priority_encode_one_hot_out.v
-$BSG_IP_CORES_DIR/bsg_misc/bsg_scan.v
-$BSG_IP_CORES_DIR/bsg_test/bsg_nonsynth_clock_gen.v
-$BSG_IP_CORES_DIR/bsg_test/bsg_nonsynth_reset_gen.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_defines.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_mux.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_lru_pseudo_tree_encode.v
 testbench.v
-
-
-

--- a/testing/bsg_misc/bsg_lru_pseudo_tree_encode/testbench.v
+++ b/testing/bsg_misc/bsg_lru_pseudo_tree_encode/testbench.v
@@ -1,47 +1,83 @@
-
 module testbench();
 
-localparam ways_p     = 8;   
-localparam lg_ways_lp =`BSG_SAFE_CLOG2(ways_p);
+  localparam ways_p = 8;   
+  localparam lg_ways_lp =`BSG_SAFE_CLOG2(ways_p);
 
-logic                  clk, reset;
-logic [ways_p-2:0]     lru;
-logic [lg_ways_lp-1:0] way_id;
+  logic [ways_p-2:0] lru_li;
+  logic [lg_ways_lp-1:0] way_id_lo;
 
-always_ff @(posedge clk) begin
-  if(reset) begin
-    lru <= '0;
-  end
-  else begin
-    lru <= lru + 'b1;
-	$display("lru_i: %b | way_id_o: %b", lru, way_id);
-  end
-  
-  if(lru == '1) begin
-    $finish;
-  end
-  
-end
-
-bsg_nonsynth_clock_gen #(.cycle_time_p(10)
-                         )
-              clock_gen (.o(clk)
-                         );
-
-bsg_nonsynth_reset_gen #(.num_clocks_p(1)
-                         ,.reset_cycles_lo_p(1)
-                         ,.reset_cycles_hi_p(4)
-                         )
-               reset_gen(.clk_i(clk)
-                         ,.async_reset_o(reset)
-                         );
-
-bsg_lru_pseudo_tree_encode
-  #(.ways_p(ways_p)
-  )
-  ptw
-  (.lru_i(lru)
-   ,.way_id_o(way_id)
+  bsg_lru_pseudo_tree_encode #(
+    .ways_p(ways_p)
+  ) DUT (
+    .lru_i(lru_li)
+    ,.way_id_o(way_id_lo)
   );
+
+  task test(
+    input [ways_p-2:0] lru
+    , input [lg_ways_lp-1:0] expected
+  );
+
+    lru_li = lru;
+    #10;
+    assert(expected == way_id_lo) else
+      $fatal("[BSG_FATAL] expected: %b, actual: %b", expected, way_id_lo);
+    #10;
+
+  endtask
+
+  initial begin
+    // 0
+    test(7'b000_0000, 3'b000);
+    test(7'b000_0100, 3'b000);
+    test(7'b111_0100, 3'b000);
+    test(7'b101_0100, 3'b000);
+
+    // 1
+    test(7'b000_1000, 3'b001);
+    test(7'b000_1100, 3'b001);
+    test(7'b100_1000, 3'b001);
+    test(7'b110_1000, 3'b001);
+
+    // 2
+    test(7'b000_0010, 3'b010);
+    test(7'b000_1010, 3'b010);
+    test(7'b100_1010, 3'b010);
+    test(7'b110_1010, 3'b010);
+
+    // 3
+    test(7'b001_0010, 3'b011);
+    test(7'b001_0110, 3'b011);
+    test(7'b101_0110, 3'b011);
+    test(7'b111_0110, 3'b011);
+
+    // 4
+    test(7'b000_0001, 3'b100);
+    test(7'b000_1001, 3'b100);
+    test(7'b001_1001, 3'b100);
+    test(7'b101_1001, 3'b100);
+
+
+    // 5
+    test(7'b010_0001, 3'b101);
+    test(7'b010_0011, 3'b101);
+    test(7'b010_1011, 3'b101);
+    test(7'b011_1011, 3'b101);
+
+    // 6
+    test(7'b000_0101, 3'b110);
+    test(7'b010_0101, 3'b110);
+    test(7'b011_0101, 3'b110);
+    test(7'b011_1101, 3'b110);
+
+    // 7
+    test(7'b100_0101, 3'b111);
+    test(7'b100_0111, 3'b111);
+    test(7'b111_1111, 3'b111);
+    test(7'b101_1111, 3'b111);
+
+    $display("[BSG_FINISH] Test Successful!");
+    $finish; 
+  end
 
 endmodule


### PR DESCRIPTION
Good evening,

Here is the basic idea. the efficient implementation only needs 4 of 2-to-1 muxes at most.
the current implementation causes huge critical path in the cache design. 

![lru_encode](https://user-images.githubusercontent.com/46542701/67069634-a1fecd00-f132-11e9-8a46-40c1d7c63090.png)
