### PR TITLE
bug fixes for issues 170, 171, 179, 184

### DIFF
--- a/bsg_dataflow/bsg_sbox_ctrl_concentrate.v
+++ b/bsg_dataflow/bsg_sbox_ctrl_concentrate.v
@@ -1,0 +1,120 @@
+// MBT 8-15-2014
+// FIXME untested
+//
+// Given a bit vector, generate
+// permutation vectors that perform
+// concentration (fwd) and deconcentration (bkwd).
+//
+//
+//           bit   fwd          bkwd
+//   pos.   vec    vec          vec
+//     3     1 --\    1      --- 2
+//                \         /
+//     2     1 -\  -> 3  <--  -- 1
+//               \           /
+//     1     0    --> 2  <---    3 --> 1
+
+//     0     1 -----> 0  <------ 0
+//
+//
+// This version is fully general, and can support a variable
+// number of inputs. However, the stable sort function would
+// need to be expanded to support other numbers besides 4.
+//
+
+/*
+ * This also would have worked (for case of 4):
+ *
+ * vec           fwd_perm   bkwd_perm
+ * 3210
+ *
+ * 0000:  3210 11_10_01_00 3210 11_10_01_00
+ * 0001:  3210 11_10_01_00 3210 11_10_01_00
+ * 0010:  3201 11_10_00_01 3201 11_11_0
+ * 0011:  3210 11_10_01_00 3210
+ * 0100:  3012 11_00_01_10 3012
+ * 0101:  3120 11_01_10_00 3120
+ * 0110:  3021 11_00_10_01 3102
+ * 0111:  3210 11_10_01_00 3210
+ *
+ * 1000:  0213 00_10_01_11 0213
+ * 1001:  1230 01_10_11_00 1230
+ * 1010:  0231 00_10_11_01 1203
+ * 1011:  2310 10_11_01_00 2310
+ * 1100:  1032 01_00_11_10 1032
+ * 1101:  1320 01_11_10_00 2130
+ * 1110:  0321 00_11_10_01 2103
+ * 1111:  3210 11_10_01_00 3210
+ *
+ */
+
+module bsg_sbox_ctrl_concentrate #(parameter width_p=4, lg_width_p=$bits(width_p))
+   (  input  [width_p-1:0] vec_i
+      , output [lg_width_p-1:0] fwd_perm_o  [width_p-1:0]
+      , output [width_p-1:0] fwd_valid_o
+      , output [lg_width_p-1:0] bkwd_perm_o [width_p-1:0]
+      );
+
+initial
+  // just because bsg_sort has not implemented sorting networks
+  // besides four elements
+  assert(width_p==4) 
+    else $error("stable sort function needs to be generalized to support width_p!=4");
+
+
+   // *********************************************
+   // *
+   // * generate forward indices using sorting network
+   // *
+
+   // * initialize input to sorting network with indexes of bits
+   // * and high bit set to vector bit. we do a stable sort on the vector bit
+   // * and the output is a vector of the indexes, concentrated.
+   //
+
+   wire [lg_width_p:0] fwd_sort_li [width_p-1:0];
+   wire [lg_width_p:0] fwd_sort_lo [width_p-1:0];
+
+   for (i = 0; i < width_p; i=i+1)
+     assign fwd_sort_li[i] = { ~vec_i[i], i[0+:lg_width_p] };
+
+   bsg_stable_sort #(  .width_p(lg_width_p+1)
+                       , .items_p(4)
+                       , .t_p(width_p)    // sort based on vector bit
+                       , .b_p(width_p-1)
+                       )
+   (.i(fwd_sort_li)
+    ,.o(fwd_sort_lo)
+    );
+
+   for (i=0; i < width_p; i=i+1)
+     begin
+        assign fwd_perm_o[i][0+:lg_width_p] = fwd_sort_lo[i][0+:lg_width_p];
+        assign fwd_valid_o[i] = fwd_sort_lo[i][lg_width_p];
+     end
+
+   // *********************************************
+   // *
+   // * generate backward indices using sorting network
+   // *
+   //
+
+   wire [lg_width_p*2-1:0] bkwd_sort_li [width_p-1:0];
+   wire [lg_width_p*2-1:0] bkwd_sort_lo [width_p-1:0];
+
+   for (i = 0; i < width_p; i=i+1)
+     assign bkwd_sort_li[i] = { fwd_perm_o[i], i[0+:lg_width_p] };
+
+   bsg_stable_sort #( .width_p(2*lg_width_p)
+                      , .items_p(4)
+                      , .t_p(2*lg_width_p-1)
+                      , .b_p(lg_width_p)
+                      )
+   (.i(bkwd_sort_li)
+    ,.o(bkwd_sort_lo)
+    );
+
+   for (i=0; i < width_p; i=i+1)
+     assign bkwd_perm_o[i] = bkwd_sort_lo[i][0+:lg_width_p];
+
+endmodule

--- a/bsg_dataflow/bsg_stable_sort.v
+++ b/bsg_dataflow/bsg_stable_sort.v
@@ -1,0 +1,71 @@
+// MBT 8-15-2015
+//
+// bsg_sort
+//
+// This is a sorting network implementation.
+// Currently, it implements a stable 4-item sort -- very efficiently.
+//
+// It takes as input parameters the inclusive bit range
+// to use for comparison. This allows us to move both
+// data and tags through the sorting network.
+//
+// NOTE: This code is UNTESTED.
+//
+
+module bsg_stable_sort #(parameter width_p="inv",
+                         items_p = "inv"
+                         , t_p   = width_p-1
+                         , b_p   = 0
+                         )
+   (input    [width_p-1:0] i [items_p-1:0]
+    , output [width_p-1:0] o [items_p-1:0]
+    );
+
+   initial
+     assert (items_p==4) else $error("unhandled case");
+
+   wire [width_p-1:0] s0 [items_p-1:0];
+   wire [width_p-1:0] s1 [items_p-1:0];
+   wire [width_p-1:0] s2 [items_p-1:0];
+   wire [width_p-1:0] s3 [items_p-1:0];
+
+   wire               swapped_3_1;
+
+   assign s0 = i;
+
+   // stage 1: compare_and swap  <3,2> and <1,0>
+
+   bsg_compare_and_swap #(.width_p(width_p), .t_p(t_p), .b_p(b_p))
+   (.data_i({s0[1], s0[0]}), .data_o({s1[1], s1[0]}));
+
+   bsg_compare_and_swap #(.width_p(width_p), .t_p(t_p), .b_p(b_p))
+   (.data_i({s0[3], s0[2]}), .data_o({s1[3], s1[2]}));
+
+   // stage 2: compare_and swap  <2,0> and <3,1>
+
+   bsg_compare_and_swap #(.width_p(width_p), .t_p(t_p), .b_p(b_p))
+   (.data_i({s1[2], s1[0]}), .data_o({s2[2], s2[0]}));
+
+   bsg_compare_and_swap #(.width_p(width_p), .t_p(t_p), .b_p(b_p))
+   (.data_i({s1[3], s1[1]}), .data_o({s2[3], s2[1]}), .swapped_o(swapped_3_1));
+
+   // stage 3: compare_and swap  <2,1>
+   //
+   // we also swap if they are equal and if <3,1> resulted in a swap
+   // this will reintroduce stability into the sort
+   //
+
+   bsg_compare_and_swap #(.width_p(width_p), .t_p(t_p), .b_p(b_p)
+                          , .cond_swap_on_equal_p(1))
+   (.data_i({s2[2], s2[1]})
+    , .swap_on_equal_i(swapped_3_1)
+    , .data_o({s3[2], s3[1]})
+    );
+
+   assign s3[3] = s2[3];
+   assign s3[0] = s2[0];
+
+   assign o = s3;
+
+endmodule
+

--- a/bsg_mem/bsg_cam_1r1w.v
+++ b/bsg_mem/bsg_cam_1r1w.v
@@ -48,7 +48,6 @@ module bsg_cam_1r1w
   logic               matched, empty_found;
   
   assign r_v_o     = en_i & r_v_i & matched;
-  assign empty_v_o = en_i & empty_found;
    
   //write the input pattern into the cam and set the corresponding valid bit
   always_ff @(posedge clk_i) begin
@@ -113,12 +112,14 @@ module bsg_cam_1r1w
          ,.addr_o(empty_addr_o)
          ,.v_o(empty_found)
         );
+    
+      assign empty_v_o = en_i & empty_found;
     end
-	else begin: fi6
-	// Otherwise, sets empty_v_o and empty_addr_o to zero
-	  assign empty_v_o    = 1'b0;
-	  assign empty_addr_o = '0;
-	end
+    else begin: fi6
+	// Otherwise, sets empty_v_o and empty_addr_o to zero	
+      assign empty_v_o    = 1'b0;
+      assign empty_addr_o = '0;
+    end
   endgenerate
   
   

--- a/bsg_misc/bsg_mul_pipelined.v
+++ b/bsg_misc/bsg_mul_pipelined.v
@@ -62,7 +62,7 @@ module bsg_mul_pipelined #(parameter width_p="inv"
                            , parameter pipeline_p=1
                            , parameter harden_p  =1
                            )
-   (  input clock_i
+   (  input clk_i
     , input en_i
     , input   [width_p-1:0] x_i
     , input [width_p-1:0] y_i
@@ -83,7 +83,7 @@ module bsg_mul_pipelined #(parameter width_p="inv"
 endmodule // bsg_mul
 
 module bsg_mul_32_32 #(parameter harden_p=0, pipeline_p=0)
-   (  input clock_i
+   (  input clk_i
     , input en_i
     , input   [31:0] x_i
     , input [31:0] y_i
@@ -241,7 +241,7 @@ module bsg_mul_32_32 #(parameter harden_p=0, pipeline_p=0)
                              ,.group_vec_p((64'h32_2b_23_1b_15_10_08_00 << 1))
                              ,.harden_p(harden_p)
                      )
-        dffe_c42_03_r (.clock_i
+        dffe_c42_03_r (.clk_i
                        ,.en_i
                        ,.data_i(c42_03_trans)
                        ,.data_o(c42_03_trans_r)
@@ -327,7 +327,7 @@ module bsg_mul_32_32 #(parameter harden_p=0, pipeline_p=0)
         bsg_dff_en #(.width_p(11)
                      ,.harden_p(harden_p)
                      )
-        dffe_gb_dot_r (.clock_i
+        dffe_gb_dot_r (.clk_i
                        ,.en_i
                        ,.data_i(gb_dot[10:0])
                        ,.data_o(gb_dot_r)
@@ -336,7 +336,7 @@ module bsg_mul_32_32 #(parameter harden_p=0, pipeline_p=0)
         bsg_dff_en #(.width_p(8)
                      ,.harden_p(harden_p)
                      )
-        dffe_c42_01s_r (.clock_i
+        dffe_c42_01s_r (.clk_i
                         ,.en_i
                         ,.data_i(c42_01s[7:0])
                         ,.data_o(c42_01s_r)
@@ -345,7 +345,7 @@ module bsg_mul_32_32 #(parameter harden_p=0, pipeline_p=0)
         bsg_dff_en #(.width_p(7)
                      ,.harden_p(harden_p)
                      )
-        dffe_c42_01c_r (.clock_i
+        dffe_c42_01c_r (.clk_i
                         ,.en_i
                         ,.data_i(c42_01c[6:0])
                         ,.data_o(c42_01c_r)
@@ -354,7 +354,7 @@ module bsg_mul_32_32 #(parameter harden_p=0, pipeline_p=0)
         bsg_dff_en #(.width_p(6)
                      ,.harden_p(harden_p)
                      )
-        dffe_s30_r (.clock_i
+        dffe_s30_r (.clk_i
                     ,.en_i
                     ,.data_i(s30[5:0])
                     ,.data_o(s30_r)
@@ -363,7 +363,7 @@ module bsg_mul_32_32 #(parameter harden_p=0, pipeline_p=0)
         bsg_dff_en #(.width_p(5)
                      ,.harden_p(harden_p)
                      )
-        dffe_c30_r (.clock_i
+        dffe_c30_r (.clk_i
                     ,.en_i
                     ,.data_i(c30[4:0])
                     ,.data_o(c30_r)
@@ -568,7 +568,7 @@ module bsg_dff_en_rep_rep #(parameter blocks_p=0
                             , group_vec_p=0
                             , harden_p=1
                             )
-   (input clock_i
+   (input clk_i
     , input en_i
     , input  [width_p-1:0] data_i
     , output [width_p-1:0] data_o
@@ -583,7 +583,7 @@ module bsg_dff_en_rep_rep #(parameter blocks_p=0
         localparam [31:0] blocks_lp  = group_end_lp-group_start_lp;
 
         bsg_dff_en #(.width_p(blocks_lp), .harden_p(harden_p)) bde
-        (.clock_i
+        (.clk_i
          ,.en_i
          ,.data_i(data_i[group_end_lp-1:group_start_lp])
          ,.data_o(data_o[group_end_lp-1:group_start_lp])


### PR DESCRIPTION
1) bsg_sbox_ctrl_concentrate.v (issue #171): filename/module name consistency fix, submodule bsg_sort -> bsg_stable_sort
2) bsg_stable_sort.v (issue #170): filename/module name consistency fix
3) bsg_cam_1r1w.v (issue #184): empty_v_o double assignment fix
4) bsg_mul_pipelined.v (issue #179): all instances of clock_i have been renamed to clk_i to be consistent with the bsg format