### PR TITLE
Add 3r1w mem

### DIFF
--- a/bsg_mem/bsg_mem_3r1w.v
+++ b/bsg_mem/bsg_mem_3r1w.v
@@ -46,13 +46,13 @@ module bsg_mem_3r1w #(parameter width_p=-1
           assert (w_addr_i < els_p)
             else $error("Invalid address %x to %m of size %x\n", w_addr_i, els_p);
 
-          assert (!(r0_addr_i == w_addr_i && w_v_i && r0_v_i && !read_write_same_addr_p))
+          assert (!(r0_addr_i == w_addr_i && r0_v_i && !read_write_same_addr_p))
             else $error("%m: Attempt to read and write same address");
 
-          assert (!(r1_addr_i == w_addr_i && w_v_i && r1_v_i && !read_write_same_addr_p))
+          assert (!(r1_addr_i == w_addr_i && r1_v_i && !read_write_same_addr_p))
             else $error("%m: Attempt to read and write same address");
 
-          assert (!(r2_addr_i == w_addr_i && w_v_i && r2_v_i && !read_write_same_addr_p))
+          assert (!(r2_addr_i == w_addr_i && r2_v_i && !read_write_same_addr_p))
             else $error("%m: Attempt to read and write same address");
 //synopsys translate_on
 

--- a/bsg_mem/bsg_mem_3r1w_sync.v
+++ b/bsg_mem/bsg_mem_3r1w_sync.v
@@ -86,13 +86,13 @@ module bsg_mem_3r1w_sync #(parameter width_p=-1
           assert (w_addr_i < els_p)
             else $error("Invalid address %x to %m of size %x\n", w_addr_i, els_p);
 
-          assert (~(r0_addr_i == w_addr_i && w_v_i && r0_v_i && !read_write_same_addr_p))
+          assert (~(r0_addr_i == w_addr_i && r0_v_i && !read_write_same_addr_p))
             else $error("%m: port 0 Attempt to read and write same address");
 
-          assert (~(r1_addr_i == w_addr_i && w_v_i && r1_v_i && !read_write_same_addr_p))
+          assert (~(r1_addr_i == w_addr_i && r1_v_i && !read_write_same_addr_p))
             else $error("%m: port 1 Attempt to read and write same address");
 
-          assert (~(r2_addr_i == w_addr_i && w_v_i && r2_v_i && !read_write_same_addr_p))
+          assert (~(r2_addr_i == w_addr_i && r2_v_i && !read_write_same_addr_p))
             else $error("%m: port 2 Attempt to read and write same address");
        end
 

--- a/bsg_mem/bsg_mem_3r1w_sync.v
+++ b/bsg_mem/bsg_mem_3r1w_sync.v
@@ -1,0 +1,107 @@
+// MBT 7/7/2016
+// DWP 11/27/2019
+//
+// 3 read-port, 1 write-port ram
+//
+// reads are synchronous
+//
+// although we could merge this with normal bsg_mem_1r1w
+// and select with a parameter, we do not do this because
+// it's typically a very big change to the instantiating code
+// to move to/from sync/async, and we want to reflect this.
+//
+
+module bsg_mem_3r1w_sync #(parameter width_p=-1
+                           , parameter els_p=-1
+                           , parameter read_write_same_addr_p=0
+                           , parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
+                           , parameter harden_p=0
+                           , parameter enable_clock_gating_p=0
+                           )
+   (input   clk_i
+    , input reset_i
+
+    , input                     w_v_i
+    , input [addr_width_lp-1:0] w_addr_i
+    , input [width_p-1:0]       w_data_i
+
+    // currently unused
+    , input                      r0_v_i
+    , input [addr_width_lp-1:0]  r0_addr_i
+    , output logic [width_p-1:0] r0_data_o
+
+    , input                      r1_v_i
+    , input [addr_width_lp-1:0]  r1_addr_i
+    , output logic [width_p-1:0] r1_data_o
+
+    , input                      r2_v_i
+    , input [addr_width_lp-1:0]  r2_addr_i
+    , output logic [width_p-1:0] r2_data_o
+    );
+
+   wire clk_lo;
+
+   if (enable_clock_gating_p)
+     begin
+       bsg_clkgate_optional icg
+         (.clk_i( clk_i )
+         ,.en_i( w_v_i | r0_v_i | r1_v_i | r2_v_i )
+         ,.bypass_i( 1'b0 )
+         ,.gated_clock_o( clk_lo )
+         );
+     end
+   else
+     begin
+       assign clk_lo = clk_i;
+     end
+
+   bsg_mem_3r1w_sync_synth
+     #(.width_p(width_p)
+       ,.els_p(els_p)
+       ,.read_write_same_addr_p(read_write_same_addr_p)
+       ,.harden_p(harden_p)
+       ) synth
+    (.clk_i( clk_lo )
+    ,.reset_i
+    ,.w_v_i
+    ,.w_addr_i
+    ,.w_data_i
+    ,.r0_v_i
+    ,.r0_addr_i
+    ,.r0_data_o
+    ,.r1_v_i
+    ,.r1_addr_i
+    ,.r1_data_o
+    ,.r2_v_i
+    ,.r2_addr_i
+    ,.r2_data_o
+    );
+
+
+//synopsys translate_off
+
+   always_ff @(negedge clk_lo)
+     if (w_v_i)
+       begin
+          assert (w_addr_i < els_p)
+            else $error("Invalid address %x to %m of size %x\n", w_addr_i, els_p);
+
+          assert (~(r0_addr_i == w_addr_i && w_v_i && r0_v_i && !read_write_same_addr_p))
+            else $error("%m: port 0 Attempt to read and write same address");
+
+          assert (~(r1_addr_i == w_addr_i && w_v_i && r1_v_i && !read_write_same_addr_p))
+            else $error("%m: port 1 Attempt to read and write same address");
+
+          assert (~(r2_addr_i == w_addr_i && w_v_i && r2_v_i && !read_write_same_addr_p))
+            else $error("%m: port 2 Attempt to read and write same address");
+       end
+
+   initial
+     begin
+        $display("## %L: instantiating width_p=%d, els_p=%d, read_write_same_addr_p=%d, harden_p=%d (%m)"
+		 ,width_p,els_p,read_write_same_addr_p,harden_p);
+     end
+
+//synopsys translate_on
+
+endmodule

--- a/bsg_mem/bsg_mem_3r1w_sync_synth.v
+++ b/bsg_mem/bsg_mem_3r1w_sync_synth.v
@@ -1,0 +1,99 @@
+// MBT 7/7/2016
+// DWP 11/27/2019
+//
+// 3 read-port, 1 write-port ram
+//
+// reads are synchronous
+//
+// although we could merge this with normal bsg_mem_1r1w
+// and select with a parameter, we do not do this because
+// it's typically a very big change to the instantiating code
+// to move to/from sync/async, and we want to reflect this.
+//
+// NOTE: Users of BaseJump STL should not instantiate this module directly
+// they should use bsg_mem_3r1w_sync.
+
+module bsg_mem_3r1w_sync_synth #(parameter width_p=-1
+				 , parameter els_p=-1
+				 , parameter read_write_same_addr_p=0
+				 , parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
+				 , parameter harden_p=0
+				 )
+   (input   clk_i
+    , input reset_i
+
+    , input                     w_v_i
+    , input [addr_width_lp-1:0] w_addr_i
+    , input [width_p-1:0]       w_data_i
+
+    // currently unused
+    , input                      r0_v_i
+    , input [addr_width_lp-1:0]  r0_addr_i
+    , output logic [width_p-1:0] r0_data_o
+
+    , input                      r1_v_i
+    , input [addr_width_lp-1:0]  r1_addr_i
+    , output logic [width_p-1:0] r1_data_o
+
+    , input                      r2_v_i
+    , input [addr_width_lp-1:0]  r2_addr_i
+    , output logic [width_p-1:0] r2_data_o
+    );
+
+   logic [width_p-1:0]    mem [els_p-1:0];
+
+   wire                   unused = reset_i;
+
+   // keep consistent with bsg_ip_cores/bsg_mem/bsg_mem_3r1w_sync.v
+   // keep consistent with bsg_ip_cores/hard/bsg_mem/bsg_mem_3r1w_sync.v
+
+   // this treats the ram as an array of registers for which the
+   // read addr is latched on the clock, the write
+   // is done on the clock edge, and actually multiplexing
+   // of the registers for reading is done after the clock edge.
+
+   // logically, this means that reads happen in time after
+   // the writes, and "simultaneous" reads and writes to the
+   // register file are allowed -- IF read_write_same_addr is set.
+
+   // note that this behavior is generally incompatible with
+   // hardened 1r1w rams, so it's better not to take advantage
+   // of it if not necessary
+
+   // we explicitly 'X out the read address if valid is not set
+   // to avoid accidental use of data when the valid signal was not
+   // asserted. without this, the output of the register file would
+   // "auto-update" based on new writes to the ram, a spooky behavior
+   // that would never correspond to that of a hardened ram.
+
+   //the read logic, register the input
+   logic [addr_width_lp-1:0]  r0_addr_r, r1_addr_r, r2_addr_r;
+
+   always_ff @(posedge clk_i)
+     if (r0_v_i)
+       r0_addr_r <= r0_addr_i;
+     else
+       r0_addr_r <= 'X;
+
+   always_ff @(posedge clk_i)
+     if (r1_v_i)
+       r1_addr_r <= r1_addr_i;
+     else
+       r1_addr_r <= 'X;
+
+   always_ff @(posedge clk_i)
+     if (r2_v_i)
+       r2_addr_r <= r2_addr_i;
+     else
+       r2_addr_r <= 'X;
+
+   assign r0_data_o = mem[ r0_addr_r ];
+   assign r1_data_o = mem[ r1_addr_r ];
+   assign r2_data_o = mem[ r2_addr_r ];
+
+   //the write logic, the memory is treated as dff array
+   always_ff @(posedge clk_i)
+     if (w_v_i)
+       mem[w_addr_i] <= w_data_i;
+
+endmodule

--- a/bsg_mem/bsg_mem_3r1w_synth.v
+++ b/bsg_mem/bsg_mem_3r1w_synth.v
@@ -1,0 +1,52 @@
+// MBT 4/1/2014
+// DWP 11/27/2019
+//
+// 3 read-port, 1 write-port ram
+//
+// reads are asynchronous
+//
+// this file should not be directly instantiated by end programmers
+// use bsg_mem_3r1w instead
+//
+
+module bsg_mem_3r1w_synth #(parameter width_p=-1
+			    , parameter els_p=-1
+			    , parameter read_write_same_addr_p=0
+			    , parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
+			    )
+   (input   w_clk_i
+    , input w_reset_i
+
+    , input                     w_v_i
+    , input [addr_width_lp-1:0] w_addr_i
+    , input [width_p-1:0]       w_data_i
+
+    , input                      r0_v_i
+    , input [addr_width_lp-1:0]  r0_addr_i
+    , output logic [width_p-1:0] r0_data_o
+
+    , input                      r1_v_i
+    , input [addr_width_lp-1:0]  r1_addr_i
+    , output logic [width_p-1:0] r1_data_o
+
+    , input                      r2_v_i
+    , input [addr_width_lp-1:0]  r2_addr_i
+    , output logic [width_p-1:0] r2_data_o
+    );
+
+   logic [width_p-1:0]    mem [els_p-1:0];
+
+   // this implementation ignores the r_v_i
+   assign r2_data_o = mem[r2_addr_i];
+   assign r1_data_o = mem[r1_addr_i];
+   assign r0_data_o = mem[r0_addr_i];
+
+   wire                   unused = w_reset_i;
+
+   always_ff @(posedge w_clk_i)
+     if (w_v_i)
+       begin
+          mem[w_addr_i] <= w_data_i;
+       end
+
+endmodule

--- a/hard/gf_14/bsg_mem/bsg_mem_3r1w_sync.v
+++ b/hard/gf_14/bsg_mem/bsg_mem_3r1w_sync.v
@@ -93,19 +93,19 @@ module bsg_mem_3r1w_sync #( parameter width_p = -1
    end // block: notmacro
 
   //synopsys translate_off
-  always_ff @(posedge clk_i)
+  always_ff @(negedge clk_i)
     if (w_v_i)
     begin
       assert (w_addr_i < els_p)
         else $error("Invalid address %x to %m of size %x\n", w_addr_i, els_p);
 
-      assert (~(r0_addr_i == w_addr_i && w_v_i && r0_v_i && !read_write_same_addr_p))
+      assert (~(r0_addr_i == w_addr_i && r0_v_i && !read_write_same_addr_p))
         else $error("%m: port 0 Attempt to read and write same address");
 
-      assert (~(r1_addr_i == w_addr_i && w_v_i && r1_v_i && !read_write_same_addr_p))
+      assert (~(r1_addr_i == w_addr_i && r1_v_i && !read_write_same_addr_p))
         else $error("%m: port 1 Attempt to read and write same address");
 
-      assert (~(r2_addr_i == w_addr_i && w_v_i && r2_v_i && !read_write_same_addr_p))
+      assert (~(r2_addr_i == w_addr_i && r2_v_i && !read_write_same_addr_p))
         else $error("%m: port 2 Attempt to read and write same address");
     end
 

--- a/hard/gf_14/bsg_mem/bsg_mem_3r1w_sync.v
+++ b/hard/gf_14/bsg_mem/bsg_mem_3r1w_sync.v
@@ -1,0 +1,118 @@
+
+`define bsg_mem_3r1w_sync_macro(words,bits,mux)      \
+  if (harden_p && els_p == words && width_p == bits) \
+    begin: macro                                     \
+      gf14_1r1w_d``words``_w``bits``_m``mux          \
+        mem0                                         \
+          ( .CLKA  ( clk_i     )                     \
+          , .CLKB  ( clk_i     )                     \
+          , .CENA  ( ~r0_v_i   )                     \
+          , .AA    ( r0_addr_i )                     \
+          , .QA    ( r0_data_o )                     \
+          , .CENB  ( ~w_v_i    )                     \
+          , .AB    ( w_addr_i  )                     \
+          , .DB    ( w_data_i  )                     \
+          , .EMAA  ( 3'b011    )                     \
+          , .EMAB  ( 3'b011    )                     \
+          , .EMASA ( 1'b0      )                     \
+          , .STOV  ( 1'b0      )                     \
+          , .RET1N ( 1'b1      )                     \
+          );                                         \
+      gf14_1r1w_d``words``_w``bits``_m``mux          \
+        mem1                                         \
+          ( .CLKA  ( clk_i     )                     \
+          , .CLKB  ( clk_i     )                     \
+          , .CENA  ( ~r1_v_i   )                     \
+          , .AA    ( r1_addr_i )                     \
+          , .QA    ( r1_data_o )                     \
+          , .CENB  ( ~w_v_i    )                     \
+          , .AB    ( w_addr_i  )                     \
+          , .DB    ( w_data_i  )                     \
+          , .EMAA  ( 3'b011    )                     \
+          , .EMAB  ( 3'b011    )                     \
+          , .EMASA ( 1'b0      )                     \
+          , .STOV  ( 1'b0      )                     \
+          , .RET1N ( 1'b1      )                     \
+          );                                         \
+      gf14_1r1w_d``words``_w``bits``_m``mux          \
+        mem2                                         \
+          ( .CLKA  ( clk_i     )                     \
+          , .CLKB  ( clk_i     )                     \
+          , .CENA  ( ~r2_v_i   )                     \
+          , .AA    ( r2_addr_i )                     \
+          , .QA    ( r2_data_o )                     \
+          , .CENB  ( ~w_v_i    )                     \
+          , .AB    ( w_addr_i  )                     \
+          , .DB    ( w_data_i  )                     \
+          , .EMAA  ( 3'b011    )                     \
+          , .EMAB  ( 3'b011    )                     \
+          , .EMASA ( 1'b0      )                     \
+          , .STOV  ( 1'b0      )                     \
+          , .RET1N ( 1'b1      )                     \
+          );                                         \
+    end: macro
+
+module bsg_mem_3r1w_sync #( parameter width_p = -1
+                          , parameter els_p = -1
+                          , parameter read_write_same_addr_p = 0
+                          , parameter addr_width_lp = `BSG_SAFE_CLOG2(els_p)
+                          , parameter harden_p = 1
+                          , parameter latch_last_read_p = 1
+                          )
+  ( input clk_i
+  , input reset_i
+
+  , input                     w_v_i
+  , input [addr_width_lp-1:0] w_addr_i
+  , input [width_p-1:0]       w_data_i
+
+  , input                      r0_v_i
+  , input [addr_width_lp-1:0]  r0_addr_i
+  , output logic [width_p-1:0] r0_data_o
+
+  , input                      r1_v_i
+  , input [addr_width_lp-1:0]  r1_addr_i
+  , output logic [width_p-1:0] r1_data_o
+
+  , input                      r2_v_i
+  , input [addr_width_lp-1:0]  r2_addr_i
+  , output logic [width_p-1:0] r2_data_o
+  );
+
+  wire unused = reset_i;
+
+  // TODO: Define more hardened macro configs here
+  `bsg_mem_3r1w_sync_macro(32,64,1) else
+  //`bsg_mem_3r1w_sync_macro(32,32,2) else
+
+  // no hardened version found
+   begin: notmacro
+     bsg_mem_3r1w_sync_synth #(.width_p(width_p), .els_p(els_p), .read_write_same_addr_p(read_write_same_addr_p), .harden_p(harden_p))
+      synth
+       (.*);
+   end // block: notmacro
+
+  //synopsys translate_off
+  always_ff @(posedge clk_i)
+    if (w_v_i)
+    begin
+      assert (w_addr_i < els_p)
+        else $error("Invalid address %x to %m of size %x\n", w_addr_i, els_p);
+
+      assert (~(r0_addr_i == w_addr_i && w_v_i && r0_v_i && !read_write_same_addr_p))
+        else $error("%m: port 0 Attempt to read and write same address");
+
+      assert (~(r1_addr_i == w_addr_i && w_v_i && r1_v_i && !read_write_same_addr_p))
+        else $error("%m: port 1 Attempt to read and write same address");
+
+      assert (~(r2_addr_i == w_addr_i && w_v_i && r2_v_i && !read_write_same_addr_p))
+        else $error("%m: port 2 Attempt to read and write same address");
+    end
+
+  initial
+    begin
+      $display("## %L: instantiating width_p=%d, els_p=%d, read_write_same_addr_p=%d, harden_p=%d (%m)",width_p,els_p,read_write_same_addr_p,harden_p);
+    end
+  //synopsys translate_on
+
+endmodule


### PR DESCRIPTION
Untested, but I was playing around with FPU integration in BP and that requires 3r1w memories for the FP regfile.  They need to be 3r1w to support high throughput FMA