### PR TITLE
Ramulator fixups

### DIFF
--- a/bsg_test/bsg_nonsynth_ramulator_hbm.v
+++ b/bsg_test/bsg_nonsynth_ramulator_hbm.v
@@ -70,7 +70,7 @@ module bsg_nonsynth_ramulator_hbm
 
   for (genvar i = 0; i < num_channels_p; i++) begin
     assign read_done_ch_addr[i] = {
-      read_done_addr[i][channel_addr_width_p-1:byte_offset_width_lp+lg_num_channels_lp],
+      read_done_addr[i][channel_addr_width_p+lg_num_channels_lp-1:byte_offset_width_lp+lg_num_channels_lp],
       {byte_offset_width_lp{1'b0}}
     };
   end

--- a/bsg_test/bsg_ramulator_hbm.cpp
+++ b/bsg_test/bsg_ramulator_hbm.cpp
@@ -8,7 +8,9 @@
 #include <iostream>
 #include <vector>
 #include <map>
+#ifdef SV_TEST
 #include "svdpi.h"
+#endif
 #include "HBM.h"
 #include "Controller.h"
 #include "Config.h"


### PR DESCRIPTION
* fixes a bug in the address translation from Ramulator addresses to channel addresses.
* adds a header guard in C++ file (needed to compile for cosimulation).