### PR TITLE
Adding cracked memories for GF12

### DIFF
--- a/bsg_noc/bsg_noc_repeater_node.v
+++ b/bsg_noc/bsg_noc_repeater_node.v
@@ -50,9 +50,9 @@ module bsg_noc_repeater_node
      ,.data_i  ( links_A_cast_i.data )
      ,.ready_o ( links_A_cast_o.ready_and_rev )
 
-     ,.v_o     ( links_A_cast_o.v    )
-     ,.data_o  ( links_A_cast_o.data )
-     ,.yumi_i  ( links_A_cast_i.ready_and_rev & links_A_cast_o.v )
+     ,.v_o     ( links_B_cast_o.v    )
+     ,.data_o  ( links_B_cast_o.data )
+     ,.yumi_i  ( links_B_cast_i.ready_and_rev & links_B_cast_o.v )
      );
 
   bsg_two_fifo #(.width_p(width_p))
@@ -64,9 +64,9 @@ module bsg_noc_repeater_node
      ,.data_i  ( links_B_cast_i.data )
      ,.ready_o ( links_B_cast_o.ready_and_rev )
 
-     ,.v_o     ( links_B_cast_o.v    )
-     ,.data_o  ( links_B_cast_o.data )
-     ,.yumi_i  ( links_B_cast_i.ready_and_rev & links_B_cast_o.v )
+     ,.v_o     ( links_A_cast_o.v    )
+     ,.data_o  ( links_A_cast_o.data )
+     ,.yumi_i  ( links_A_cast_i.ready_and_rev & links_A_cast_o.v )
      );
 
 endmodule

--- a/hard/gf_14/bsg_mem/bsg_mem_1rw_sync.v
+++ b/hard/gf_14/bsg_mem/bsg_mem_1rw_sync.v
@@ -45,7 +45,8 @@ module bsg_mem_1rw_sync #( parameter width_p = -1
   `bsg_mem_1rw_sync_macro(256,96,2) else
   `bsg_mem_1rw_sync_macro(1024,46,4) else
   `bsg_mem_1rw_sync_macro(16,32,2) else
-  `bsg_mem_1rw_sync_macro(64,49,4) else
+  //`bsg_mem_1rw_sync_macro(64,49,4) else
+  `bsg_mem_1rw_sync_macro(256,48,2) else
 
   // no hardened version found
     begin : z

--- a/hard/gf_14/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.v
+++ b/hard/gf_14/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.v
@@ -1,3 +1,4 @@
+`include "bsg_defines.v"
 
 `define bsg_mem_1rw_sync_mask_write_bit_macro(words,bits,mux) \
   if (harden_p && els_p == words && width_p == bits)          \
@@ -43,6 +44,42 @@
         end: bank                                                         \
     end: macro
 
+`define bsg_mem_1rw_sync_mask_write_bit_macro_banks_cracks(words,bits,mux,banks,cracks) \
+  if (harden_p && els_p == words*cracks && width_p == banks*bits)             \
+    begin: macro                                                              \
+      localparam lg_cracks_lp = `BSG_SAFE_CLOG2(cracks);                      \
+      localparam lg_words_lp = `BSG_SAFE_CLOG2(words);                        \
+      wire [cracks-1:0][width_p-1:0] data_lo;                                 \
+      for (genvar j = 0; j < cracks; j++)                                     \
+        begin: crack                                                          \
+          wire crack_sel_li = (addr_i[lg_words_lp+:lg_cracks_lp] == j);       \
+          wire v_li = v_i & crack_sel_li;                                     \
+          wire w_li = w_i & crack_sel_li;                                     \
+          for (genvar i = 0; i < banks; i++)                                  \
+            begin: bank                                                       \
+              gf14_1rw_d``words``_w``bits``_m``mux``_bit                      \
+                mem                                                           \
+                  ( .CLK   ( clk_i                          )                 \
+                  , .A     ( addr_i[0+:lg_words_lp]         )                 \
+                  , .D     ( data_i[i*(width_p/banks)+:width_p/banks]     )   \
+                  , .Q     ( data_lo[j][i*(width_p/banks)+:width_p/banks] )   \
+                  , .CEN   ( ~v_li                          )                 \
+                  , .GWEN  ( ~w_li                          )                 \
+                  , .WEN   ( ~w_mask_i[i*(width_p/banks)+:width_p/banks] )    \
+                  , .RET1N ( 1'b1                           )                 \
+                  , .STOV  ( 1'b0                           )                 \
+                  , .EMA   ( 3'b011                         )                 \
+                  , .EMAW  ( 2'b01                          )                 \
+                  , .EMAS  ( 1'b0                           )                 \
+                  );                                                          \
+            end                                                               \
+        end                                                                   \
+      logic [lg_cracks_lp-1:0] crack_r;                                       \
+      always_ff @(posedge clk_i)                                              \
+        if (v_i & ~w_i) crack_r <= addr_i[lg_words_lp+:lg_cracks_lp];         \
+      assign data_o = data_lo[crack_r];                                       \
+    end: macro
+
 module bsg_mem_1rw_sync_mask_write_bit #( parameter width_p = -1
                                         , parameter els_p = -1
                                         , parameter addr_width_lp = `BSG_SAFE_CLOG2(els_p)
@@ -62,8 +99,8 @@ module bsg_mem_1rw_sync_mask_write_bit #( parameter width_p = -1
   wire unused = reset_i;
 
   // TODO: Define more hardened macro configs here
-  `bsg_mem_1rw_sync_mask_write_bit_macro( 64,15,4) else
-  `bsg_mem_1rw_sync_mask_write_bit_macro( 64, 7,4) else
+  //`bsg_mem_1rw_sync_mask_write_bit_macro( 64,15,4) else
+  //`bsg_mem_1rw_sync_mask_write_bit_macro( 64, 7,4) else
   `bsg_mem_1rw_sync_mask_write_bit_macro(256,48,2) else
   `bsg_mem_1rw_sync_mask_write_bit_macro(256,30,2) else
   `bsg_mem_1rw_sync_mask_write_bit_macro(256,4,2) else
@@ -72,33 +109,14 @@ module bsg_mem_1rw_sync_mask_write_bit #( parameter width_p = -1
   `bsg_mem_1rw_sync_mask_write_bit_macro(512,32,4) else
 
   `bsg_mem_1rw_sync_mask_write_bit_macro_banks(64,116,2, 2) else
+  `bsg_mem_1rw_sync_mask_write_bit_macro_banks(64,116,2, 2) else
   `bsg_mem_1rw_sync_mask_write_bit_macro_banks(128,116,2, 2) else
+  `bsg_mem_1rw_sync_mask_write_bit_macro_banks(256,112,2, 2) else
+  `bsg_mem_1rw_sync_mask_write_bit_macro_banks(64,62,2,8) else
+  `bsg_mem_1rw_sync_mask_write_bit_macro_banks(64,124,2,2) else
+
+  `bsg_mem_1rw_sync_mask_write_bit_macro_banks_cracks(128,112,2,1,2) else
   
-  // HACKED VERSION OF THE FOLLOWING
-  // `bsg_mem_1rw_sync_mask_write_bit_macro_banks( 8,116,2,32) else
-  if (harden_p && els_p == 8 && width_p == 32*116)
-    begin: macro
-      genvar i;
-      for (i = 0; i < 32; i++)
-        begin: bank
-          gf14_1rw_d16_w116_m2_bit
-            mem
-              ( .CLK   ( clk_i                                 )
-              , .A     ( {1'b0, addr_i}                        )
-              , .D     ( data_i[i*(width_p/32)+:width_p/32]    )
-              , .Q     ( data_o[i*(width_p/32)+:width_p/32]    )
-              , .CEN   ( ~v_i                                  )
-              , .GWEN  ( ~w_i                                  )
-              , .WEN   ( ~w_mask_i[i*(width_p/32)+:width_p/32] )
-              , .RET1N ( 1'b1                                  )
-              , .STOV  ( 1'b0                                  )
-              , .EMA   ( 3'b010                                )
-              , .EMAW  ( 2'b00                                 )
-              , .EMAS  ( 1'b0                                  )
-              );
-        end: bank
-    end: macro
-  else
     begin: notmacro
       bsg_mem_1rw_sync_mask_write_bit_synth #(.width_p(width_p), .els_p(els_p))
         synth

--- a/hard/gf_14/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.v
+++ b/hard/gf_14/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.v
@@ -72,6 +72,7 @@ module bsg_mem_1rw_sync_mask_write_bit #( parameter width_p = -1
   `bsg_mem_1rw_sync_mask_write_bit_macro(512,32,4) else
 
   `bsg_mem_1rw_sync_mask_write_bit_macro_banks(64,116,2, 2) else
+  `bsg_mem_1rw_sync_mask_write_bit_macro_banks(128,116,2, 2) else
   
   // HACKED VERSION OF THE FOLLOWING
   // `bsg_mem_1rw_sync_mask_write_bit_macro_banks( 8,116,2,32) else

--- a/hard/gf_14/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v
+++ b/hard/gf_14/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v
@@ -24,6 +24,45 @@
           );                                                   \
     end: macro
 
+`define bsg_mem_1rw_sync_mask_write_byte_macro_banks_cracks(words,bits,mux,banks,cracks) \
+  if (harden_p && els_p == words*cracks && data_width_p == bits*banks)                \
+    begin: macro                                                                      \
+      localparam lg_cracks_lp = `BSG_SAFE_CLOG2(cracks);                              \
+      localparam lg_words_lp = `BSG_SAFE_CLOG2(words);                                \
+      wire [data_width_p-1:0] wen;                                                    \
+      wire [cracks-1:0][data_width_p-1:0] data_lo;                                    \
+      for(genvar k = 0; k < write_mask_width_lp; k++)                                 \
+        assign wen[8*k+:8] = {8{write_mask_i[k]}};                                    \
+      for (genvar j = 0; j < cracks; j++)                                             \
+        begin: crack                                                                  \
+          wire crack_sel_li = (addr_i[lg_words_lp+:lg_cracks_lp] == j);               \
+          wire v_li = v_i & crack_sel_li;                                             \
+          wire w_li = w_i & crack_sel_li;                                             \
+          for (genvar i = 0; i < banks; i++)                                          \
+            begin: bank                                                               \
+              gf14_1rw_d``words``_w``bits``_m``mux``_byte                             \
+                mem                                                                   \
+                  ( .CLK   ( clk_i  )                                                 \
+                  , .A     ( addr_i[0+:lg_words_lp] )                                 \
+                  , .D     ( data_i[i*(data_width_p/banks)+:data_width_p/banks]     ) \
+                  , .Q     ( data_lo[j][i*(data_width_p/banks)+:data_width_p/banks] ) \
+                  , .CEN   ( ~v_li  )                                                 \
+                  , .GWEN  ( ~w_li  )                                                 \
+                  , .WEN   ( ~wen[i*(data_width_p/banks)+:data_width_p/banks] )       \
+                  , .RET1N ( 1'b1   )                                                 \
+                  , .STOV  ( 1'b0   )                                                 \
+                  , .EMA   ( 3'b011 )                                                 \
+                  , .EMAW  ( 2'b01  )                                                 \
+                  , .EMAS  ( 1'b0   )                                                 \
+                  );                                                                  \
+            end                                                                       \
+        end                                                                           \
+      logic [lg_cracks_lp-1:0] crack_r;                                               \
+      always_ff @(posedge clk_i)                                                      \
+        if (v_i & ~w_i) crack_r <= addr_i[lg_words_lp+:lg_cracks_lp];                 \
+      assign data_o = data_lo[crack_r];                                               \
+    end: macro
+
 module bsg_mem_1rw_sync_mask_write_byte #( parameter els_p = -1
                                          , parameter data_width_p = -1
                                          , parameter addr_width_lp = `BSG_SAFE_CLOG2(els_p)
@@ -49,7 +88,8 @@ module bsg_mem_1rw_sync_mask_write_byte #( parameter els_p = -1
   `bsg_mem_1rw_sync_mask_write_byte_macro(1024,32,4) else
   `bsg_mem_1rw_sync_mask_write_byte_macro(2048,64,4) else
   `bsg_mem_1rw_sync_mask_write_byte_macro(4096,64,4) else
-  `bsg_mem_1rw_sync_mask_write_byte_macro(1024,512,2) else
+  `bsg_mem_1rw_sync_mask_write_byte_macro(512,128,2) else
+  `bsg_mem_1rw_sync_mask_write_byte_macro_banks_cracks(512,64,2,4,4) else
 
   // no hardened version found
     begin : notmacro

--- a/hard/gf_14/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v
+++ b/hard/gf_14/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v
@@ -49,6 +49,7 @@ module bsg_mem_1rw_sync_mask_write_byte #( parameter els_p = -1
   `bsg_mem_1rw_sync_mask_write_byte_macro(1024,32,4) else
   `bsg_mem_1rw_sync_mask_write_byte_macro(2048,64,4) else
   `bsg_mem_1rw_sync_mask_write_byte_macro(4096,64,4) else
+  `bsg_mem_1rw_sync_mask_write_byte_macro(1024,512,2) else
 
   // no hardened version found
     begin : notmacro

--- a/hard/tsmc_40/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.v
+++ b/hard/tsmc_40/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.v
@@ -56,6 +56,7 @@ module bsg_mem_1rw_sync_mask_write_bit #(parameter width_p=-1
    `bsg_mem_1rf_sync_macro_bit(256,34,8,2) else
    `bsg_mem_1rf_sync_macro_bit(256,36,8,2) else
    `bsg_mem_1rw_sync_macro_bit(64,80,6,1)  else
+   `bsg_mem_1rw_sync_macro_bit(128,232,2)
    bsg_mem_1rw_sync_mask_write_bit_synth
      #(.width_p(width_p)
        ,.els_p(els_p)

--- a/hard/tsmc_40/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v
+++ b/hard/tsmc_40/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v
@@ -103,6 +103,7 @@ module bsg_mem_1rw_sync_mask_write_byte
   `bsg_mem_1rf_sync_macro_byte_banks(512,32,9,4) else
   `bsg_mem_1rf_sync_macro_byte(1024,32,10,8) else
   `bsg_mem_1rw_sync_macro_byte(1024,32,10,4) else
+  `bsg_mem_1rw_sync_macro_byte(1024,512,2) else
   // no hardened version found
     begin  : notmacro
 


### PR DESCRIPTION
Adds cracked memories for 1rw bit and byte for GF12.  Tested independently and in the context of BP with L2.

Overheads are lg_cracks_lp flops used for muxing the return data, and of course the mux itself.