### PR TITLE
Removing implicit latch from store buffer

### DIFF
--- a/bsg_cache/bsg_cache_sbuf.v
+++ b/bsg_cache/bsg_cache_sbuf.v
@@ -99,6 +99,7 @@ module bsg_cache_sbuf
         // this would never happen.
         v_o = 0;
         empty_o = 0;
+        full_o = 0;
         el0_valid = 0;
         el1_valid = 0;
         el0_enable = 0;


### PR DESCRIPTION
There's an incomplete assignment in bsg_cache_sbuf