### PR TITLE
BSG Circular Pointer Non-pow2 Behavior Fix in RTL Simulation

### DIFF
--- a/bsg_misc/bsg_circular_ptr.v
+++ b/bsg_misc/bsg_circular_ptr.v
@@ -20,7 +20,7 @@ module bsg_circular_ptr #(parameter slots_p     = -1
     , output [ptr_width_lp-1:0] n_o
     );
 
-   logic [ptr_width_lp-1:0] ptr_r, ptr_n;
+   logic [ptr_width_lp-1:0] ptr_r, ptr_n, ptr_nowrap;
    logic [ptr_width_lp:0]   ptr_wrap;
 
    assign o = ptr_r;
@@ -57,24 +57,21 @@ module bsg_circular_ptr #(parameter slots_p     = -1
        end
      else
        begin: notpow2
+          // compute wrapped and non-wrap cases
+          // in parallel
+          assign ptr_wrap = { 1'b0, ptr_r } - slots_p + add_i;
+          assign ptr_nowrap = ptr_r + add_i;
+
+          // if (ptr_r + add_i - slots_p >= 0)
+          // then we have wrapped around
+          assign ptr_n = ~ptr_wrap[ptr_width_lp] ? ptr_wrap[0+:ptr_width_lp] : ptr_nowrap;
+
+	  // synopsys translate_off
           always_comb
             begin
-               // compute wrapped and non-wrap cases
-               // in parallel
-
-               ptr_wrap = { 1'b0, ptr_r } - slots_p + add_i;
-               ptr_n = ptr_r + add_i;
-
-               // if (ptr_r + add_i - slots_p >= 0)
-               // then we have wrapped around
-
-               if  (~ptr_wrap[ptr_width_lp])
-                 ptr_n = ptr_wrap[0+:ptr_width_lp];
-
-	       // synopsys translate_off
-               assert( (ptr_n < slots_p) || (|ptr_n === 'X) || reset_i || (add_i > slots_p))
-                 else $error("bsg_circular_ptr counter overflow (ptr_r=%b/add_i=%b/ptr_wrap=%b/ptr_n=%b)",ptr_r,add_i,ptr_wrap,ptr_n, slots_p);
-	       // synopsys translate_on
+              assert( (ptr_n < slots_p) || (|ptr_n === 'X) || reset_i || (add_i > slots_p))
+                else $error("bsg_circular_ptr counter overflow (ptr_r=%b/add_i=%b/ptr_wrap=%b/ptr_n=%b)",ptr_r,add_i,ptr_wrap,ptr_n, slots_p);
             end
+	  // synopsys translate_on
 end
 endmodule // bsg_circular_ptr


### PR DESCRIPTION
The bsg_circular_ptr module when simulated in VCS versions L-2016.06-SP2-15, O-2018.09-SP2-6, and P-2019.06 is not working correctly when slots_p is a non-power of 2. Specifically, it appeared as if statements in the combinational block with "+ add_i" was simply not being added. I am unclear about why this is showing up now ...

Logically, this module is the same after the fixes. I just changed the syntax which seems to work better with VCS.

Post synthesis results show a 0% change in area and 0% change in critical path for every path group.