### PR TITLE
Cache_to_axi support multiple outstanding requests

### DIFF
--- a/bsg_cache/bsg_cache_to_axi.v
+++ b/bsg_cache/bsg_cache_to_axi.v
@@ -10,6 +10,10 @@ module bsg_cache_to_axi
     ,parameter block_size_in_words_p="inv"
     ,parameter data_width_p="inv"
     ,parameter num_cache_p="inv"
+    
+    // tag fifo size can be greater than number of cache dma interfaces
+    // Set to maximum possible outstanding requests to avoid stalling
+    ,parameter tag_fifo_els_p=num_cache_p
 
     ,parameter axi_id_width_p="inv" // 6
     ,parameter axi_addr_width_p="inv"
@@ -183,6 +187,7 @@ module bsg_cache_to_axi
     .num_cache_p(num_cache_p)
     ,.data_width_p(data_width_p)
     ,.block_size_in_words_p(block_size_in_words_p)
+    ,.tag_fifo_els_p(tag_fifo_els_p)
     ,.axi_id_width_p(axi_id_width_p)
     ,.axi_addr_width_p(axi_addr_width_p)
     ,.axi_data_width_p(axi_data_width_p)
@@ -225,6 +230,7 @@ module bsg_cache_to_axi
     .num_cache_p(num_cache_p)
     ,.data_width_p(data_width_p)
     ,.block_size_in_words_p(block_size_in_words_p)
+    ,.tag_fifo_els_p(tag_fifo_els_p)
     ,.axi_id_width_p(axi_id_width_p)
     ,.axi_addr_width_p(axi_addr_width_p)
     ,.axi_data_width_p(axi_data_width_p)

--- a/bsg_cache/bsg_cache_to_axi_rx.v
+++ b/bsg_cache/bsg_cache_to_axi_rx.v
@@ -8,7 +8,7 @@ module bsg_cache_to_axi_rx
   #(parameter num_cache_p="inv"
     ,parameter data_width_p="inv"
     ,parameter block_size_in_words_p="inv"
-    ,parameter tag_fifo_els_p="inv"
+    ,parameter tag_fifo_els_p=num_cache_p
 
     ,parameter axi_id_width_p="inv"
     ,parameter axi_addr_width_p="inv"

--- a/bsg_cache/bsg_cache_to_axi_rx.v
+++ b/bsg_cache/bsg_cache_to_axi_rx.v
@@ -8,6 +8,7 @@ module bsg_cache_to_axi_rx
   #(parameter num_cache_p="inv"
     ,parameter data_width_p="inv"
     ,parameter block_size_in_words_p="inv"
+    ,parameter tag_fifo_els_p="inv"
 
     ,parameter axi_id_width_p="inv"
     ,parameter axi_addr_width_p="inv"
@@ -61,28 +62,31 @@ module bsg_cache_to_axi_rx
   // tag fifo
   //
   logic tag_fifo_v_li;
+  logic tag_fifo_ready_lo;
   logic tag_fifo_v_lo;
   logic tag_fifo_yumi_li;
   logic [lg_num_cache_lp-1:0] tag_lo;
 
   bsg_fifo_1r1w_small #(
     .width_p(lg_num_cache_lp)
-    ,.els_p(num_cache_p)
+    ,.els_p(tag_fifo_els_p)
   ) tag_fifo (
     .clk_i(clk_i)
     ,.reset_i(reset_i)
 
     ,.v_i(tag_fifo_v_li)
-    ,.ready_o()
+    ,.ready_o(tag_fifo_ready_lo)
     ,.data_i(tag_i)
 
     ,.v_o(tag_fifo_v_lo)
     ,.data_o(tag_lo)
     ,.yumi_i(tag_fifo_yumi_li)
   );
-
-  assign yumi_o = v_i & axi_arready_i;
-  assign tag_fifo_v_li = yumi_o;
+  
+  // yumi when both tag_fifo and axi_ar are ready
+  assign yumi_o = v_i & axi_arready_i & tag_fifo_ready_lo;
+  // tag_fifo is valid when axi_ar is ready
+  assign tag_fifo_v_li = v_i & axi_arready_i;
   
   // axi read address channel
   //
@@ -94,7 +98,8 @@ module bsg_cache_to_axi_rx
   assign axi_arcache_o = 4'b0000; // non-bufferable
   assign axi_arprot_o = 2'b00;    // unprevileged
   assign axi_arlock_o = 1'b0;    // normal access
-  assign axi_arvalid_o = v_i;
+  // axi_ar is valid when tag_fifo is ready
+  assign axi_arvalid_o = v_i & tag_fifo_ready_lo;
 
  
   // axi read data channel

--- a/bsg_cache/bsg_cache_to_axi_tx.v
+++ b/bsg_cache/bsg_cache_to_axi_tx.v
@@ -9,6 +9,7 @@ module bsg_cache_to_axi_tx
   #(parameter num_cache_p="inv"
     ,parameter data_width_p="inv"
     ,parameter block_size_in_words_p="inv"
+    ,parameter tag_fifo_els_p="inv"
     
     ,parameter axi_id_width_p="inv"
     ,parameter axi_addr_width_p="inv"
@@ -63,19 +64,20 @@ module bsg_cache_to_axi_tx
   // tag fifo
   //
   logic tag_fifo_v_li;
+  logic tag_fifo_ready_lo;
   logic tag_fifo_v_lo;
   logic tag_fifo_yumi_li;
   logic [lg_num_cache_lp-1:0] tag_lo;
 
   bsg_fifo_1r1w_small #(
     .width_p(lg_num_cache_lp)
-    ,.els_p(num_cache_p)
+    ,.els_p(tag_fifo_els_p)
   ) tag_fifo (
     .clk_i(clk_i)
     ,.reset_i(reset_i)
 
     ,.v_i(tag_fifo_v_li)
-    ,.ready_o()
+    ,.ready_o(tag_fifo_ready_lo)
     ,.data_i(tag_i)
 
     ,.v_o(tag_fifo_v_lo)
@@ -92,8 +94,10 @@ module bsg_cache_to_axi_tx
 
   // tag 
   //
-  assign yumi_o = v_i & axi_awready_i;
-  assign tag_fifo_v_li = yumi_o;
+  // yumi when both tag_fifo and axi_aw are ready
+  assign yumi_o = v_i & axi_awready_i & tag_fifo_ready_lo;
+  // tag_fifo is valid when axi_aw is ready
+  assign tag_fifo_v_li = v_i & axi_awready_i;
 
   // axi write address channel
   //
@@ -105,7 +109,8 @@ module bsg_cache_to_axi_tx
   assign axi_awcache_o = 4'b0000; // non-bufferable
   assign axi_awprot_o = 2'b00;    // unprivileged
   assign axi_awlock_o = 1'b0;    // normal access
-  assign axi_awvalid_o = v_i;
+  // axi_aw is valid when tag_fifo is ready
+  assign axi_awvalid_o = v_i & tag_fifo_ready_lo;
 
   // axi write data channel
   //

--- a/bsg_cache/bsg_cache_to_axi_tx.v
+++ b/bsg_cache/bsg_cache_to_axi_tx.v
@@ -9,7 +9,7 @@ module bsg_cache_to_axi_tx
   #(parameter num_cache_p="inv"
     ,parameter data_width_p="inv"
     ,parameter block_size_in_words_p="inv"
-    ,parameter tag_fifo_els_p="inv"
+    ,parameter tag_fifo_els_p=num_cache_p
     
     ,parameter axi_id_width_p="inv"
     ,parameter axi_addr_width_p="inv"


### PR DESCRIPTION
Currently cache_to_axi assumes one bsg_cache attach to one cache_dma port, each bsg_cache has only one outstanding request. If more than one outstanding requests appear, tag_fifo would drop them.

This PR adds two features:
1. tag_fifo now has flow control, which stalls instead of dropping tags
2. tag_fifo size is parameterized and exposed to outside
