### PR TITLE
Move RAM data for test DRAM channel into C++ vector

### DIFF
--- a/bsg_test/bsg_nonsynth_dramsim3.v
+++ b/bsg_test/bsg_nonsynth_dramsim3.v
@@ -158,13 +158,13 @@ module bsg_nonsynth_dramsim3
   logic [num_channels_p-1:0][channel_addr_width_p-1:0] read_addr_li;
   logic [num_channels_p-1:0] write_v_li;
 
-  for (genvar i = 0; i < num_channels_p; i++) begin
-
+  for (genvar i = 0; i < num_channels_p; i++) begin: channels
     bsg_nonsynth_test_dram_channel
       #(.channel_addr_width_p(channel_addr_width_p)
         ,.data_width_p(data_width_p)
         ,.init_mem_p(init_mem_p)
-        ,.mem_els_p((size_in_bits_p/num_channels_p)/data_width_p))
+        ,.mem_els_p((size_in_bits_p/num_channels_p)/data_width_p)
+        ,.channel_id_p(i))
     channel
       (.clk_i(clk_i)
       ,.reset_i(reset_i)
@@ -215,7 +215,6 @@ module bsg_nonsynth_dramsim3
       end
     end
   end
-
 
 
   // final

--- a/bsg_test/bsg_nonsynth_test_dram_channel.v
+++ b/bsg_test/bsg_nonsynth_test_dram_channel.v
@@ -64,19 +64,18 @@ module bsg_nonsynth_test_dram_channel
   logic [7:0] mem_data_lo [0:data_width_in_bytes_lp-1];
   logic       data_v_lo;
 
-  for (genvar byte_id = 0; byte_id < data_width_in_bytes_lp; byte_id++) begin
-    always_ff @(negedge clk_i) begin
-      if (read_v_i) begin
-        mem_data_lo[byte_id] <= bsg_test_dram_channel_get(memory, read_addr_i+byte_id);
-      end
-    end
-  end
+   always_ff @(negedge clk_i) begin
+      for (integer byte_id = 0; byte_id < data_width_in_bytes_lp; byte_id++) begin
+	 if (read_v_i)
+	   mem_data_lo[byte_id] <= bsg_test_dram_channel_get(memory, read_addr_i+byte_id);
 
-  always_ff @(negedge clk_i) begin
-    data_v_lo <= '0;
-    if (read_v_i)
-      data_v_lo <= '1;
-  end
+      end
+
+      data_v_lo <= '0;
+      if (read_v_i)
+	data_v_lo <= '1;
+
+   end
 
   assign data_v_o = data_v_lo;
 
@@ -95,21 +94,17 @@ module bsg_nonsynth_test_dram_channel
     assign mem_data_li[byte_id] = data_i[byte_id*8+:8];
   end
 
-  for (genvar byte_id = 0; byte_id < data_width_in_bytes_lp; byte_id++) begin
-    always_ff @ (posedge clk_i) begin
-      if (~reset_i) begin
-        if (write_v_i & data_v_i) begin
-          bsg_test_dram_channel_set(memory, write_addr_i+byte_id, mem_data_li[byte_id]);
-        end
+   always_ff @(posedge clk_i) begin
+      for (integer byte_id = 0; byte_id < data_width_in_bytes_lp; byte_id++) begin
+	 if (~reset_i & write_v_i & data_v_i)
+	   bsg_test_dram_channel_set(memory, write_addr_i+byte_id, mem_data_li[byte_id]);
+
       end
-    end
-  end
 
-  always_ff @(posedge clk_i) begin
-    data_yumi_o <= '0;
-    if (~reset_i & write_v_i & data_v_i)
-      data_yumi_o <= '1;
-  end
+      data_yumi_o <= '0;
+      if (~reset_i & write_v_i & data_v_i)
+	data_yumi_o <= '1;
 
+   end
 
 endmodule

--- a/bsg_test/bsg_nonsynth_test_dram_channel.v
+++ b/bsg_test/bsg_nonsynth_test_dram_channel.v
@@ -61,13 +61,13 @@ module bsg_nonsynth_test_dram_channel
   // read logic //
   ////////////////
 
-  logic [7:0] mem_data_lo [0:data_width_in_bytes_lp-1];
-  logic       data_v_lo;
+  logic [data_width_p-1:0] mem_data_lo;
+  logic 		   data_v_lo;
 
    always_ff @(negedge clk_i) begin
       for (integer byte_id = 0; byte_id < data_width_in_bytes_lp; byte_id++) begin
 	 if (read_v_i)
-	   mem_data_lo[byte_id] <= bsg_test_dram_channel_get(memory, read_addr_i+byte_id);
+	   mem_data_lo[byte_id*8+:8] <= bsg_test_dram_channel_get(memory, read_addr_i+byte_id);
 
       end
 
@@ -78,29 +78,24 @@ module bsg_nonsynth_test_dram_channel
    end
 
   assign data_v_o = data_v_lo;
-
-  for (genvar byte_id = 0; byte_id < data_width_in_bytes_lp; byte_id++) begin
-    assign data_o[byte_id*8+:8] = mem_data_lo[byte_id];
-  end
+  assign data_o = mem_data_lo;
 
 
   /////////////////
   // write logic //
   /////////////////
 
-  logic [7:0] mem_data_li [0:data_width_in_bytes_lp-1];
-  logic      write_valid;
+  logic [data_width_p-1:0] mem_data_li;
+  logic 		   write_valid;
 
   assign write_valid = ~reset_i & write_v_i & data_v_i;
 
-  for (genvar byte_id = 0; byte_id < data_width_in_bytes_lp; byte_id++) begin
-    assign mem_data_li[byte_id] = data_i[byte_id*8+:8];
-  end
+  assign mem_data_li = data_i;
 
    always_ff @(posedge clk_i) begin
       for (integer byte_id = 0; byte_id < data_width_in_bytes_lp; byte_id++) begin
 	 if (write_valid)
-	   bsg_test_dram_channel_set(memory, write_addr_i+byte_id, mem_data_li[byte_id]);
+	   bsg_test_dram_channel_set(memory, write_addr_i+byte_id, mem_data_li[byte_id*8+:8]);
 
       end
    end

--- a/bsg_test/bsg_nonsynth_test_dram_channel.v
+++ b/bsg_test/bsg_nonsynth_test_dram_channel.v
@@ -89,6 +89,9 @@ module bsg_nonsynth_test_dram_channel
   /////////////////
 
   logic [7:0] mem_data_li [0:data_width_in_bytes_lp-1];
+  logic      write_valid;
+
+  assign write_valid = ~reset_i & write_v_i & data_v_i;
 
   for (genvar byte_id = 0; byte_id < data_width_in_bytes_lp; byte_id++) begin
     assign mem_data_li[byte_id] = data_i[byte_id*8+:8];
@@ -96,15 +99,13 @@ module bsg_nonsynth_test_dram_channel
 
    always_ff @(posedge clk_i) begin
       for (integer byte_id = 0; byte_id < data_width_in_bytes_lp; byte_id++) begin
-	 if (~reset_i & write_v_i & data_v_i)
+	 if (write_valid)
 	   bsg_test_dram_channel_set(memory, write_addr_i+byte_id, mem_data_li[byte_id]);
 
       end
-
-      data_yumi_o <= '0;
-      if (~reset_i & write_v_i & data_v_i)
-	data_yumi_o <= '1;
-
    end
+
+   assign data_yumi_o = write_valid;
+
 
 endmodule

--- a/bsg_test/bsg_nonsynth_test_dram_channel.v
+++ b/bsg_test/bsg_nonsynth_test_dram_channel.v
@@ -12,6 +12,7 @@ module bsg_nonsynth_test_dram_channel
     , parameter data_mask_width_lp=(data_width_p>>3)
     , parameter byte_offset_width_lp=`BSG_SAFE_CLOG2(data_width_p>>3)
     , parameter data_width_in_bytes_lp = data_mask_width_lp
+    , parameter init_mem_p=0
   )
   (
     input clk_i
@@ -39,7 +40,8 @@ module bsg_nonsynth_test_dram_channel
     chandle bsg_test_dram_channel_init(longint unsigned id,
                                        longint unsigned channel_addr_width_fp,
                                        longint unsigned data_width_fp,
-                                       longint unsigned mem_els_fp);
+                                       longint unsigned mem_els_fp,
+				       longint unsigned init_mem_fp);
 
   import "DPI-C" context function
     byte unsigned bsg_test_dram_channel_get(chandle handle, longint unsigned addr);
@@ -52,7 +54,7 @@ module bsg_nonsynth_test_dram_channel
 
   initial begin
     memory
-      = bsg_test_dram_channel_init(channel_id_p, channel_addr_width_p, data_width_p, mem_els_p);
+      = bsg_test_dram_channel_init(channel_id_p, channel_addr_width_p, data_width_p, mem_els_p, init_mem_p);
   end
 
   ////////////////

--- a/bsg_test/bsg_nonsynth_test_dram_channel.v
+++ b/bsg_test/bsg_nonsynth_test_dram_channel.v
@@ -7,8 +7,7 @@ module bsg_nonsynth_test_dram_channel
   #(parameter channel_addr_width_p="inv"
     , parameter data_width_p="inv"
     , parameter mem_els_p=2**23 // 512 MB total
-
-    , parameter init_mem_p=0
+    , parameter channel_id_p="inv"
 
     , parameter data_mask_width_lp=(data_width_p>>3)
     , parameter byte_offset_width_lp=`BSG_SAFE_CLOG2(data_width_p>>3)
@@ -36,19 +35,24 @@ module bsg_nonsynth_test_dram_channel
 
   logic [data_width_p-1:0] mem [mem_els_p-1:0];
 
-  import "DPI-C" function chandle bsg_test_dram_channel_init(longint unsigned channel_addr_width_fp,
-                                                             longint unsigned data_width_fp,
-                                                             longint unsigned mem_els_fp);
+  import "DPI-C" context function
+    chandle bsg_test_dram_channel_init(longint unsigned id,
+                                       longint unsigned channel_addr_width_fp,
+                                       longint unsigned data_width_fp,
+                                       longint unsigned mem_els_fp);
 
-  import "DPI-C" function byte unsigned bsg_test_dram_channel_get(chandle handle, longint unsigned addr);
+  import "DPI-C" context function
+    byte unsigned bsg_test_dram_channel_get(chandle handle, longint unsigned addr);
 
-  import "DPI-C" function void bsg_test_dram_channel_set(chandle handle, longint unsigned addr, byte val);
+  import "DPI-C" context function
+    void bsg_test_dram_channel_set(chandle handle, longint unsigned addr, byte val);
 
   chandle memory;
 
 
   initial begin
-    memory = bsg_test_dram_channel_init(channel_addr_width_p, data_width_p, mem_els_p);
+    memory
+      = bsg_test_dram_channel_init(channel_id_p, channel_addr_width_p, data_width_p, mem_els_p);
   end
 
   ////////////////

--- a/bsg_test/bsg_test_dram_channel.cpp
+++ b/bsg_test/bsg_test_dram_channel.cpp
@@ -1,8 +1,9 @@
 #include "svdpi.h"
 #include "svdpi_src.h"
-#include <vector>
 #include <cstdio>
 #include <cassert>
+#include <map>
+#include "bsg_test_dram_channel.hpp"
 
 #ifdef DEBUG
 #define pr_dbg(fmt, ...)                        \
@@ -14,66 +15,21 @@
 using namespace std;
 
 namespace bsg_test_dram_channel {
-    using parameter_t = unsigned long long;
-    using byte_t = unsigned char;
-    using address_t = unsigned long long;
-
-    class Memory {
-    public:
-        Memory(parameter_t channel_addr_width_p,
-               parameter_t data_width_p,
-               parameter_t mem_els_p):
-            _channel_addr_width_p(channel_addr_width_p),
-            _data_width_p(data_width_p),
-            _mem_els_p(mem_els_p) {
-
-            parameter_t bytes = (data_width_p/8) * mem_els_p;
-            _data.resize(bytes);
-        }
-
-        byte_t get(address_t addr) const {
-            return _data[addr];
-        }
-
-        void set(address_t addr, byte_t val) {
-            _data[addr] = val;
-        }
-
-        byte_t & operator[](address_t addr) {
-            return _data[addr];
-        }
-
-        byte_t operator[](address_t addr) const {
-            return _data[addr];
-        }
-
-    private:
-        std::vector<byte_t> _data;
-        parameter_t _channel_addr_width_p;
-        parameter_t _data_width_p;
-        parameter_t _mem_els_p;
-    };
+    std::map<parameter_t, Memory *> global_memories;
 }
 
 using namespace bsg_test_dram_channel;
 
 extern "C" void * bsg_test_dram_channel_init(
+    parameter_t id,
     parameter_t channel_addr_width_p,
     parameter_t data_width_p,
     parameter_t mem_els_p
     )
 {
-    int bytes = data_width_p/8;
-
     assert(data_width_p % 8 == 0);
-
     Memory *memory =  new Memory(channel_addr_width_p, data_width_p, mem_els_p);
-
-    memory->set(0x00000000, 0xbe);
-    memory->set(0x00000001, 0xba);
-    memory->set(0x00000002, 0xfe);
-    memory->set(0x00000003, 0xca);
-
+    global_memories[id] = memory;
     return memory;
 }
 
@@ -96,4 +52,15 @@ extern "C" void bsg_test_dram_channel_set(
     pr_dbg("setting 0x%08llx to %02x\n", addr, val);
     Memory *memory = reinterpret_cast<Memory*>(handle);
     memory->set(addr, val);
+}
+namespace bsg_test_dram_channel {
+    Memory *bsg_test_dram_channel_get_memory(parameter_t id)
+    {
+        auto m = global_memories.find(id);
+        if (m != global_memories.end()) {
+            return m->second;
+        } else {
+            return nullptr;
+        }
+    }
 }

--- a/bsg_test/bsg_test_dram_channel.cpp
+++ b/bsg_test/bsg_test_dram_channel.cpp
@@ -24,11 +24,12 @@ extern "C" void * bsg_test_dram_channel_init(
     parameter_t id,
     parameter_t channel_addr_width_p,
     parameter_t data_width_p,
-    parameter_t mem_els_p
+    parameter_t mem_els_p,
+    parameter_t init_mem_p
     )
 {
     assert(data_width_p % 8 == 0);
-    Memory *memory =  new Memory(channel_addr_width_p, data_width_p, mem_els_p);
+    Memory *memory =  new Memory(channel_addr_width_p, data_width_p, mem_els_p, init_mem_p);
     global_memories[id] = memory;
     return memory;
 }

--- a/bsg_test/bsg_test_dram_channel.cpp
+++ b/bsg_test/bsg_test_dram_channel.cpp
@@ -1,0 +1,99 @@
+#include "svdpi.h"
+#include "svdpi_src.h"
+#include <vector>
+#include <cstdio>
+#include <cassert>
+
+#ifdef DEBUG
+#define pr_dbg(fmt, ...)                        \
+    printf("[bsg_test_dram_channel]: " fmt, ##__VA_ARGS__)
+#else
+#define pr_dbg(fmt, ...)
+#endif
+
+using namespace std;
+
+namespace bsg_test_dram_channel {
+    using parameter_t = unsigned long long;
+    using byte_t = unsigned char;
+    using address_t = unsigned long long;
+
+    class Memory {
+    public:
+        Memory(parameter_t channel_addr_width_p,
+               parameter_t data_width_p,
+               parameter_t mem_els_p):
+            _channel_addr_width_p(channel_addr_width_p),
+            _data_width_p(data_width_p),
+            _mem_els_p(mem_els_p) {
+
+            parameter_t bytes = (data_width_p/8) * mem_els_p;
+            _data.resize(bytes);
+        }
+
+        byte_t get(address_t addr) const {
+            return _data[addr];
+        }
+
+        void set(address_t addr, byte_t val) {
+            _data[addr] = val;
+        }
+
+        byte_t & operator[](address_t addr) {
+            return _data[addr];
+        }
+
+        byte_t operator[](address_t addr) const {
+            return _data[addr];
+        }
+
+    private:
+        std::vector<byte_t> _data;
+        parameter_t _channel_addr_width_p;
+        parameter_t _data_width_p;
+        parameter_t _mem_els_p;
+    };
+}
+
+using namespace bsg_test_dram_channel;
+
+extern "C" void * bsg_test_dram_channel_init(
+    parameter_t channel_addr_width_p,
+    parameter_t data_width_p,
+    parameter_t mem_els_p
+    )
+{
+    int bytes = data_width_p/8;
+
+    assert(data_width_p % 8 == 0);
+
+    Memory *memory =  new Memory(channel_addr_width_p, data_width_p, mem_els_p);
+
+    memory->set(0x00000000, 0xbe);
+    memory->set(0x00000001, 0xba);
+    memory->set(0x00000002, 0xfe);
+    memory->set(0x00000003, 0xca);
+
+    return memory;
+}
+
+extern "C" byte_t bsg_test_dram_channel_get(
+    void *handle,
+    address_t addr
+    )
+{
+    Memory *memory = reinterpret_cast<Memory*>(handle);
+    pr_dbg("getting 0x%08llx   (%02x)\n", addr, memory->get(addr));
+    return memory->get(addr);
+}
+
+extern "C" void bsg_test_dram_channel_set(
+    void *handle,
+    address_t addr,
+    byte_t val
+    )
+{
+    pr_dbg("setting 0x%08llx to %02x\n", addr, val);
+    Memory *memory = reinterpret_cast<Memory*>(handle);
+    memory->set(addr, val);
+}

--- a/bsg_test/bsg_test_dram_channel.hpp
+++ b/bsg_test/bsg_test_dram_channel.hpp
@@ -1,0 +1,46 @@
+#pragma once
+#include <vector>
+
+namespace bsg_test_dram_channel {
+    using parameter_t = unsigned long long;
+    using byte_t = unsigned char;
+    using address_t = unsigned long long;
+
+    class Memory {
+    public:
+        Memory(parameter_t channel_addr_width_p,
+               parameter_t data_width_p,
+               parameter_t mem_els_p):
+            _channel_addr_width_p(channel_addr_width_p),
+            _data_width_p(data_width_p),
+            _mem_els_p(mem_els_p) {
+
+            parameter_t bytes = (data_width_p/8) * mem_els_p;
+            _data.resize(bytes);
+        }
+
+        byte_t get(address_t addr) const {
+            return _data[addr];
+        }
+
+        void set(address_t addr, byte_t val) {
+            _data[addr] = val;
+        }
+
+        byte_t & operator[](address_t addr) {
+            return _data[addr];
+        }
+
+        byte_t operator[](address_t addr) const {
+            return _data[addr];
+        }
+
+        std::vector<byte_t> _data;
+        parameter_t _channel_addr_width_p;
+        parameter_t _data_width_p;
+        parameter_t _mem_els_p;
+
+    };
+
+    Memory *bsg_test_dram_channel_get_memory(parameter_t id);
+}

--- a/bsg_test/bsg_test_dram_channel.hpp
+++ b/bsg_test/bsg_test_dram_channel.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <vector>
+#include <cstring>
 
 namespace bsg_test_dram_channel {
     using parameter_t = unsigned long long;
@@ -10,13 +11,16 @@ namespace bsg_test_dram_channel {
     public:
         Memory(parameter_t channel_addr_width_p,
                parameter_t data_width_p,
-               parameter_t mem_els_p):
+               parameter_t mem_els_p,
+	       parameter_t init_mem_p):
             _channel_addr_width_p(channel_addr_width_p),
             _data_width_p(data_width_p),
             _mem_els_p(mem_els_p) {
 
             parameter_t bytes = (data_width_p/8) * mem_els_p;
             _data.resize(bytes);
+	    if (init_mem_p != 0)
+	      std::memset(&_data[0], 0, _data.size());
         }
 
         byte_t get(address_t addr) const {

--- a/testing/bsg_test/bsg_nonsynth_dramsim3/sv.include
+++ b/testing/bsg_test/bsg_nonsynth_dramsim3/sv.include
@@ -11,6 +11,7 @@ $BASEJUMP_STL_DIR/bsg_test/bsg_nonsynth_dramsim3_map.v
 $BASEJUMP_STL_DIR/bsg_test/bsg_nonsynth_dramsim3_unmap.v
 $BASEJUMP_STL_DIR/bsg_test/bsg_nonsynth_test_dram_channel.v
 $BASEJUMP_STL_DIR/bsg_test/bsg_dramsim3.cpp
+$BASEJUMP_STL_DIR/bsg_test/bsg_test_dram_channel.cpp
 
 
 $BASEJUMP_STL_DIR/imports/DRAMSim3/src/bankstate.cc


### PR DESCRIPTION
* exposes data store - can be used in C++ cosimulation for fast IO.