### PR TITLE
BSG_HASH_BANK_UP / DOWN

### DIFF
--- a/bsg_misc/bsg_defines.v
+++ b/bsg_misc/bsg_defines.v
@@ -4,8 +4,8 @@
 `define BSG_MAX(x,y) (((x)>(y)) ? (x) : (y))
 `define BSG_MIN(x,y) (((x)<(y)) ? (x) : (y))
 
-// maps 1 --> 1 instead of to 0
-`define BSG_SAFE_CLOG2(x) ( ((x)==1) ? 1 : $clog2((x)))
+// maps 0, 1 --> 1 instead of to 0
+`define BSG_SAFE_CLOG2(x) ( ((x)<2) ? 1 : $clog2((x)))
 `define BSG_IS_POW2(x) ( (1 << $clog2(x)) == (x))
 `define BSG_WIDTH(x) ($clog2(x+1))
 

--- a/bsg_misc/bsg_defines.v
+++ b/bsg_misc/bsg_defines.v
@@ -4,8 +4,8 @@
 `define BSG_MAX(x,y) (((x)>(y)) ? (x) : (y))
 `define BSG_MIN(x,y) (((x)<(y)) ? (x) : (y))
 
-// maps 0, 1 --> 1 instead of to 0
-`define BSG_SAFE_CLOG2(x) ( ((x)<2) ? 1 : $clog2((x)))
+// maps 1 --> 1 instead of to 0
+`define BSG_SAFE_CLOG2(x) ( ((x)==1) ? 1 : $clog2((x)))
 `define BSG_IS_POW2(x) ( (1 << $clog2(x)) == (x))
 `define BSG_WIDTH(x) ($clog2(x+1))
 
@@ -27,6 +27,16 @@
 `endif
 
 `define BSG_STRINGIFY(x) `"x`"
+
+// Slices an address from the start bit down, distributing among els elements
+// If there are 1 or fewer elements in the slice, return 0
+`define BSG_SAFE_HASH_BANK_DOWN(sig,start,els) \
+  (els > 1) ? sig[start-:`BSG_SAFE_CLOG2(`BSG_MAX(els,2))] : '0
+
+// Slices an address from the start bit up, distributing among els elements
+// If there are 1 or fewer elements in the slice, return 0
+`define BSG_SAFE_HASH_BANK_UP(sig,start,els) \
+  (els > 1) ? sig[start+:`BSG_SAFE_CLOG2(`BSG_MAX(els,2))] : '0
 
 // using C-style shifts instead of a[i] allows the parameter of BSG_GET_BIT to be a parameter subrange                                                                                                                                                                               
 // e.g., parameter[4:1][1], which DC 2016.12 does not allow                                                                                                                                                                                                                          


### PR DESCRIPTION
Making `BSG_SAFE_CLOG2(0) == 1

Example code:
```
    // Slice logx when x is greater than 1, else just do 0
    foo = (x > 1)
               ? bar[y-:`BSG_SAFE_CLOG2(x)]
               : '0;
```
If x is 0 here, then foo = '0.  However, bar[y-:`BSG_SAFE_CLOG2(x)] will still get elaborated and cause a compilation issue, even though it will be optimized away.

I don't think this change could break anything, because the old code will just error directly on `BSG_SAFE_CLOG2(0)