### PR TITLE
Adding BSG_CAST_I and BSG_CAST_O

### DIFF
--- a/bsg_misc/bsg_defines.v
+++ b/bsg_misc/bsg_defines.v
@@ -28,8 +28,8 @@
 
 `define BSG_STRINGIFY(x) `"x`"
 
-`define BSG_CAST_I(struct,x) struct ``x``_cast_i; assign ``x``_cast_i = ``x``_i;
-`define BSG_CAST_O(struct,x) struct ``x``_cast_o; assign ``x``_o = ``x``_cast_o;
+`define BSG_CAST_I(struct,x,x_cast) struct x_cast; assign x_cast = x;
+`define BSG_CAST_O(struct,x,x_cast) struct x_cast; assign x = x_cast;
 
 // using C-style shifts instead of a[i] allows the parameter of BSG_GET_BIT to be a parameter subrange                                                                                                                                                                               
 // e.g., parameter[4:1][1], which DC 2016.12 does not allow                                                                                                                                                                                                                          

--- a/bsg_misc/bsg_defines.v
+++ b/bsg_misc/bsg_defines.v
@@ -28,6 +28,9 @@
 
 `define BSG_STRINGIFY(x) `"x`"
 
+`define BSG_CAST_I(struct,x) struct ``x``_cast_i; assign ``x``_cast_i = ``x``_i;
+`define BSG_CAST_O(struct,x) struct ``x``_cast_o; assign ``x``_o = ``x``_cast_o;
+
 // using C-style shifts instead of a[i] allows the parameter of BSG_GET_BIT to be a parameter subrange                                                                                                                                                                               
 // e.g., parameter[4:1][1], which DC 2016.12 does not allow                                                                                                                                                                                                                          
 


### PR DESCRIPTION
I've been using an analogue of these in BlackParrot.  It has a few advantages:
1) Less verbose than the two line variant
2) Enforces x_cast_i / x_cast_o coding style (which we could depend on for meta-macros)
3) It is more explicit than assignment statements, which are often forgotten.

Could also add a suffix parameter, but then we lose out on some of the code reduction.