### PR TITLE
Dramsim3 address mapping

### DIFF
--- a/bsg_test/bsg_dramsim3_pkg.v
+++ b/bsg_test/bsg_dramsim3_pkg.v
@@ -52,6 +52,25 @@ endpackage // bsg_dramsim3_hbm2_8gb_x128_pkg
    - `dramsim3_co_width(num_columns_mp)   \
    - `dramsim3_byte_offset_width(data_width_mp))
 
+`define dramsim3_ro_width_pkg(dram_pkg) \
+  `dramsim3_ro_width(dram_pkg::channel_addr_width_p, \
+                    dram_pkg::data_width_p, \
+                    dram_pkg::num_ba_p, \
+                    dram_pkg::num_bg_p, \
+                    dram_pkg::num_columns_p)
+
+`define dramsim3_ba_width_pkg(dram_pkg) \
+  `dramsim3_ba_width(dram_pkg::num_ba_p)
+
+`define dramsim3_bg_width_pkg(dram_pkg) \
+  `dramsim3_bg_width(dram_pkg::num_bg_p)
+
+`define dramsim3_co_width_pkg(dram_pkg) \
+  `dramsim3_co_width(dram_pkg::num_columns_p)
+
+`define dramsim3_byte_offset_width_pkg(dram_pkg) \
+  `dramsim3_byte_offset_width(dram_pkg::data_width_p)
+
 `define declare_dramsim3_ch_addr_s(typename_mp, ch_addr_width_mp, data_width_mp, num_ba_mp, num_bg_mp, num_columns_mp) \
   typedef struct packed { \
     logic [`dramsim3_ro_width(ch_addr_width_mp, data_width_mp, num_ba_mp, num_bg_mp, num_columns_mp)-1:0] ro; \

--- a/bsg_test/bsg_dramsim3_pkg.v
+++ b/bsg_test/bsg_dramsim3_pkg.v
@@ -18,6 +18,8 @@ package bsg_dramsim3_hbm2_8gb_x128_pkg;
   parameter int data_width_p=256;
   parameter int num_channels_p=8;
   parameter int num_columns_p=64;
+  parameter int num_ba_p=4;
+  parameter int num_bg_p=4;
   parameter longint size_in_bits_p=2**36; // 8GB (64Gb)
   parameter string config_p="HBM2_8Gb_x128.ini";
   parameter address_mapping_p=bsg_dramsim3_pkg::e_ro_ra_bg_ba_ch_co;
@@ -30,8 +32,39 @@ package bsg_dramsim3_hbm2_4gb_x128_pkg;
   parameter int data_width_p=256;
   parameter int num_channels_p=8;
   parameter int num_columns_p=64;
+  parameter int num_ba_p=4;
+  parameter int num_bg_p=4;
   parameter longint size_in_bits_p=2**35; // 4GB (32Gb)
   parameter string config_p="HBM2_4Gb_x128.ini";
   parameter address_mapping_p=bsg_dramsim3_pkg::e_ro_ra_bg_ba_ch_co;
-
 endpackage // bsg_dramsim3_hbm2_8gb_x128_pkg
+
+`define dramsim3_ba_width(num_ba_mp) $clog2(num_ba_mp)
+`define dramsim3_bg_width(num_bg_mp) $clog2(num_bg_mp)
+`define dramsim3_co_width(num_columns_mp) $clog2(num_columns_mp)
+`define dramsim3_byte_offset_width(data_width_mp) \
+  $clog2(data_width_mp>>3)
+
+`define dramsim3_ro_width(ch_addr_width_mp, data_width_mp, num_ba_mp, num_bg_mp, num_columns_mp) \
+  (ch_addr_width_mp   \
+   - `dramsim3_ba_width(num_ba_mp)   \
+   - `dramsim3_bg_width(num_bg_mp)   \
+   - `dramsim3_co_width(num_columns_mp)   \
+   - `dramsim3_byte_offset_width(data_width_mp))
+
+`define declare_dramsim3_ch_addr_s(typename_mp, ch_addr_width_mp, data_width_mp, num_ba_mp, num_bg_mp, num_columns_mp) \
+  typedef struct packed { \
+    logic [`dramsim3_ro_width(ch_addr_width_mp, data_width_mp, num_ba_mp, num_bg_mp, num_columns_mp)-1:0] ro; \
+    logic [`dramsim3_bg_width(num_bg_mp)-1:0] bg; \
+    logic [`dramsim3_ba_width(num_ba_mp)-1:0] ba; \
+    logic [`dramsim3_co_width(num_columns_mp)-1:0] co; \
+    logic [`dramsim3_byte_offset_width(data_width_mp)-1:0] byte_offset; \
+  } typename_mp
+
+`define declare_dramsim3_ch_addr_s_with_pkg(typename_mp, dram_pkg) \
+  `declare_dramsim3_ch_addr_s(typename_mp, \
+                              dram_pkg::channel_addr_width_p, \
+                              dram_pkg::data_width_p, \
+                              dram_pkg::num_ba_p, \
+                              dram_pkg::num_bg_p, \
+                              dram_pkg::num_columns_p)

--- a/testing/bsg_test/bsg_nonsynth_dramsim3/Makefile
+++ b/testing/bsg_test/bsg_nonsynth_dramsim3/Makefile
@@ -23,16 +23,16 @@ VSOURCES += $(BASEJUMP_STL_DIR)/bsg_test/bsg_nonsynth_clock_gen.v
 VSOURCES += $(BASEJUMP_STL_DIR)/bsg_test/bsg_nonsynth_reset_gen.v
 VSOURCES += $(BASEJUMP_STL_DIR)/bsg_test/bsg_nonsynth_test_rom.v
 VSOURCES += $(BASEJUMP_STL_DIR)/bsg_fsb/bsg_fsb_node_trace_replay.v
-
 VSOURCES += $(BASEJUMP_STL_DIR)/bsg_test/bsg_dramsim3_pkg.v
 VSOURCES += $(BASEJUMP_STL_DIR)/bsg_test/bsg_nonsynth_dramsim3.v
 VSOURCES += $(BASEJUMP_STL_DIR)/bsg_test/bsg_nonsynth_dramsim3_map.v
 VSOURCES += $(BASEJUMP_STL_DIR)/bsg_test/bsg_nonsynth_dramsim3_unmap.v
-VSOURCES += $(BASEJUMP_STL_DIR)/bsg_test/bsg_nonsynth_test_dram_channel.v
+VSOURCES += $(BASEJUMP_STL_DIR)/bsg_mem/bsg_nonsynth_mem_1r1w_sync_mask_write_byte_dma.v
+VSOURCES += $(BASEJUMP_STL_DIR)/bsg_mem/bsg_nonsynth_mem_1r1w_sync_dma.v
 VSOURCES += testbench.v
 
 VSOURCES += $(BASEJUMP_STL_DIR)/bsg_test/bsg_dramsim3.cpp
-VSOURCES += $(BASEJUMP_STL_DIR)/bsg_test/bsg_test_dram_channel.cpp
+VSOURCES += $(BASEJUMP_STL_DIR)/bsg_mem/bsg_mem_dma.cpp
 
 VSOURCES += $(BASEJUMP_STL_DIR)/imports/DRAMSim3/src/bankstate.cc
 VSOURCES += $(BASEJUMP_STL_DIR)/imports/DRAMSim3/src/channel_state.cc

--- a/testing/bsg_test/bsg_nonsynth_dramsim3/Makefile
+++ b/testing/bsg_test/bsg_nonsynth_dramsim3/Makefile
@@ -17,19 +17,49 @@ CFLAGS += -CFLAGS "-DBASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR)"
 
 DRAMS := hbm2_8gb_x128 hbm2_4gb_x128
 
+VSOURCES += $(BASEJUMP_STL_DIR)/bsg_misc/bsg_defines.v
+VSOURCES += $(BASEJUMP_STL_DIR)/bsg_misc/bsg_reduce.v
+VSOURCES += $(BASEJUMP_STL_DIR)/bsg_test/bsg_nonsynth_clock_gen.v
+VSOURCES += $(BASEJUMP_STL_DIR)/bsg_test/bsg_nonsynth_reset_gen.v
+VSOURCES += $(BASEJUMP_STL_DIR)/bsg_test/bsg_nonsynth_test_rom.v
+VSOURCES += $(BASEJUMP_STL_DIR)/bsg_fsb/bsg_fsb_node_trace_replay.v
+
+VSOURCES += $(BASEJUMP_STL_DIR)/bsg_test/bsg_dramsim3_pkg.v
+VSOURCES += $(BASEJUMP_STL_DIR)/bsg_test/bsg_nonsynth_dramsim3.v
+VSOURCES += $(BASEJUMP_STL_DIR)/bsg_test/bsg_nonsynth_dramsim3_map.v
+VSOURCES += $(BASEJUMP_STL_DIR)/bsg_test/bsg_nonsynth_dramsim3_unmap.v
+VSOURCES += $(BASEJUMP_STL_DIR)/bsg_test/bsg_nonsynth_test_dram_channel.v
+VSOURCES += testbench.v
+
+VSOURCES += $(BASEJUMP_STL_DIR)/bsg_test/bsg_dramsim3.cpp
+VSOURCES += $(BASEJUMP_STL_DIR)/bsg_test/bsg_test_dram_channel.cpp
+
+VSOURCES += $(BASEJUMP_STL_DIR)/imports/DRAMSim3/src/bankstate.cc
+VSOURCES += $(BASEJUMP_STL_DIR)/imports/DRAMSim3/src/channel_state.cc
+VSOURCES += $(BASEJUMP_STL_DIR)/imports/DRAMSim3/src/command_queue.cc
+VSOURCES += $(BASEJUMP_STL_DIR)/imports/DRAMSim3/src/common.cc
+VSOURCES += $(BASEJUMP_STL_DIR)/imports/DRAMSim3/src/configuration.cc
+VSOURCES += $(BASEJUMP_STL_DIR)/imports/DRAMSim3/src/controller.cc
+VSOURCES += $(BASEJUMP_STL_DIR)/imports/DRAMSim3/src/dram_system.cc
+VSOURCES += $(BASEJUMP_STL_DIR)/imports/DRAMSim3/src/hmc.cc
+VSOURCES += $(BASEJUMP_STL_DIR)/imports/DRAMSim3/src/memory_system.cc
+VSOURCES += $(BASEJUMP_STL_DIR)/imports/DRAMSim3/src/refresh.cc
+VSOURCES += $(BASEJUMP_STL_DIR)/imports/DRAMSim3/src/simple_stats.cc
+VSOURCES += $(BASEJUMP_STL_DIR)/imports/DRAMSim3/src/timing.cc
+
 all: $(DRAMS)
 
 $(DRAMS): %: %.tr
-$(DRAMS):
+$(DRAMS): $(VSOURCES)
 	vcs -R +v2k +lint=all,noSVA-UA,noSVA-NSVU,noVCDE \
 		-cpp g++ $(CFLAGS) \
 		$(INCDIR) \
 		+define+dram_pkg=bsg_dramsim3_$@_pkg \
 		+define+trace_file=$@.trace \
 		+define+rom_file=$@.tr \
-		-sverilog -full64 -f sv.include -timescale=1ps/1ps +vcs+vcdpluson -l vcs.log
+		-sverilog -full64  -timescale=1ps/1ps +vcs+vcdpluson -l vcs.log $(VSOURCES)
 
-$(foreach dram, $(DRAMS), $(dram).tr):
+$(foreach dram, $(DRAMS), $(dram).tr): hbm_trace_gen.py
 	python hbm_trace_gen.py $(@:.tr=) > $@
 
 dve:

--- a/testing/bsg_test/bsg_nonsynth_dramsim3/testbench.v
+++ b/testing/bsg_test/bsg_nonsynth_dramsim3/testbench.v
@@ -26,7 +26,8 @@ module testbench ();
   
   // dramsim3
   import `dram_pkg::*;
-
+  `declare_dramsim3_ch_addr_s_with_pkg(dram_ch_addr_s, `dram_pkg);
+  
   logic [num_channels_p-1:0]                            dramsim3_v_li;
   logic [num_channels_p-1:0]                            dramsim3_write_not_read_li;
   logic [num_channels_p-1:0] [channel_addr_width_p-1:0] dramsim3_ch_addr_li;
@@ -38,7 +39,10 @@ module testbench ();
 
   logic [num_channels_p-1:0]                            dramsim3_data_v_lo;
   logic [num_channels_p-1:0] [data_width_p-1:0]         dramsim3_data_lo;
-      
+
+  dram_ch_addr_s dramsim3_ch_addr_li_cast;
+  assign dramsim3_ch_addr_li_cast = dramsim3_ch_addr_li[0];
+  
   bsg_nonsynth_dramsim3
     #(.channel_addr_width_p(`dram_pkg::channel_addr_width_p)
       ,.data_width_p(`dram_pkg::data_width_p)
@@ -146,5 +150,25 @@ module testbench ();
     # 10000000 $finish;
   end
   
+  always_ff @(posedge clk) begin
+    if (~reset & dramsim3_v_li[0]) begin
+      if (dramsim3_write_not_read_li[0])
+        $display("write: 0x%08x {ro: %d, ba: %d, bg: %d, co: %d, byte: %d}",
+                 dramsim3_ch_addr_li[0], 
+                 dramsim3_ch_addr_li_cast.ro,
+                 dramsim3_ch_addr_li_cast.ba,
+                 dramsim3_ch_addr_li_cast.bg,
+                 dramsim3_ch_addr_li_cast.co,
+                 dramsim3_ch_addr_li_cast.byte_offset);
+      else
+        $display("read: 0x%08x {ro: %d, ba: %d, bg: %d, co: %d, byte: %d}",
+                 dramsim3_ch_addr_li[0], 
+                 dramsim3_ch_addr_li_cast.ro,
+                 dramsim3_ch_addr_li_cast.ba,
+                 dramsim3_ch_addr_li_cast.bg,
+                 dramsim3_ch_addr_li_cast.co,
+                 dramsim3_ch_addr_li_cast.byte_offset);
+    end    
+  end
   
 endmodule


### PR DESCRIPTION
adds helper structures for DRAM hierarchy address mapping.