### PR TITLE
Redirecting to public version of dramsim3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,5 +3,4 @@
 	url = https://github.com/bespoke-silicon-group/ramulator
 [submodule "DRAMSim3"]
 	path = imports/DRAMSim3
-	url = git@github.com:bespoke-silicon-group/bsg_dramsim3
-        update = none
+	url = https://github.com/umd-memsys/DRAMsim3

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/bespoke-silicon-group/ramulator
 [submodule "DRAMSim3"]
 	path = imports/DRAMSim3
-	url = https://github.com/umd-memsys/DRAMsim3
+	url = https://github.com/bsg-external/DRAMsim3


### PR DESCRIPTION
Minor thing: The remote repo is called "DRAMsim3" not "DRAMSim3".  We should probably update paths to avoid any weird issues in the future.