### PR TITLE
DPI ROM

### DIFF
--- a/bsg_test/bsg_nonsynth_dpi_rom.hpp
+++ b/bsg_test/bsg_nonsynth_dpi_rom.hpp
@@ -1,0 +1,63 @@
+#ifndef __BSG_NONSYNTH_DPI_ROM_HPP
+#define __BSG_NONSYNTH_DPI_ROM_HPP
+#include <svdpi.h>
+#include <verilated.h>
+#include <bsg_nonsynth_dpi.hpp>
+
+extern "C" {
+        // DPI Export function: Get the value at an index in the
+        // rom. Calls $fatal if an invalid index is accessed.
+        extern svBitVecVal bsg_dpi_rom_get(int);
+}
+
+namespace bsg_nonsynth_dpi{
+
+        // dpi_rom is the C++ wrapper class for the
+        // bsg_nonsynth_dpi_rom verilog module.
+        // 
+        // Template Parameters:
+        // 
+        //   typename T: The C-type that this rom contains. While
+        //     verilog may represent arbitrary bit-widths, C cannot,
+        //     so this rom is restricted to C-types.
+        //
+        //   unsigned int N: Number of Elements in the ROM.
+        //
+        // Superclasses are used to check template parameters at run
+        // time against the corresponding verilog module.
+        template <typename T, unsigned int N>
+        class dpi_rom : public dpi_base, 
+                    public dpi_width<T>, 
+                    public dpi_nels<N>{
+        public:
+
+                // Constructor: Creates a dpi_rom object. 
+                // 
+                // Arguments: 
+                //   char *hierarchy: The string describing
+                //     the instantiation of this the corresponding
+                //     bsg_nonsynth_dpi_rom verilog module in the
+                //     testbench.
+                dpi_rom(const char *hierarchy)
+                        : dpi_base(hierarchy),
+                          dpi_width<T>(hierarchy),
+                          dpi_nels<N>(hierarchy)
+                {
+                }
+
+                // T operator[](unsigned int idx): Returns the value
+                // at an index in the ROM
+                // 
+                // Arguments: 
+                //   unsigned int idx: The index to read
+                T operator[](unsigned int idx){
+                        T o;
+                        prev = svSetScope(scope);
+                        auto output = bsg_dpi_rom_get(idx);
+                        svSetScope(prev);
+                        svToIntegral(&output, o);
+                        return o;
+                }
+        };
+}
+#endif

--- a/bsg_test/bsg_nonsynth_dpi_rom.v
+++ b/bsg_test/bsg_nonsynth_dpi_rom.v
@@ -1,0 +1,136 @@
+// Non-Synthesizable DPI ROM
+//
+// This module is useful for putting compile-time parameters in a
+// verilog design to be accessed by a C/C++ runtime.
+//
+// Parameters:
+//   int els_p: Number of ROM elements
+//   int width_p: bit-width of ROM elements
+//   bit [width_p-1:0] arr_p [els_p-1:0]: The array of values to load
+//     into the ROM.
+//   int debug_p: Turn on debug messages at compile time (as opposed
+//     to runtime)
+// DPI Functions:
+//   void bsg_dpi_init(): Initialize this module. Must be called after
+//     the initial block has been evaluated.
+//   void bsg_dpi_fini(): Destruct this module. Must be called before
+//     the final block has been evaluated.
+//   void bsg_dpi_debug(bit): Set or unset the debug_o output bit. If a state change occurs
+//     (0->1 or 1->0) then module will print DEBUG ENABLED / DEBUG
+//     DISABLED. No messages are printed if a state change does not
+//     occur.
+//   int bsg_dpi_nels(): returns the parameter els_p
+//   int bsg_dpi_width(): returns the parameter width_p
+//   bit [width_p-1:0] bsg_dpi_rom_get(int): Read and return the value
+//     at index idx in arr_p
+module bsg_nonsynth_dpi_rom
+   #(parameter int els_p = -1
+     ,parameter int width_p = -1
+     ,parameter bit [width_p-1:0] arr_p [els_p-1:0] = '{default:0}
+     ,parameter bit debug_p = 0
+     )
+   ();
+
+   bit             debug_b;
+
+   bit [width_p-1:0] rom_l [0:els_p-1];
+
+   if(els_p <= 0)
+     $fatal(1, "BSG ERROR (%M): els_p must be greater than 0");
+
+   if(width_p <= 0)
+     $fatal(1, "BSG ERROR (%M): width_p must be greater than 0");
+
+   // Print module parameters to the console and set the intial debug
+   // value. We use init_b to track whether the module has been
+   // initialized.
+   bit             init_b;
+   initial begin
+      debug_b = debug_p;
+      init_b = 0;
+
+      $display("BSG INFO: bsg_nonsynth_dpi_rom (initial begin)");
+      $display("BSG INFO:     Instantiation: %M");
+      $display("BSG INFO:     width_p:       %d", width_p);
+      $display("BSG INFO:     els_p:         %d", els_p);
+      $display("BSG INFO:     debug_p:       %d", debug_p);
+      for(int i = 0; i < els_p; i++)
+        $display("BSG INFO:     arr_p[%d]:     0x%x", i, arr_p[i]);
+   end
+
+   // This assert checks that fini was called before $finish
+   final begin
+      if(init_b)
+        $fatal(1, "BSG ERROR (%M): final block executed before fini() was called");
+   end
+
+   export "DPI-C" function bsg_dpi_init;
+   export "DPI-C" function bsg_dpi_fini;
+   export "DPI-C" function bsg_dpi_debug;
+   export "DPI-C" function bsg_dpi_rom_get;
+   export "DPI-C" function bsg_dpi_nels;
+   export "DPI-C" function bsg_dpi_width;
+
+   // Initialize this Manycore DPI Interface
+   function void bsg_dpi_init();
+      if(init_b)
+        $fatal(1, "BSG ERROR (%M): init() already called");
+
+      init_b = 1;
+   endfunction
+
+   // Terminate this Manycore DPI Interface
+   function void bsg_dpi_fini();
+      if(~init_b)
+        $fatal(1, "BSG ERROR (%M): fini() already called");
+
+      init_b = 0;
+   endfunction
+
+   // Set or unset the debug_o output bit. If a state change occurs
+   // (0->1 or 1->0) then module will print DEBUG ENABLED / DEBUG
+   // DISABLED. No messages are printed if a state change does not
+   // occur.
+   function void bsg_dpi_debug(input bit switch_i);
+      if(!debug_b & switch_i)
+        $display("BSG DBGINFO (%M@%t): DEBUG ENABLED", $time);
+      else if (debug_b & !switch_i)
+        $display("BSG DBGINFO (%M@%t): DEBUG DISABLED", $time);
+
+      debug_b = switch_i;
+   endfunction
+
+   // Return the parameter els_p
+   function int bsg_dpi_nels();
+      return els_p;
+   endfunction
+
+   // Return the parameter width_p
+   function int bsg_dpi_width();
+      return width_p;
+   endfunction
+
+   // Initialize every index in the rom array variable with data from
+   // arr_p
+   generate
+      for(genvar i = 0; i < els_p; i++) begin
+         initial
+           rom_l[i] = arr_p[i];
+      end
+   endgenerate
+
+   // Get the value at an index in the rom. This fails if an invalid
+   // index is accessed.
+   function bit [width_p-1:0] bsg_dpi_rom_get(input int idx);
+      if(~init_b)
+         $fatal(1, "BSG ERROR (%M): get() called before init()");
+
+      if(idx >= els_p | idx < 0)
+         $fatal(1, "BSG ERROR (%M): Invalid index %d", idx);
+
+      if(debug_b)
+        $display("BSG INFO (%M): Read Index %d: %x", idx, rom_l[idx]);
+
+      return rom_l[idx];
+   endfunction
+endmodule

--- a/testing/bsg_test/bsg_nonsynth_dpi_rom/Makefile
+++ b/testing/bsg_test/bsg_nonsynth_dpi_rom/Makefile
@@ -1,0 +1,44 @@
+.DEFAULT_GOAL := test_rom
+
+BASEJUMP_STL_DIR := $(abspath ../../../)
+
+#VERILATOR=/home/drichmond/Research/repositories/git/verilator/bin/verilator
+#VERILATOR_ROOT=/home/drichmond/Research/repositories/git/verilator
+VERILATOR_ROOT=/usr/share/verilator
+VERILATOR=verilator
+VSOURCES += $(BASEJUMP_STL_DIR)/testing/bsg_test/bsg_nonsynth_dpi_rom/top.v
+VSOURCES += $(BASEJUMP_STL_DIR)/bsg_test/bsg_nonsynth_dpi_rom.v
+VSOURCES += $(BASEJUMP_STL_DIR)/bsg_test/bsg_nonsynth_dpi_clock_gen.v
+VINCLUDES += -I$(BASEJUMP_STL_DIR)/bsg_misc/
+
+CFLAGS += -CFLAGS -std=c++11
+CFLAGS +=-CFLAGS -I$(BASEJUMP_STL_DIR)/bsg_test/
+CXXSOURCES += main.cpp
+
+INCLUDES += -I$(VERILATOR_ROOT)/include
+INCLUDES += -I$(VERILATOR_ROOT)/include/vltstd
+INCLUDES += -I$(BASEJUMP_STL_DIR)/bsg_test/
+INCLUDES += -Iobj_dir
+
+obj_dir/Vtop.mk: $(VSOURCES) 
+	$(VERILATOR) -cc $^ -Wno-lint $(VINCLUDES) $(CFLAGS) $(CXXSOURCES) -o test_rom
+
+%__ALL.a: %.mk
+	$(MAKE) -j -C $(dir $@) -f $(notdir $<) default
+
+%.o: $(VERILATOR_ROOT)/include/%.cpp
+	g++ -MMD -I$(VERILATOR_ROOT)/include -I$(VERILATOR_ROOT)/include/vltstd -DVL_PRINTF=printf -DVM_COVERAGE=0 -DVM_SC=0 -DVM_TRACE=0 -std=c++11 -c -o $@ $^
+
+%.o: $(BASEJUMP_STL_DIR)/bsg_test/%.cpp
+	g++ -MMD -I$(VERILATOR_ROOT)/include $(INCLUDES) -DVL_PRINTF=printf -DVM_COVERAGE=0 -DVM_SC=0 -DVM_TRACE=0 -std=c++11 -c -o $@ $<
+
+main.o: main.cpp obj_dir/Vtop__ALL.a
+	g++ -MMD -I$(VERILATOR_ROOT)/include $(INCLUDES) -DVL_PRINTF=printf -DVM_COVERAGE=0 -DVM_SC=0 -DVM_TRACE=0 -std=c++11 -c -o $@ $<
+
+test_rom: verilated.o verilated_dpi.o main.o obj_dir/Vtop__ALL.a bsg_nonsynth_dpi_clock_gen.o 
+	g++ -std=c++11 $^ -o $@
+
+clean:
+	rm -rf obj_dir test_rom *.o *.d
+
+.PRECIOUS: obj_dir/Vtop.mk

--- a/testing/bsg_test/bsg_nonsynth_dpi_rom/main.cpp
+++ b/testing/bsg_test/bsg_nonsynth_dpi_rom/main.cpp
@@ -1,0 +1,41 @@
+#include <Vtop.h>
+
+#include <bsg_nonsynth_dpi_rom.hpp>
+using namespace bsg_nonsynth_dpi;
+
+#include <cstdio>
+#include <queue>
+
+// Verilator / DPI Headers
+#include <svdpi.h>
+#include <verilated.h>
+
+int main(int argc, char** argv) {
+        Verilated::commandArgs(argc, argv);
+
+        // Instantiation of the top-level testbench module
+        Vtop *top = new Vtop;
+
+        // Uncomment internalsDump to debug the module hierarchy. This
+        // is useful when you're trying to figure out the names of the
+        // DPI functions you are trying to call.
+        // Verilated::internalsDump();
+
+        // Run the intial blocks with eval(). This must happen before
+        // the fifo interfaces are constructed. It will also cause the
+        // clock generators to register themselves.
+        top->eval();
+
+        dpi_rom<unsigned int, 4> *config = new dpi_rom<unsigned int, 4>("TOP.top.rom");
+        for(int i =0 ; i < 4; ++i){
+                printf("BSG INFO: Index: %d, Value: %x\n", i, (*config)[i]);
+                if(i != (*config)[i]){
+                        fprintf(stderr, "BSG ERROR: Incorrect value at index %d, expected %d\n", i, i);
+                }
+        }
+
+        delete config;
+        // Then, trigger the final blocks in Verilog
+        top->final();
+        return 0;
+}

--- a/testing/bsg_test/bsg_nonsynth_dpi_rom/top.v
+++ b/testing/bsg_test/bsg_nonsynth_dpi_rom/top.v
@@ -1,0 +1,24 @@
+module top();
+   localparam width_lp = 32;
+   localparam els_lp = 4;
+   localparam bit [width_lp-1:0] arr_lp [els_lp-1:0] = '{3, 2, 1, 0};
+
+   // TODO: Read from somewhere
+   parameter lc_cycle_time_p = 1000000;
+
+   bsg_nonsynth_dpi_clock_gen
+     #(.cycle_time_p(lc_cycle_time_p)
+       )
+   core_clk_gen
+     (.o(core_clk));
+
+   bsg_nonsynth_dpi_rom
+     #(.els_p(els_lp)
+       ,.width_p(width_lp)
+       ,.arr_p(arr_lp))
+   rom
+     ();
+
+   
+endmodule
+


### PR DESCRIPTION
Reading from the BSG Rom is tedious in Verilator -- it requires setting inputs and calling eval(), or putting it on a bus and then waiting multiple clock cycles. 

I took a shortcut. I created a DPI module that acts like a ROM, and can be instantiated in Verilog, but doesn't require any eval() ing.

It's silly, but useful. 

