### PR TITLE
Update BSG Link Comments

### DIFF
--- a/bsg_link/bsg_link_ddr_downstream.v
+++ b/bsg_link/bsg_link_ddr_downstream.v
@@ -3,7 +3,10 @@
 //
 // This is the receiver part of bsg_link_ddr, a complete DDR communication 
 // endpoint over multiple source-synchronous channels.
-// ALWAYS use in pair with bsg_link_ddr_upstream
+//
+// * This module MUST be mirrored with bsg_link_ddr_upstream, which is
+//   instantiated on the source chip or FPGA. It is not a must to
+//   use upstream and downstream in pair on same chip or FPGA.
 // 
 // The purpose of bsg_link_ddr_downstream is to receive DDR data bits from 
 // physical IO pins, then reassemble to ready-valid interface in core clock domain.

--- a/bsg_link/bsg_link_ddr_upstream.v
+++ b/bsg_link/bsg_link_ddr_upstream.v
@@ -3,7 +3,10 @@
 //
 // This is the sender part of bsg_link_ddr, a complete DDR communication 
 // endpoint over multiple source-synchronous channels.
-// ALWAYS use in pair with bsg_link_ddr_downstream
+//
+// * This module MUST be mirrored with bsg_link_ddr_downstream, which is
+//   instantiated on the destination chip or FPGA. It is not a must to
+//   use upstream and downstream in pair on same chip or FPGA.
 // 
 // The purpose of bsg_link_ddr_upstream is to receive data packets from ready-valid
 // interface in core clock domain, serialize them to fit in IO channels (optional),


### PR DESCRIPTION
Clarify that bsg_link_upstream and bsg_link_downstream need to be mirrored on source chip and destination chip. It is not a must to "pair" upstream and downstream on same chip.