### PR TITLE
Fixing critical path in bsg_encode_one_hot

### DIFF
--- a/bsg_misc/bsg_arb_fixed.v
+++ b/bsg_misc/bsg_arb_fixed.v
@@ -17,6 +17,7 @@ module bsg_arb_fixed #(parameter     inputs_p = "inv"
                                      ) enc
      (.i ( reqs_i            )
       ,.o( grants_unmasked_lo)
+      ,.v_o(                 )
       );
 
    // mask with ready bits

--- a/bsg_misc/bsg_id_pool.v
+++ b/bsg_misc/bsg_id_pool.v
@@ -50,6 +50,7 @@ module bsg_id_pool
   ) pe0 (
     .i(~allocated_r | dealloc_decode)
     ,.o(one_hot_out)
+    ,.v_o()
   );
 
   bsg_encode_one_hot #(

--- a/bsg_misc/bsg_id_pool.v
+++ b/bsg_misc/bsg_id_pool.v
@@ -44,13 +44,15 @@ module bsg_id_pool
   logic alloc_v_lo;
   logic [els_p-1:0] one_hot_out;
 
+   // We use this v_o instead of the v_o of bsg_encode_one_hot
+   //   because it has better critical path
   bsg_priority_encode_one_hot_out #(
     .width_p(els_p)
     ,.lo_to_hi_p(1)
   ) pe0 (
     .i(~allocated_r | dealloc_decode)
     ,.o(one_hot_out)
-    ,.v_o()
+    ,.v_o(alloc_v_lo)
   );
 
   bsg_encode_one_hot #(
@@ -59,7 +61,7 @@ module bsg_id_pool
   ) enc0 (
     .i(one_hot_out)
     ,.addr_o(alloc_id_lo)
-    ,.v_o(alloc_v_lo)
+    ,.v_o()
   );
 
   assign alloc_id_o = alloc_id_lo;

--- a/bsg_misc/bsg_priority_encode.v
+++ b/bsg_misc/bsg_priority_encode.v
@@ -24,11 +24,14 @@ module bsg_priority_encode #(parameter   width_p    = "inv"
 
    logic [width_p-1:0] enc_lo;
 
+   // We use this v_o instead of the v_o of bsg_encode_one_hot
+   //   because it has better critical path
    bsg_priority_encode_one_hot_out #(.width_p(width_p)
                                      ,.lo_to_hi_p(lo_to_hi_p)
                                      ) a
      (.i(i)
       ,.o(enc_lo)
+      ,.v_o(v_o)
       );
 
    bsg_encode_one_hot #(.width_p(width_p)
@@ -36,7 +39,7 @@ module bsg_priority_encode #(parameter   width_p    = "inv"
                         ) b
      (.i      (enc_lo)
       ,.addr_o(addr_o)
-      ,.v_o   (v_o)
+      ,.v_o   ()
       );
 
 endmodule

--- a/bsg_misc/bsg_priority_encode_one_hot_out.v
+++ b/bsg_misc/bsg_priority_encode_one_hot_out.v
@@ -13,6 +13,7 @@ module bsg_priority_encode_one_hot_out #(parameter width_p      = "inv"
 
    (input    [width_p-1:0] i
     , output [width_p-1:0] o
+    , output               v_o
     );
 
    logic [width_p-1:0] scan_lo;
@@ -21,17 +22,23 @@ module bsg_priority_encode_one_hot_out #(parameter width_p      = "inv"
      assign o = i;
    else
      begin
-	bsg_scan #(.width_p(width_p)
-		   ,.or_p      (1)
-		   ,.lo_to_hi_p(lo_to_hi_p)
-		   ) scan (.i (i)
-			   ,.o(scan_lo)
-			   );
+       bsg_scan #(.width_p(width_p)
+                  ,.or_p      (1)
+                  ,.lo_to_hi_p(lo_to_hi_p)
+                  ) scan (.i (i)
+                          ,.o(scan_lo)
+                          );
 
-	// edge detect
-	if (lo_to_hi_p)
-	  assign o = scan_lo & { (~scan_lo[width_p-2:0]), 1'b1 };
-	else
-	  assign o = scan_lo & { 1'b1, (~scan_lo[width_p-1:1]) };
+       // edge detect
+       if (lo_to_hi_p)
+         begin : fi1
+           assign o = scan_lo & { (~scan_lo[width_p-2:0]), 1'b1 };
+           assign v_o = scan_lo[width_p-1];
+         end
+       else
+         begin : fi1
+           assign o = scan_lo & { 1'b1, (~scan_lo[width_p-1:1]) };
+           assign v_o = scan_lo[0];
+         end
      end
 endmodule


### PR DESCRIPTION
The recursive nature of bsg_encode_one_hot leads to huge delays on the v_o signal for this module.  For a 16-entry priority encoder, I've seen 10-15 FO4 on the v_o port. I've squashed this path in the past by ignoring the v_o port and doing an OR on the bits outside of the module, but it makes sense for this fix to live inside the module.

My theory as to why the QoR is so bad is due to a lack of flattening.  Otherwise, I would think an OR reduce should synthesize fine, recursive or not