### PR TITLE
Added ifndef/ifdef for Verilator unsupported construct around an assert

### DIFF
--- a/bsg_async/bsg_launch_sync_sync.v
+++ b/bsg_async/bsg_launch_sync_sync.v
@@ -236,13 +236,16 @@ module bsg_launch_sync_sync #(parameter width_p="inv"
         $display("%m: instantiating blss of size %d",width_p);
      end
  */
+`ifndef VERILATOR
+   // The comparison to z makes verilator think that iclk_reset_i is a
+   // tri-state top-level (unsupported in Verilator v4.036)
    initial assert (iclk_reset_i !== 'z)
      else
        begin
           $error("%m iclk_reset should be connected");
           $finish();
        end
-
+`endif
 // synopsys translate_on
 
    genvar i;


### PR DESCRIPTION
This adds an ifndef/endif around an unsupported construct that ONLY affects an assertion. 

Verilator casts an input port into an in/out when it is compared with z (even though it is just an assertion). @dpetrisko thinks this might actually be IEEE compliant and not a bug in verilator. 

Nonetheless, z isn't supported in Verilator. I've added these ifdefs to allow the use of `--assert` in bsg_replicant, which addresses the issues in #324 