### PR TITLE
Added new address mapping to DRAMSim3

### DIFF
--- a/bsg_test/bsg_dramsim3.cpp
+++ b/bsg_test/bsg_dramsim3.cpp
@@ -147,6 +147,7 @@ extern "C" bool bsg_dramsim3_init(
     int num_channels_p,
     int data_width_p,
     long long size_in_bits_p,
+    int num_columns_p,
     char *config_p)
 {
     string config_dir = stringify(BASEJUMP_STL_DIR) "/imports/DRAMSim3/configs/";
@@ -211,17 +212,22 @@ extern "C" bool bsg_dramsim3_init(
                num_channels_p, cfg->channels, config_p);
         bsg_dramsim3_exit();
         exit(1);
-    } else if (cfg->BL * cfg->device_width != data_width_p) {
-        pr_err("data_width_p (%d) does not match product of burst length (%d) and device width (%d) found in %s\n",
-               data_width_p, cfg->BL, cfg->device_width, config_p);
+    } else if (cfg->BL * cfg->bus_width != data_width_p) {
+        pr_err("data_width_p (%d) does not match product of burst length (%d) and bus width (%d) found in %s\n",
+               data_width_p, cfg->BL, cfg->bus_width, config_p);
         bsg_dramsim3_exit();
         exit(1);
     } else if (memory_size != size_in_bits_p) {
         pr_err("size_in_bits_p (%lld) does not match device size (%lld) found in %s\n",
                size_in_bits_p, memory_size, config_p);
+        bsg_dramsim3_exit();
+        exit(1);
+    } else if (cfg->columns / cfg->BL != num_columns_p) {
+       pr_err("num_columns_p (%d) does not match columns (%d) and burst length (%d) found in %s\n",
+               num_columns_p, cfg->columns, cfg->BL, config_p);
+        bsg_dramsim3_exit();
         exit(1);
     }
-    
     return true;
 }
 

--- a/bsg_test/bsg_dramsim3_pkg.v
+++ b/bsg_test/bsg_dramsim3_pkg.v
@@ -26,6 +26,14 @@ package bsg_dramsim3_hbm2_8gb_x128_pkg;
   parameter string config_p="HBM2_8Gb_x128.ini";
   parameter address_mapping_p=bsg_dramsim3_pkg::e_ro_ra_bg_ba_ch_co;
 
+  typedef struct packed {
+    logic [$clog2(num_rows_p)-1:0] ro;
+    logic [$clog2(num_bg_p)-1:0] bg;
+    logic [$clog2(num_ba_p)-1:0] ba;
+    logic [$clog2(num_columns_p)-1:0] co;
+    logic [$clog2(data_width_p>>3)-1:0] byte_offset;
+  } dram_ch_addr_s;
+
 endpackage // bsg_dramsim3_hbm2_8gb_x128_pkg
 
 package bsg_dramsim3_hbm2_4gb_x128_pkg;
@@ -41,6 +49,15 @@ package bsg_dramsim3_hbm2_4gb_x128_pkg;
   parameter longint size_in_bits_p=2**35; // 4GB (32Gb)
   parameter string config_p="HBM2_4Gb_x128.ini";
   parameter address_mapping_p=bsg_dramsim3_pkg::e_ro_ra_bg_ba_ch_co;
+
+  typedef struct packed {
+    logic [$clog2(num_rows_p)-1:0] ro;
+    logic [$clog2(num_bg_p)-1:0] bg;
+    logic [$clog2(num_ba_p)-1:0] ba;
+    logic [$clog2(num_columns_p)-1:0] co;
+    logic [$clog2(data_width_p>>3)-1:0] byte_offset;
+  } dram_ch_addr_s;
+
 endpackage // bsg_dramsim3_hbm2_8gb_x128_pkg
 
 package bsg_dramsim3_lpddr3_8gb_x32_1600_pkg;
@@ -56,6 +73,14 @@ package bsg_dramsim3_lpddr3_8gb_x32_1600_pkg;
   parameter longint size_in_bits_p=2**34; // 2GB (16Gb)
   parameter string config_p="LPDDR3_8Gb_x32_1600.ini";
   parameter address_mapping_p=bsg_dramsim3_pkg::e_ro_ch_ra_ba_bg_co;
+
+  typedef struct packed {
+    logic [$clog2(num_rows_p)-1:0] ro;
+    logic [$clog2(num_ba_p)-1:0] ba;
+    logic [$clog2(num_columns_p)-1:0] co;
+    logic [$clog2(data_width_p>>3)-1:0] byte_offset;
+  } dram_ch_addr_s;
+
 endpackage // bsg_dramsim3_lpddr3_8gb_x32_1600_pkg
 
 `define dramsim3_ba_width(num_ba_mp) $clog2(num_ba_mp)

--- a/bsg_test/bsg_dramsim3_pkg.v
+++ b/bsg_test/bsg_dramsim3_pkg.v
@@ -18,8 +18,10 @@ package bsg_dramsim3_hbm2_8gb_x128_pkg;
   parameter int data_width_p=256;
   parameter int num_channels_p=8;
   parameter int num_columns_p=64;
+  parameter int num_rows_p=32768;
   parameter int num_ba_p=4;
   parameter int num_bg_p=4;
+  parameter int num_ranks_p=1;
   parameter longint size_in_bits_p=2**36; // 8GB (64Gb)
   parameter string config_p="HBM2_8Gb_x128.ini";
   parameter address_mapping_p=bsg_dramsim3_pkg::e_ro_ra_bg_ba_ch_co;
@@ -32,32 +34,37 @@ package bsg_dramsim3_hbm2_4gb_x128_pkg;
   parameter int data_width_p=256;
   parameter int num_channels_p=8;
   parameter int num_columns_p=64;
+  parameter int num_rows_p=16384;
   parameter int num_ba_p=4;
   parameter int num_bg_p=4;
+  parameter int num_ranks_p=1;
   parameter longint size_in_bits_p=2**35; // 4GB (32Gb)
   parameter string config_p="HBM2_4Gb_x128.ini";
   parameter address_mapping_p=bsg_dramsim3_pkg::e_ro_ra_bg_ba_ch_co;
 endpackage // bsg_dramsim3_hbm2_8gb_x128_pkg
 
+package bsg_dramsim3_lpddr3_8gb_x32_1600_pkg;
+  parameter int tck_ps = 1250;
+  parameter int channel_addr_width_p = 31;
+  parameter int data_width_p=512;
+  parameter int num_channels_p=1;
+  parameter int num_columns_p=128;
+  parameter int num_rows_p=32768;
+  parameter int num_ba_p=8;
+  parameter int num_bg_p=1;
+  parameter int num_ranks_p=1;
+  parameter longint size_in_bits_p=2**34; // 2GB (16Gb)
+  parameter string config_p="LPDDR3_8Gb_x32_1600.ini";
+  parameter address_mapping_p=bsg_dramsim3_pkg::e_ro_ch_ra_ba_bg_co;
+endpackage // bsg_dramsim3_lpddr3_8gb_x32_1600_pkg
+
 `define dramsim3_ba_width(num_ba_mp) $clog2(num_ba_mp)
 `define dramsim3_bg_width(num_bg_mp) $clog2(num_bg_mp)
 `define dramsim3_co_width(num_columns_mp) $clog2(num_columns_mp)
+`define dramsim3_ro_width(num_rows_mp) $clog2(num_rows_mp)
+`define dramsim3_ra_width(num_ranks_mp) $clog2(num_ranks_mp)
 `define dramsim3_byte_offset_width(data_width_mp) \
   $clog2(data_width_mp>>3)
-
-`define dramsim3_ro_width(ch_addr_width_mp, data_width_mp, num_ba_mp, num_bg_mp, num_columns_mp) \
-  (ch_addr_width_mp   \
-   - `dramsim3_ba_width(num_ba_mp)   \
-   - `dramsim3_bg_width(num_bg_mp)   \
-   - `dramsim3_co_width(num_columns_mp)   \
-   - `dramsim3_byte_offset_width(data_width_mp))
-
-`define dramsim3_ro_width_pkg(dram_pkg) \
-  `dramsim3_ro_width(dram_pkg::channel_addr_width_p, \
-                    dram_pkg::data_width_p, \
-                    dram_pkg::num_ba_p, \
-                    dram_pkg::num_bg_p, \
-                    dram_pkg::num_columns_p)
 
 `define dramsim3_ba_width_pkg(dram_pkg) \
   `dramsim3_ba_width(dram_pkg::num_ba_p)
@@ -68,22 +75,11 @@ endpackage // bsg_dramsim3_hbm2_8gb_x128_pkg
 `define dramsim3_co_width_pkg(dram_pkg) \
   `dramsim3_co_width(dram_pkg::num_columns_p)
 
+`define dramsim3_ro_width_pkg(dram_pkg) \
+  `dramsim3_ro_width(dram_pkg::num_rows_p)
+
+`define dramsim3_ra_width_pkg(dram_pkg) \
+  `dramsim3_ra_width(dram_pkg::num_ranks_p)
+
 `define dramsim3_byte_offset_width_pkg(dram_pkg) \
   `dramsim3_byte_offset_width(dram_pkg::data_width_p)
-
-`define declare_dramsim3_ch_addr_s(typename_mp, ch_addr_width_mp, data_width_mp, num_ba_mp, num_bg_mp, num_columns_mp) \
-  typedef struct packed { \
-    logic [`dramsim3_ro_width(ch_addr_width_mp, data_width_mp, num_ba_mp, num_bg_mp, num_columns_mp)-1:0] ro; \
-    logic [`dramsim3_bg_width(num_bg_mp)-1:0] bg; \
-    logic [`dramsim3_ba_width(num_ba_mp)-1:0] ba; \
-    logic [`dramsim3_co_width(num_columns_mp)-1:0] co; \
-    logic [`dramsim3_byte_offset_width(data_width_mp)-1:0] byte_offset; \
-  } typename_mp
-
-`define declare_dramsim3_ch_addr_s_with_pkg(typename_mp, dram_pkg) \
-  `declare_dramsim3_ch_addr_s(typename_mp, \
-                              dram_pkg::channel_addr_width_p, \
-                              dram_pkg::data_width_p, \
-                              dram_pkg::num_ba_p, \
-                              dram_pkg::num_bg_p, \
-                              dram_pkg::num_columns_p)

--- a/bsg_test/bsg_nonsynth_dramsim3.v
+++ b/bsg_test/bsg_nonsynth_dramsim3.v
@@ -10,6 +10,10 @@ module bsg_nonsynth_dramsim3
     , parameter data_width_p="inv"
     , parameter num_channels_p="inv"
     , parameter num_columns_p="inv"
+    , parameter num_rows_p="inv"
+    , parameter num_ba_p="inv"
+    , parameter num_bg_p="inv"
+    , parameter num_ranks_p="inv"
     , parameter address_mapping_p="inv"
     , parameter size_in_bits_p=0
     , parameter masked_p=0
@@ -18,7 +22,7 @@ module bsg_nonsynth_dramsim3
     , parameter string config_p="inv"
     , parameter string trace_file_p="bsg_nonsynth_dramsim3_trace.txt"
     , parameter base_id_p=0 // use this for multiple instances of this module
-    , parameter lg_num_channels_lp=`BSG_SAFE_CLOG2(num_channels_p)
+    , parameter mem_addr_width_lp=$clog2(num_channels_p)+channel_addr_width_p
     , parameter data_mask_width_lp=(data_width_p>>3)
     , parameter byte_offset_width_lp=`BSG_SAFE_CLOG2(data_width_p>>3)
   )
@@ -52,6 +56,7 @@ module bsg_nonsynth_dramsim3
     bit     bsg_dramsim3_init(input int     num_channels,
                               input int     data_width,
                               input longint size,
+                              input int     num_columns,
                               string        config_file);
   
   import "DPI-C" context function 
@@ -80,11 +85,11 @@ module bsg_nonsynth_dramsim3
      bit    init;
 
   initial begin
-    init = bsg_dramsim3_init(num_channels_p, data_width_p, size_in_bits_p, config_p);
+    init = bsg_dramsim3_init(num_channels_p, data_width_p, size_in_bits_p, num_columns_p, config_p);
   end
 
   // memory addr
-  logic [num_channels_p-1:0][lg_num_channels_lp+channel_addr_width_p-1:0] mem_addr;
+  logic [num_channels_p-1:0][mem_addr_width_lp-1:0] mem_addr;
 
   for (genvar i = 0; i < num_channels_p; i++) begin
     bsg_nonsynth_dramsim3_map
@@ -92,6 +97,10 @@ module bsg_nonsynth_dramsim3
         ,.data_width_p(data_width_p)
         ,.num_channels_p(num_channels_p)
         ,.num_columns_p(num_columns_p)
+        ,.num_rows_p(num_rows_p)
+        ,.num_ba_p(num_ba_p)
+        ,.num_bg_p(num_bg_p)
+        ,.num_ranks_p(num_ranks_p)
         ,.address_mapping_p(address_mapping_p)
         ,.channel_select_p(i)
         ,.debug_p(debug_p))
@@ -108,7 +117,7 @@ module bsg_nonsynth_dramsim3
     
   // read channel signal
   logic [num_channels_p-1:0] read_done;
-  logic [num_channels_p-1:0][lg_num_channels_lp+channel_addr_width_p-1:0] read_done_addr;
+  logic [num_channels_p-1:0][mem_addr_width_lp-1:0] read_done_addr;
   logic [num_channels_p-1:0][channel_addr_width_p-1:0] read_done_ch_addr;
 
   for (genvar i = 0; i < num_channels_p; i++) begin
@@ -117,6 +126,10 @@ module bsg_nonsynth_dramsim3
        ,.data_width_p(data_width_p)
        ,.num_channels_p(num_channels_p)
        ,.num_columns_p(num_columns_p)
+       ,.num_rows_p(num_rows_p)
+       ,.num_ba_p(num_ba_p)
+       ,.num_bg_p(num_bg_p)
+       ,.num_ranks_p(num_ranks_p)
        ,.address_mapping_p(address_mapping_p)
        ,.channel_select_p(i)
        ,.debug_p(debug_p))
@@ -127,7 +140,7 @@ module bsg_nonsynth_dramsim3
   end
 
   // write channel signal
-  logic [num_channels_p-1:0][lg_num_channels_lp+channel_addr_width_p-1:0] write_done_addr;
+  logic [num_channels_p-1:0][mem_addr_width_lp-1:0] write_done_addr;
 
   for (genvar i = 0; i < num_channels_p; i++) begin
 
@@ -136,6 +149,10 @@ module bsg_nonsynth_dramsim3
        ,.data_width_p(data_width_p)
        ,.num_channels_p(num_channels_p)
        ,.num_columns_p(num_columns_p)
+       ,.num_rows_p(num_rows_p)
+       ,.num_ba_p(num_ba_p)
+       ,.num_bg_p(num_bg_p)
+       ,.num_ranks_p(num_ranks_p)
        ,.address_mapping_p(address_mapping_p)
        ,.channel_select_p(i)
        ,.debug_p(debug_p))

--- a/bsg_test/bsg_nonsynth_dramsim3_map.v
+++ b/bsg_test/bsg_nonsynth_dramsim3_map.v
@@ -9,11 +9,19 @@ module bsg_nonsynth_dramsim3_map
     , parameter data_width_p="inv"
     , parameter num_channels_p="inv"
     , parameter num_columns_p="inv"
+    , parameter num_rows_p="inv"
+    , parameter num_ba_p="inv"
+    , parameter num_bg_p="inv"
+    , parameter num_ranks_p="inv"
     , parameter address_mapping_p="inv"
     , parameter channel_select_p="inv"
     , parameter debug_p=0
-    , parameter lg_num_channels_lp=`BSG_SAFE_CLOG2(num_channels_p)
-    , parameter lg_num_columns_lp=`BSG_SAFE_CLOG2(num_columns_p)
+    , parameter lg_num_channels_lp=$clog2(num_channels_p)
+    , parameter lg_num_columns_lp=$clog2(num_columns_p)
+    , parameter lg_num_rows_lp=$clog2(num_rows_p)
+    , parameter lg_num_ba_lp=$clog2(num_ba_p)
+    , parameter lg_num_bg_lp=$clog2(num_bg_p)
+    , parameter lg_num_ranks_lp=$clog2(num_ranks_p)
     , parameter data_mask_width_lp=(data_width_p>>3)
     , parameter byte_offset_width_lp=`BSG_SAFE_CLOG2(data_width_p>>3)
     , parameter addr_width_lp=lg_num_channels_lp+channel_addr_width_p
@@ -22,6 +30,12 @@ module bsg_nonsynth_dramsim3_map
     input logic [channel_addr_width_p-1:0] ch_addr_i
     , output logic [addr_width_lp-1:0] mem_addr_o
    );
+
+  localparam co_pos_lp = byte_offset_width_lp;
+  localparam ba_pos_lp = co_pos_lp + lg_num_columns_lp;
+  localparam bg_pos_lp = ba_pos_lp + lg_num_ba_lp;
+  localparam ra_pos_lp = bg_pos_lp + lg_num_bg_lp;
+  localparam ro_pos_lp = ra_pos_lp + lg_num_ranks_lp;
 
   if (address_mapping_p == e_ro_ra_bg_ba_co_ch) begin
     assign mem_addr_o
@@ -40,6 +54,32 @@ module bsg_nonsynth_dramsim3_map
          ch_addr_i[lg_num_columns_lp+byte_offset_width_lp-1:byte_offset_width_lp],
          {byte_offset_width_lp{1'b0}}
          };
+  end
+  else if (address_mapping_p == e_ro_ch_ra_ba_bg_co) begin
+
+    localparam mem_co_pos_lp = byte_offset_width_lp;
+    localparam mem_bg_pos_lp = mem_co_pos_lp + lg_num_columns_lp;
+    localparam mem_ba_pos_lp = mem_bg_pos_lp + lg_num_bg_lp;
+    localparam mem_ra_pos_lp = mem_ba_pos_lp + lg_num_ba_lp;
+    localparam mem_ch_pos_lp = mem_ra_pos_lp + lg_num_ranks_lp;
+    localparam mem_ro_pos_lp = mem_ch_pos_lp + lg_num_channels_lp;
+
+    for (genvar i=0; i < addr_width_lp; i++) begin
+      if (i >= mem_ro_pos_lp)
+        assign mem_addr_o[i] = ch_addr_i[ro_pos_lp+i-mem_ro_pos_lp];
+      else if ((i >= mem_ch_pos_lp) && (num_channels_p > 1))
+        assign mem_addr_o[i] = channel_select_p[i-mem_ch_pos_lp];
+      else if (i >= mem_ra_pos_lp)
+        assign mem_addr_o[i] = ch_addr_i[ra_pos_lp+i-mem_ra_pos_lp];
+      else if (i >= mem_ba_pos_lp)
+        assign mem_addr_o[i] = ch_addr_i[ba_pos_lp+i-mem_ba_pos_lp];
+      else if (i >= mem_bg_pos_lp)
+        assign mem_addr_o[i] = ch_addr_i[bg_pos_lp+i-mem_bg_pos_lp];
+      else if (i >= mem_co_pos_lp)
+        assign mem_addr_o[i] = ch_addr_i[co_pos_lp+i-mem_co_pos_lp];
+      else
+        assign mem_addr_o[i] = 1'b0;
+    end
   end
 
 endmodule // bsg_nonsynth_dramsim3_map

--- a/bsg_test/bsg_nonsynth_dramsim3_map.v
+++ b/bsg_test/bsg_nonsynth_dramsim3_map.v
@@ -41,7 +41,7 @@ module bsg_nonsynth_dramsim3_map
     assign mem_addr_o
       = {
          ch_addr_i[channel_addr_width_p-1:byte_offset_width_lp],
-         (lg_num_channels_lp)'(channel_select_p),
+         {lg_num_channels_lp!=0{`BSG_MAX(lg_num_channels_lp, 1)'(channel_select_p)}},
          {byte_offset_width_lp{1'b0}}
          };
   end
@@ -50,36 +50,22 @@ module bsg_nonsynth_dramsim3_map
     assign mem_addr_o
       = {
          ch_addr_i[channel_addr_width_p-1:lg_num_columns_lp+byte_offset_width_lp],
-         (lg_num_channels_lp)'(channel_select_p),
+         {lg_num_channels_lp!=0{`BSG_MAX(lg_num_channels_lp, 1)'(channel_select_p)}},
          ch_addr_i[lg_num_columns_lp+byte_offset_width_lp-1:byte_offset_width_lp],
          {byte_offset_width_lp{1'b0}}
          };
   end
   else if (address_mapping_p == e_ro_ch_ra_ba_bg_co) begin
-
-    localparam mem_co_pos_lp = byte_offset_width_lp;
-    localparam mem_bg_pos_lp = mem_co_pos_lp + lg_num_columns_lp;
-    localparam mem_ba_pos_lp = mem_bg_pos_lp + lg_num_bg_lp;
-    localparam mem_ra_pos_lp = mem_ba_pos_lp + lg_num_ba_lp;
-    localparam mem_ch_pos_lp = mem_ra_pos_lp + lg_num_ranks_lp;
-    localparam mem_ro_pos_lp = mem_ch_pos_lp + lg_num_channels_lp;
-
-    for (genvar i=0; i < addr_width_lp; i++) begin
-      if (i >= mem_ro_pos_lp)
-        assign mem_addr_o[i] = ch_addr_i[ro_pos_lp+i-mem_ro_pos_lp];
-      else if ((i >= mem_ch_pos_lp) && (num_channels_p > 1))
-        assign mem_addr_o[i] = channel_select_p[i-mem_ch_pos_lp];
-      else if (i >= mem_ra_pos_lp)
-        assign mem_addr_o[i] = ch_addr_i[ra_pos_lp+i-mem_ra_pos_lp];
-      else if (i >= mem_ba_pos_lp)
-        assign mem_addr_o[i] = ch_addr_i[ba_pos_lp+i-mem_ba_pos_lp];
-      else if (i >= mem_bg_pos_lp)
-        assign mem_addr_o[i] = ch_addr_i[bg_pos_lp+i-mem_bg_pos_lp];
-      else if (i >= mem_co_pos_lp)
-        assign mem_addr_o[i] = ch_addr_i[co_pos_lp+i-mem_co_pos_lp];
-      else
-        assign mem_addr_o[i] = 1'b0;
-    end
+    assign mem_addr_o
+      = {
+         ch_addr_i[ro_pos_lp+:lg_num_rows_lp],
+         {lg_num_channels_lp!=0{`BSG_MAX(lg_num_channels_lp, 1)'(channel_select_p)}},
+         {lg_num_ranks_lp!=0{ch_addr_i[ra_pos_lp+:`BSG_MAX(lg_num_ranks_lp, 1)]}},
+         {lg_num_ba_lp!=0{ch_addr_i[ba_pos_lp+:`BSG_MAX(lg_num_ba_lp, 1)]}},
+         {lg_num_bg_lp!=0{ch_addr_i[bg_pos_lp+:`BSG_MAX(lg_num_bg_lp, 1)]}},
+         ch_addr_i[co_pos_lp+:lg_num_columns_lp],
+         {byte_offset_width_lp{1'b0}}
+         };
   end
 
 endmodule // bsg_nonsynth_dramsim3_map

--- a/bsg_test/bsg_nonsynth_dramsim3_unmap.v
+++ b/bsg_test/bsg_nonsynth_dramsim3_unmap.v
@@ -31,12 +31,6 @@ module bsg_nonsynth_dramsim3_unmap
     , output logic [channel_addr_width_p-1:0] ch_addr_o
     );
 
-    localparam co_pos_lp = byte_offset_width_lp;
-    localparam ba_pos_lp = co_pos_lp + lg_num_columns_lp;
-    localparam bg_pos_lp = ba_pos_lp + lg_num_ba_lp;
-    localparam ra_pos_lp = bg_pos_lp + lg_num_bg_lp;
-    localparam ro_pos_lp = ra_pos_lp + lg_num_ranks_lp;
-
     if (address_mapping_p == e_ro_ra_bg_ba_co_ch) begin
       assign ch_addr_o
         = {
@@ -62,20 +56,15 @@ module bsg_nonsynth_dramsim3_unmap
       localparam mem_ch_pos_lp = mem_ra_pos_lp + lg_num_ranks_lp;
       localparam mem_ro_pos_lp = mem_ch_pos_lp + lg_num_channels_lp;
 
-      for (genvar i=0; i < channel_addr_width_p; i++) begin
-        if (i >= ro_pos_lp)
-          assign ch_addr_o[i] = mem_addr_i[mem_ro_pos_lp+i-ro_pos_lp];
-        else if (i >= ra_pos_lp)
-          assign ch_addr_o[i] = mem_addr_i[mem_ra_pos_lp+i-ra_pos_lp];
-        else if (i >= bg_pos_lp)
-          assign ch_addr_o[i] = mem_addr_i[mem_bg_pos_lp+i-bg_pos_lp];
-        else if (i >= ba_pos_lp)
-          assign ch_addr_o[i] = mem_addr_i[mem_ba_pos_lp+i-ba_pos_lp];
-        else if (i >= co_pos_lp)
-          assign ch_addr_o[i] = mem_addr_i[mem_co_pos_lp+i-co_pos_lp];
-        else
-          assign ch_addr_o[i] = 1'b0;
-      end
+      assign ch_addr_o
+        = {
+           mem_addr_i[mem_ro_pos_lp+:lg_num_rows_lp],
+           {lg_num_ranks_lp!=0{mem_addr_i[mem_ra_pos_lp+:`BSG_MAX(lg_num_ranks_lp, 1)]}},
+           {lg_num_bg_lp!=0{mem_addr_i[mem_bg_pos_lp+:`BSG_MAX(lg_num_bg_lp, 1)]}},
+           {lg_num_ba_lp!=0{mem_addr_i[mem_ba_pos_lp+:`BSG_MAX(lg_num_ba_lp, 1)]}},
+           mem_addr_i[mem_co_pos_lp+:lg_num_columns_lp],
+           {byte_offset_width_lp{1'b0}}
+           };
     end
 
 endmodule // bsg_nonsynth_dramsim3_unmap

--- a/testing/bsg_test/bsg_nonsynth_dramsim3/testbench.v
+++ b/testing/bsg_test/bsg_nonsynth_dramsim3/testbench.v
@@ -38,7 +38,10 @@ module testbench ();
 
   logic [num_channels_p-1:0]                            dramsim3_data_v_lo;
   logic [num_channels_p-1:0] [data_width_p-1:0]         dramsim3_data_lo;
-  
+
+  `dram_pkg::dram_ch_addr_s dramsim3_ch_addr_li_cast;
+  assign dramsim3_ch_addr_li_cast = dramsim3_ch_addr_li[0];
+
   bsg_nonsynth_dramsim3
     #(.channel_addr_width_p(`dram_pkg::channel_addr_width_p)
       ,.data_width_p(`dram_pkg::data_width_p)
@@ -155,9 +158,21 @@ module testbench ();
   always_ff @(posedge clk) begin
     if (~reset & dramsim3_v_li[0]) begin
       if (dramsim3_write_not_read_li[0])
-        $display("write: 0x%08x", dramsim3_ch_addr_li[0]);
+        $display("write: 0x%08x {ro: %d, ba: %d, bg: %d, co: %d, byte: %d}",
+                 dramsim3_ch_addr_li[0],
+                 dramsim3_ch_addr_li_cast.ro,
+                 dramsim3_ch_addr_li_cast.ba,
+                 dramsim3_ch_addr_li_cast.bg,
+                 dramsim3_ch_addr_li_cast.co,
+                 dramsim3_ch_addr_li_cast.byte_offset);
       else
-        $display("read: 0x%08x", dramsim3_ch_addr_li[0]);
+        $display("read: 0x%08x {ro: %d, ba: %d, bg: %d, co: %d, byte: %d}",
+                 dramsim3_ch_addr_li[0],
+                 dramsim3_ch_addr_li_cast.ro,
+                 dramsim3_ch_addr_li_cast.ba,
+                 dramsim3_ch_addr_li_cast.bg,
+                 dramsim3_ch_addr_li_cast.co,
+                 dramsim3_ch_addr_li_cast.byte_offset);
     end    
   end
   

--- a/testing/bsg_test/bsg_nonsynth_dramsim3/testbench.v
+++ b/testing/bsg_test/bsg_nonsynth_dramsim3/testbench.v
@@ -26,7 +26,6 @@ module testbench ();
   
   // dramsim3
   import `dram_pkg::*;
-  `declare_dramsim3_ch_addr_s_with_pkg(dram_ch_addr_s, `dram_pkg);
   
   logic [num_channels_p-1:0]                            dramsim3_v_li;
   logic [num_channels_p-1:0]                            dramsim3_write_not_read_li;
@@ -39,18 +38,20 @@ module testbench ();
 
   logic [num_channels_p-1:0]                            dramsim3_data_v_lo;
   logic [num_channels_p-1:0] [data_width_p-1:0]         dramsim3_data_lo;
-
-  dram_ch_addr_s dramsim3_ch_addr_li_cast;
-  assign dramsim3_ch_addr_li_cast = dramsim3_ch_addr_li[0];
   
   bsg_nonsynth_dramsim3
     #(.channel_addr_width_p(`dram_pkg::channel_addr_width_p)
       ,.data_width_p(`dram_pkg::data_width_p)
       ,.num_channels_p(`dram_pkg::num_channels_p)
       ,.num_columns_p(`dram_pkg::num_columns_p)
+      ,.num_rows_p(`dram_pkg::num_rows_p)
+      ,.num_ba_p(`dram_pkg::num_ba_p)
+      ,.num_bg_p(`dram_pkg::num_bg_p)
+      ,.num_ranks_p(`dram_pkg::num_ranks_p)
       ,.size_in_bits_p(`dram_pkg::size_in_bits_p)
       ,.address_mapping_p(`dram_pkg::address_mapping_p)
       ,.config_p(`dram_pkg::config_p)
+      ,.masked_p(0)
       ,.trace_file_p(`BSG_STRINGIFY(`trace_file))
       ,.debug_p(1))
     mem
@@ -64,6 +65,7 @@ module testbench ();
 
        ,.data_v_i(dramsim3_data_v_li)
        ,.data_i(dramsim3_data_li)
+       ,.mask_i('0)
        ,.data_yumi_o(dramsim3_data_yumi_lo)
       
        ,.data_v_o(dramsim3_data_v_lo)
@@ -153,21 +155,9 @@ module testbench ();
   always_ff @(posedge clk) begin
     if (~reset & dramsim3_v_li[0]) begin
       if (dramsim3_write_not_read_li[0])
-        $display("write: 0x%08x {ro: %d, ba: %d, bg: %d, co: %d, byte: %d}",
-                 dramsim3_ch_addr_li[0], 
-                 dramsim3_ch_addr_li_cast.ro,
-                 dramsim3_ch_addr_li_cast.ba,
-                 dramsim3_ch_addr_li_cast.bg,
-                 dramsim3_ch_addr_li_cast.co,
-                 dramsim3_ch_addr_li_cast.byte_offset);
+        $display("write: 0x%08x", dramsim3_ch_addr_li[0]);
       else
-        $display("read: 0x%08x {ro: %d, ba: %d, bg: %d, co: %d, byte: %d}",
-                 dramsim3_ch_addr_li[0], 
-                 dramsim3_ch_addr_li_cast.ro,
-                 dramsim3_ch_addr_li_cast.ba,
-                 dramsim3_ch_addr_li_cast.bg,
-                 dramsim3_ch_addr_li_cast.co,
-                 dramsim3_ch_addr_li_cast.byte_offset);
+        $display("read: 0x%08x", dramsim3_ch_addr_li[0]);
     end    
   end
   

--- a/testing/bsg_test/dramsim3_bandwidth/testbench.v
+++ b/testing/bsg_test/dramsim3_bandwidth/testbench.v
@@ -100,9 +100,14 @@ module testbench();
     ,.data_width_p(`dram_pkg::data_width_p)
     ,.num_channels_p(`dram_pkg::num_channels_p)
     ,.num_columns_p(`dram_pkg::num_columns_p)
+    ,.num_rows_p(`dram_pkg::num_rows_p)
+    ,.num_ba_p(`dram_pkg::num_ba_p)
+    ,.num_bg_p(`dram_pkg::num_bg_p)
+    ,.num_ranks_p(`dram_pkg::num_ranks_p)
     ,.size_in_bits_p(`dram_pkg::size_in_bits_p)
     ,.address_mapping_p(`dram_pkg::address_mapping_p)
     ,.config_p(`dram_pkg::config_p)
+    ,.masked_p(0)
     ,.debug_p(1)
     ,.init_mem_p(1)
   ) DUT (
@@ -116,6 +121,7 @@ module testbench();
 
     ,.data_v_i(dramsim3_data_v_li)
     ,.data_i(dramsim3_data_li)
+    ,.mask_i('0)
     ,.data_yumi_o(dramsim3_data_yumi_lo)
 
     ,.data_v_o(dramsim3_data_v_lo)

--- a/testing/bsg_test/dramsim3_bandwidth2/testbench.v
+++ b/testing/bsg_test/dramsim3_bandwidth2/testbench.v
@@ -215,9 +215,14 @@ module testbench();
     ,.num_channels_p(num_channels_p)
 
     ,.num_columns_p(`dram_pkg::num_columns_p)
+    ,.num_rows_p(`dram_pkg::num_rows_p)
+    ,.num_ba_p(`dram_pkg::num_ba_p)
+    ,.num_bg_p(`dram_pkg::num_bg_p)
+    ,.num_ranks_p(`dram_pkg::num_ranks_p)
     ,.size_in_bits_p(`dram_pkg::size_in_bits_p)
     ,.address_mapping_p(`dram_pkg::address_mapping_p)
     ,.config_p(`dram_pkg::config_p)
+    ,.masked_p(0)
     ,.init_mem_p(1)
 
     ,.debug_p(1)
@@ -232,6 +237,7 @@ module testbench();
 
     ,.data_v_i(dramsim3_data_v_li)
     ,.data_i(dramsim3_data_li)
+    ,.mask_i('0)
     ,.data_yumi_o(dramsim3_data_yumi_lo)
 
     ,.data_v_o(dramsim3_data_v_lo)


### PR DESCRIPTION
- Added the `rochrababgco` address mapping to the translation modules
- Fixed a small error in Verilog parameter validation vs DRAMSim3