### PR TITLE
Fixing saturation of read and write counters in DRAM controller

### DIFF
--- a/bsg_dmc/bsg_dmc_controller.v
+++ b/bsg_dmc/bsg_dmc_controller.v
@@ -480,7 +480,7 @@ module bsg_dmc_controller
       cmd_wr_tick <= 0;
     else if(shoot && n_cmd == WRITE)
       cmd_wr_tick <= 0;
-    else if(cmd_tick != 8'hf)
+    else if(cmd_wr_tick != 8'hf)
       cmd_wr_tick <= cmd_wr_tick + 1;
   end
 
@@ -489,7 +489,7 @@ module bsg_dmc_controller
       cmd_rd_tick <= 0;
     else if(shoot && n_cmd == READ)
       cmd_rd_tick <= 0;
-    else if(cmd_tick != 8'hf)
+    else if(cmd_rd_tick != 8'hf)
       cmd_rd_tick <= cmd_rd_tick + 1;
   end
 


### PR DESCRIPTION
If these counters that are used to enforce the minimum timing delays of the DRAM model overflow, it can add additional delays between issued DRAM operations.