### PR TITLE
Prevent erroring on trace-replay nop

### DIFF
--- a/bsg_test/bsg_trace_replay.v
+++ b/bsg_test/bsg_trace_replay.v
@@ -159,6 +159,7 @@ module bsg_trace_replay
    always @(negedge clk_i) begin
         if (instr_completed & ~reset_i & ~done_r) begin
              case(op)
+               eNop: begin end
                eSend: begin
                     if (debug_p >= 2) begin
                          $display("### bsg_trace_replay SEND %d'b%b (%m)", payload_width_p,data_o);


### PR DESCRIPTION
Missing case statement leads to ```### bsg_trace_replay UNKNOWN op 0 (testbench.trace_replay)``` for nops and terminates the simulation.  Credit to @gaozihou for the debug!