### PR TITLE
Remove inside in generate if

### DIFF
--- a/bsg_test/bsg_nonsynth_dpi_from_fifo.v
+++ b/bsg_test/bsg_nonsynth_dpi_from_fifo.v
@@ -67,7 +67,7 @@ module bsg_nonsynth_dpi_from_fifo
    bit    rx_r = 0;
    
    // Check if width_p is a ctype width. call $fatal, if not.
-   if (!(width_p inside {32'd8, 32'd16, 32'd32, 32'd64, 32'd128})) begin
+   if (!(width_p == 32'd8 || width_p == 32'd16 || width_p == 32'd32 || width_p == 32'd64 || width_p == 32'd128)) begin
       $fatal(1, "BSG ERROR (%M): width_p of %d is not supported. Must be a power of 2 and divisible by 8", width_p);
    end
 

--- a/bsg_test/bsg_nonsynth_dpi_to_fifo.v
+++ b/bsg_test/bsg_nonsynth_dpi_to_fifo.v
@@ -74,7 +74,7 @@ module bsg_nonsynth_dpi_to_fifo
    bit    tx_r = 0;
    
    // Check if width_p is a ctype width. call $fatal, if not.
-   if (!(width_p inside {32'd8, 32'd16, 32'd32, 32'd64, 32'd128})) begin
+   if (!(width_p == 32'd8 || width_p == 32'd16 || width_p == 32'd32 || width_p == 32'd64 || width_p == 32'd128)) begin
       $fatal(1, "BSG ERROR (%M): width_p of %d is not supported. Must be a power of 2 and divisible by 8", width_p);
    end
 


### PR DESCRIPTION
In LRM, `generate if` takes `constant_expression`, but `inside` is `expression`.
So `inside` can't be used in `generate if`.

> LRM A.4.2
> if_generate_construct ::=
if ( constant_expression ) generate_block [ else generate_block ]