### PR TITLE
BSG_SAFE_MINUS

### DIFF
--- a/bsg_misc/bsg_defines.v
+++ b/bsg_misc/bsg_defines.v
@@ -8,6 +8,7 @@
 `define BSG_SAFE_CLOG2(x) ( ((x)==1) ? 1 : $clog2((x)))
 `define BSG_IS_POW2(x) ( (1 << $clog2(x)) == (x))
 `define BSG_WIDTH(x) ($clog2(x+1))
+`define BSG_SAFE_MINUS(x, y) (x - y < 0) ? 0 : (x - y)
 
 // calculate ceil(x/y) 
 `define BSG_CDIV(x,y) (((x)+(y)-1)/(y))

--- a/bsg_misc/bsg_defines.v
+++ b/bsg_misc/bsg_defines.v
@@ -8,7 +8,7 @@
 `define BSG_SAFE_CLOG2(x) ( ((x)==1) ? 1 : $clog2((x)))
 `define BSG_IS_POW2(x) ( (1 << $clog2(x)) == (x))
 `define BSG_WIDTH(x) ($clog2(x+1))
-`define BSG_SAFE_MINUS(x, y) (x - y < 0) ? 0 : (x - y)
+`define BSG_SAFE_MINUS(x, y) (((x)-(y)) < 0) ? 0 : ((x)-(y))
 
 // calculate ceil(x/y) 
 `define BSG_CDIV(x,y) (((x)+(y)-1)/(y))

--- a/bsg_misc/bsg_lru_pseudo_tree_backup.v
+++ b/bsg_misc/bsg_lru_pseudo_tree_backup.v
@@ -59,22 +59,22 @@ module bsg_lru_pseudo_tree_backup
     assign modify_data_o = 1'b0;
   end
   else begin: lru
-    // backup LRU logic
-    // i = rank
-    for (genvar i = 0; i < lg_ways_lp; i++) begin
+  // backup LRU logic
+  // i = rank
+  for (genvar i = 0; i < lg_ways_lp; i++) begin
 
-      logic [(2**(i+1))-1:0] and_reduce;
+    logic [(2**(i+1))-1:0] and_reduce;
     
-      // j = bucket
-      for (genvar j = 0; j < (2**(i+1)); j++)
-        assign and_reduce[j] = &disabled_ways_i[(ways_p/(2**(i+1)))*j+:(ways_p/(2**(i+1)))];
+    // j = bucket
+    for (genvar j = 0; j < (2**(i+1)); j++)
+      assign and_reduce[j] = &disabled_ways_i[(ways_p/(2**(i+1)))*j+:(ways_p/(2**(i+1)))];
   
-      // k = start index in LRU bits
-      for (genvar k = 0; k < (2**(i+1))/2; k++) begin
-        assign modify_data_o[(2**i)-1+k] = and_reduce[2*k];
-        assign modify_mask_o[(2**i)-1+k] = |and_reduce[2*k+:2];
-      end
+    // k = start index in LRU bits
+    for (genvar k = 0; k < (2**(i+1))/2; k++) begin
+      assign modify_data_o[(2**i)-1+k] = and_reduce[2*k];
+      assign modify_mask_o[(2**i)-1+k] = |and_reduce[2*k+:2];
     end
+  end
   end
 
 endmodule

--- a/bsg_misc/bsg_lru_pseudo_tree_backup.v
+++ b/bsg_misc/bsg_lru_pseudo_tree_backup.v
@@ -49,25 +49,31 @@ module bsg_lru_pseudo_tree_backup
   )
   (
     input [ways_p-1:0] disabled_ways_i
-    , output logic [ways_p-2:0] modify_mask_o
-    , output logic [ways_p-2:0] modify_data_o
+    , output logic [`BSG_SAFE_MINUS(ways_p, 2):0] modify_mask_o
+    , output logic [`BSG_SAFE_MINUS(ways_p, 2):0] modify_data_o
   );
 
+  // If direct-mapped there is no meaning to backup LRU
+  if (ways_p == 1) begin: no_lru
+    assign modify_mask_o = 1'b1;
+    assign modify_data_o = 1'b0;
+  end
+  else begin: lru
+    // backup LRU logic
+    // i = rank
+    for (genvar i = 0; i < lg_ways_lp; i++) begin
 
-  // backup LRU logic
-  // i = rank
-  for (genvar i = 0; i < lg_ways_lp; i++) begin
-
-    logic [(2**(i+1))-1:0] and_reduce;
+      logic [(2**(i+1))-1:0] and_reduce;
     
-    // j = bucket
-    for (genvar j = 0; j < (2**(i+1)); j++)
-      assign and_reduce[j] = &disabled_ways_i[(ways_p/(2**(i+1)))*j+:(ways_p/(2**(i+1)))];
+      // j = bucket
+      for (genvar j = 0; j < (2**(i+1)); j++)
+        assign and_reduce[j] = &disabled_ways_i[(ways_p/(2**(i+1)))*j+:(ways_p/(2**(i+1)))];
   
-    // k = start index in LRU bits
-    for (genvar k = 0; k < (2**(i+1))/2; k++) begin
-      assign modify_data_o[(2**i)-1+k] = and_reduce[2*k];
-      assign modify_mask_o[(2**i)-1+k] = |and_reduce[2*k+:2];
+      // k = start index in LRU bits
+      for (genvar k = 0; k < (2**(i+1))/2; k++) begin
+        assign modify_data_o[(2**i)-1+k] = and_reduce[2*k];
+        assign modify_mask_o[(2**i)-1+k] = |and_reduce[2*k+:2];
+      end
     end
   end
 

--- a/bsg_misc/bsg_lru_pseudo_tree_decode.v
+++ b/bsg_misc/bsg_lru_pseudo_tree_decode.v
@@ -17,26 +17,32 @@ module bsg_lru_pseudo_tree_decode
     ,localparam lg_ways_lp = `BSG_SAFE_CLOG2(ways_p)
   )
   (input [lg_ways_lp-1:0]      way_id_i
-   , output logic [ways_p-2:0] data_o
-   , output logic [ways_p-2:0] mask_o
+   , output logic [`BSG_SAFE_MINUS(ways_p, 2):0] data_o
+   , output logic [`BSG_SAFE_MINUS(ways_p, 2):0] mask_o
   );
 
   genvar i;
-  generate 
-    for(i=0; i<ways_p-1; i++) begin: rof
-      // Mask generation
-	  if(i == 0) begin: fi
-	    assign mask_o[i] = 1'b1;
-	  end
-	  else if(i%2 == 1) begin: fi
-	    assign mask_o[i] = mask_o[(i-1)/2] & ~way_id_i[lg_ways_lp-`BSG_SAFE_CLOG2(i+2)+1];
-	  end
-	  else begin: fi
-	    assign mask_o[i] = mask_o[(i-2)/2] & way_id_i[lg_ways_lp-`BSG_SAFE_CLOG2(i+2)+1];
-	  end
+  generate
+    if (ways_p == 1) begin: no_lru
+      assign mask_o[0] = 1'b1;
+      assign data_o[0] = 1'b0;
+    end
+    else begin: lru 
+      for(i=0; i<ways_p-1; i++) begin: rof
+        // Mask generation
+	    if(i == 0) begin: fi
+	      assign mask_o[i] = 1'b1;
+	    end
+	    else if(i%2 == 1) begin: fi
+	      assign mask_o[i] = mask_o[(i-1)/2] & ~way_id_i[lg_ways_lp-`BSG_SAFE_CLOG2(i+2)+1];
+	    end
+	    else begin: fi
+	      assign mask_o[i] = mask_o[(i-2)/2] & way_id_i[lg_ways_lp-`BSG_SAFE_CLOG2(i+2)+1];
+	    end
 	  
-	  // Data generation
-	  assign data_o[i] = mask_o[i] & ~way_id_i[lg_ways_lp-`BSG_SAFE_CLOG2(i+2)];
+	    // Data generation
+	    assign data_o[i] = mask_o[i] & ~way_id_i[lg_ways_lp-`BSG_SAFE_CLOG2(i+2)];
+      end
     end
   endgenerate
 

--- a/bsg_misc/bsg_lru_pseudo_tree_decode.v
+++ b/bsg_misc/bsg_lru_pseudo_tree_decode.v
@@ -27,22 +27,22 @@ module bsg_lru_pseudo_tree_decode
       assign mask_o[0] = 1'b1;
       assign data_o[0] = 1'b0;
     end
-    else begin: lru 
-      for(i=0; i<ways_p-1; i++) begin: rof
-        // Mask generation
-	    if(i == 0) begin: fi
-	      assign mask_o[i] = 1'b1;
-	    end
-	    else if(i%2 == 1) begin: fi
-	      assign mask_o[i] = mask_o[(i-1)/2] & ~way_id_i[lg_ways_lp-`BSG_SAFE_CLOG2(i+2)+1];
-	    end
-	    else begin: fi
-	      assign mask_o[i] = mask_o[(i-2)/2] & way_id_i[lg_ways_lp-`BSG_SAFE_CLOG2(i+2)+1];
-	    end
+    else begin: lru
+    for(i=0; i<ways_p-1; i++) begin: rof
+      // Mask generation
+	  if(i == 0) begin: fi
+	    assign mask_o[i] = 1'b1;
+	  end
+	  else if(i%2 == 1) begin: fi
+	    assign mask_o[i] = mask_o[(i-1)/2] & ~way_id_i[lg_ways_lp-`BSG_SAFE_CLOG2(i+2)+1];
+	  end
+	  else begin: fi
+	    assign mask_o[i] = mask_o[(i-2)/2] & way_id_i[lg_ways_lp-`BSG_SAFE_CLOG2(i+2)+1];
+	  end
 	  
-	    // Data generation
-	    assign data_o[i] = mask_o[i] & ~way_id_i[lg_ways_lp-`BSG_SAFE_CLOG2(i+2)];
-      end
+	  // Data generation
+	  assign data_o[i] = mask_o[i] & ~way_id_i[lg_ways_lp-`BSG_SAFE_CLOG2(i+2)];
+    end
     end
   endgenerate
 

--- a/bsg_misc/bsg_lru_pseudo_tree_encode.v
+++ b/bsg_misc/bsg_lru_pseudo_tree_encode.v
@@ -41,28 +41,28 @@ module bsg_lru_pseudo_tree_encode
     assign way_id_o = 1'b0;
   end
   else begin: lru
-    for (genvar i = 0; i < lg_ways_lp; i++) begin: rank
+  for (genvar i = 0; i < lg_ways_lp; i++) begin: rank
 
-      if (i == 0) begin: z
+    if (i == 0) begin: z
 
-        // top way_id_o bit is just the lowest LRU bit
-        assign way_id_o[lg_ways_lp-1] = lru_i[0];  // root
+      // top way_id_o bit is just the lowest LRU bit
+      assign way_id_o[lg_ways_lp-1] = lru_i[0];  // root
 
-      end
-      else begin: nz
-        // each output way_id_o bit uses *all* of the way_id_o bits above it in the way_id_o vector
-        // as the select to a mux which has as input an exponentially growing (2^i) collection of unique LRU bits
-        bsg_mux #(
-          .width_p(1)
-          ,.els_p(2**i)
-        ) mux (
-          .data_i(lru_i[((2**i)-1)+:(2**i)])
-          ,.sel_i(way_id_o[lg_ways_lp-1-:i])
-          ,.data_o(way_id_o[lg_ways_lp-1-i])
-        );
-
-      end
     end
+    else begin: nz
+      // each output way_id_o bit uses *all* of the way_id_o bits above it in the way_id_o vector
+      // as the select to a mux which has as input an exponentially growing (2^i) collection of unique LRU bits
+      bsg_mux #(
+        .width_p(1)
+        ,.els_p(2**i)
+      ) mux (
+        .data_i(lru_i[((2**i)-1)+:(2**i)])
+        ,.sel_i(way_id_o[lg_ways_lp-1-:i])
+        ,.data_o(way_id_o[lg_ways_lp-1-i])
+      );
+
+    end
+  end
   end
 
 

--- a/bsg_misc/bsg_lru_pseudo_tree_encode.v
+++ b/bsg_misc/bsg_lru_pseudo_tree_encode.v
@@ -33,31 +33,35 @@ module bsg_lru_pseudo_tree_encode
     , parameter lg_ways_lp = `BSG_SAFE_CLOG2(ways_p)
   )
   (
-    input [ways_p-2:0] lru_i
+    input [`BSG_SAFE_MINUS(ways_p, 2):0] lru_i
     , output logic [lg_ways_lp-1:0] way_id_o
   );
 
+  if (ways_p == 1) begin: no_lru
+    assign way_id_o = 1'b0;
+  end
+  else begin: lru
+    for (genvar i = 0; i < lg_ways_lp; i++) begin: rank
 
-  for (genvar i = 0; i < lg_ways_lp; i++) begin: rank
+      if (i == 0) begin: z
 
-    if (i == 0) begin: z
+        // top way_id_o bit is just the lowest LRU bit
+        assign way_id_o[lg_ways_lp-1] = lru_i[0];  // root
 
-      // top way_id_o bit is just the lowest LRU bit
-      assign way_id_o[lg_ways_lp-1] = lru_i[0];  // root
+      end
+      else begin: nz
+        // each output way_id_o bit uses *all* of the way_id_o bits above it in the way_id_o vector
+        // as the select to a mux which has as input an exponentially growing (2^i) collection of unique LRU bits
+        bsg_mux #(
+          .width_p(1)
+          ,.els_p(2**i)
+        ) mux (
+          .data_i(lru_i[((2**i)-1)+:(2**i)])
+          ,.sel_i(way_id_o[lg_ways_lp-1-:i])
+          ,.data_o(way_id_o[lg_ways_lp-1-i])
+        );
 
-    end
-    else begin: nz
-      // each output way_id_o bit uses *all* of the way_id_o bits above it in the way_id_o vector
-      // as the select to a mux which has as input an exponentially growing (2^i) collection of unique LRU bits
-      bsg_mux #(
-        .width_p(1)
-        ,.els_p(2**i)
-      ) mux (
-        .data_i(lru_i[((2**i)-1)+:(2**i)])
-        ,.sel_i(way_id_o[lg_ways_lp-1-:i])
-        ,.data_o(way_id_o[lg_ways_lp-1-i])
-      );
-
+      end
     end
   end
 


### PR DESCRIPTION
This PR adds a new macro to bsg_defines called BSG_SAFE_MINUS. This macro can be used to handle corner cases where widths tend to become negative (Although this is allowed in SV it might not be desirable). 

This macro is used in the Pseudo-LRU modules to handle the case where the number of ways = 1 (i.e direct-mapped)