### PR TITLE
BSG SAFE MINUS and Zero Width Support for Memories

### DIFF
--- a/bsg_mem/bsg_mem_1r1w.v
+++ b/bsg_mem/bsg_mem_1r1w.v
@@ -18,13 +18,13 @@ module bsg_mem_1r1w #(parameter width_p=-1
 
     , input                     w_v_i
     , input [addr_width_lp-1:0] w_addr_i
-    , input [width_p-1:0]       w_data_i
+    , input [`BSG_SAFE_MINUS(width_p, 1):0]       w_data_i
 
     // currently unused
     , input                      r_v_i
     , input [addr_width_lp-1:0]  r_addr_i
 
-    , output logic [width_p-1:0] r_data_o
+    , output logic [`BSG_SAFE_MINUS(width_p, 1):0] r_data_o
     );
 
    bsg_mem_1r1w_synth

--- a/bsg_mem/bsg_mem_1r1w_sync.v
+++ b/bsg_mem/bsg_mem_1r1w_sync.v
@@ -25,13 +25,13 @@ module bsg_mem_1r1w_sync #(parameter width_p=-1
 
     , input                     w_v_i
     , input [addr_width_lp-1:0] w_addr_i
-    , input [width_p-1:0]       w_data_i
+    , input [`BSG_SAFE_MINUS(width_p, 1):0]       w_data_i
 
     // currently unused
     , input                      r_v_i
     , input [addr_width_lp-1:0]  r_addr_i
 
-    , output logic [width_p-1:0] r_data_o
+    , output logic [`BSG_SAFE_MINUS(width_p, 1):0] r_data_o
     );
 
    wire clk_lo;

--- a/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit.v
+++ b/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit.v
@@ -22,14 +22,14 @@ module bsg_mem_1r1w_sync_mask_write_bit #(parameter width_p=-1
     , input reset_i
 
     , input                     w_v_i
-    , input [width_p-1:0]       w_mask_i
+    , input [`BSG_SAFE_MINUS(width_p, 1):0]       w_mask_i
     , input [addr_width_lp-1:0] w_addr_i
-    , input [width_p-1:0]       w_data_i
+    , input [`BSG_SAFE_MINUS(width_p, 1):0]       w_data_i
 
     , input                      r_v_i
     , input [addr_width_lp-1:0]  r_addr_i
 
-    , output logic [width_p-1:0] r_data_o
+    , output logic [`BSG_SAFE_MINUS(width_p, 1):0] r_data_o
     );
 
    wire clk_lo;

--- a/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit_synth.v
+++ b/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit_synth.v
@@ -35,18 +35,12 @@ module bsg_mem_1r1w_sync_mask_write_bit_synth #(parameter width_p=-1
    wire                   unused = reset_i;
 
    if (width_p == 0)
-    begin: zero_width
-      wire unused0 = clk_i;
-      wire unused1 = w_v_i;
-      wire unused2 = w_mask_i;
-      wire [addr_width_lp-1:0] unused3 = w_addr_i;
-      wire unused4 = r_v_i;
-      wire [addr_width_lp-1:0] unused5 = r_addr_i;
-
+    begin: z
+      wire unused0 = &{clk_i, w_v_i, w_mask_i, w_addr_i, r_v_i, r_addr_i};
       assign r_data_o = '0;
     end
    else
-    begin: non_zero_width
+    begin: nz
 
    logic [width_p-1:0]    mem [els_p-1:0];
 

--- a/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit_synth.v
+++ b/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit_synth.v
@@ -21,20 +21,34 @@ module bsg_mem_1r1w_sync_mask_write_bit_synth #(parameter width_p=-1
     , input reset_i
 
     , input                     w_v_i
-    , input [width_p-1:0]       w_mask_i
+    , input [`BSG_SAFE_MINUS(width_p, 1):0]       w_mask_i
     , input [addr_width_lp-1:0] w_addr_i
-    , input [width_p-1:0]       w_data_i
+    , input [`BSG_SAFE_MINUS(width_p, 1):0]       w_data_i
 
     // currently unused
     , input                      r_v_i
     , input [addr_width_lp-1:0]  r_addr_i
 
-    , output logic [width_p-1:0] r_data_o
+    , output logic [`BSG_SAFE_MINUS(width_p, 1):0] r_data_o
     );
 
-   logic [width_p-1:0]    mem [els_p-1:0];
-
    wire                   unused = reset_i;
+
+   if (width_p == 0)
+    begin: zero_width
+      wire unused0 = clk_i;
+      wire unused1 = w_v_i;
+      wire unused2 = w_mask_i;
+      wire [addr_width_lp-1:0] unused3 = w_addr_i;
+      wire unused4 = r_v_i;
+      wire [addr_width_lp-1:0] unused5 = r_addr_i;
+
+      assign r_data_o = '0;
+    end
+   else
+    begin: non_zero_width
+
+   logic [width_p-1:0]    mem [els_p-1:0];
 
    // this treats the ram as an array of registers for which the
    // read addr is latched on the clock, the write
@@ -91,5 +105,5 @@ module bsg_mem_1r1w_sync_mask_write_bit_synth #(parameter width_p=-1
 	  if (w_v_i && w_mask_i[i])
             mem[w_addr_i][i] <= w_data_i[i];
      end
-
+  end
 endmodule

--- a/bsg_mem/bsg_mem_1r1w_sync_synth.v
+++ b/bsg_mem/bsg_mem_1r1w_sync_synth.v
@@ -25,18 +25,31 @@ module bsg_mem_1r1w_sync_synth #(parameter width_p=-1
 
     , input                     w_v_i
     , input [addr_width_lp-1:0] w_addr_i
-    , input [width_p-1:0]       w_data_i
+    , input [`BSG_SAFE_MINUS(width_p, 1):0]       w_data_i
 
     // currently unused
     , input                      r_v_i
     , input [addr_width_lp-1:0]  r_addr_i
 
-    , output logic [width_p-1:0] r_data_o
+    , output logic [`BSG_SAFE_MINUS(width_p, 1):0] r_data_o
     );
 
-   logic [width_p-1:0]    mem [els_p-1:0];
-
    wire                   unused = reset_i;
+
+   if (width_p == 0)
+    begin: zero_width
+      wire unused0 = clk_i;
+      wire unused1 = w_v_i;
+      wire [addr_width_lp-1:0] unused2 = w_addr_i;
+      wire unused3 = r_v_i;
+      wire [addr_width_lp-1:0] unused4 = r_addr_i;
+
+      assign r_data_o = '0;
+    end
+   else
+    begin: non_zero_width
+
+   logic [width_p-1:0]    mem [els_p-1:0];
 
    // this treats the ram as an array of registers for which the
    // read addr is latched on the clock, the write
@@ -71,4 +84,5 @@ module bsg_mem_1r1w_sync_synth #(parameter width_p=-1
      if (w_v_i)
        mem[w_addr_i] <= w_data_i;
 
+   end
 endmodule

--- a/bsg_mem/bsg_mem_1r1w_sync_synth.v
+++ b/bsg_mem/bsg_mem_1r1w_sync_synth.v
@@ -37,17 +37,12 @@ module bsg_mem_1r1w_sync_synth #(parameter width_p=-1
    wire                   unused = reset_i;
 
    if (width_p == 0)
-    begin: zero_width
-      wire unused0 = clk_i;
-      wire unused1 = w_v_i;
-      wire [addr_width_lp-1:0] unused2 = w_addr_i;
-      wire unused3 = r_v_i;
-      wire [addr_width_lp-1:0] unused4 = r_addr_i;
-
+    begin: z
+      wire unused0 = &{clk_i, w_v_i, w_addr_i, r_v_i, r_addr_i};
       assign r_data_o = '0;
     end
    else
-    begin: non_zero_width
+    begin: nz
 
    logic [width_p-1:0]    mem [els_p-1:0];
 

--- a/bsg_mem/bsg_mem_1r1w_synth.v
+++ b/bsg_mem/bsg_mem_1r1w_synth.v
@@ -21,19 +21,32 @@ module bsg_mem_1r1w_synth #(parameter width_p=-1
 
   ,input w_v_i
   ,input [addr_width_lp-1:0] w_addr_i
-  ,input [width_p-1:0] w_data_i
+  ,input [`BSG_SAFE_MINUS(width_p, 1):0] w_data_i
 
   // currently unused
   ,input r_v_i
   ,input [addr_width_lp-1:0]  r_addr_i
 
-  ,output logic [width_p-1:0] r_data_o
+  ,output logic [`BSG_SAFE_MINUS(width_p, 1):0] r_data_o
 );
-
-  logic [width_p-1:0] mem [els_p-1:0];
 
   wire unused0 = w_reset_i;
   wire unused1 = r_v_i;
+
+  if (width_p == 0)
+   begin: zero_width
+     wire unused2 = clk_i;
+     wire [addr_width_lp-1:0] unused3 = w_addr_i;
+     wire unused4 = w_data_i;
+     wire [addr_width_lp-1:0] unused5 = r_addr_i;
+
+     assign r_data_o = '0;
+   end
+  else
+   begin: non_zero_width
+
+  logic [width_p-1:0] mem [els_p-1:0];
+
 
   // this implementation ignores the r_v_i
   assign r_data_o = mem[r_addr_i];
@@ -43,5 +56,5 @@ module bsg_mem_1r1w_synth #(parameter width_p=-1
       mem[w_addr_i] <= w_data_i;
     end
   end
-
+   end
 endmodule

--- a/bsg_mem/bsg_mem_1r1w_synth.v
+++ b/bsg_mem/bsg_mem_1r1w_synth.v
@@ -35,7 +35,7 @@ module bsg_mem_1r1w_synth #(parameter width_p=-1
 
   if (width_p == 0)
    begin: zero_width
-     wire unused2 = clk_i;
+     wire unused2 = w_clk_i;
      wire [addr_width_lp-1:0] unused3 = w_addr_i;
      wire unused4 = w_data_i;
      wire [addr_width_lp-1:0] unused5 = r_addr_i;

--- a/bsg_mem/bsg_mem_1r1w_synth.v
+++ b/bsg_mem/bsg_mem_1r1w_synth.v
@@ -34,16 +34,12 @@ module bsg_mem_1r1w_synth #(parameter width_p=-1
   wire unused1 = r_v_i;
 
   if (width_p == 0)
-   begin: zero_width
-     wire unused2 = w_clk_i;
-     wire [addr_width_lp-1:0] unused3 = w_addr_i;
-     wire unused4 = w_data_i;
-     wire [addr_width_lp-1:0] unused5 = r_addr_i;
-
+   begin: z
+     wire unused2 = &{w_clk_i, w_addr_i, w_data_i, r_addr_i};
      assign r_data_o = '0;
    end
   else
-   begin: non_zero_width
+   begin: nz
 
   logic [width_p-1:0] mem [els_p-1:0];
 

--- a/bsg_mem/bsg_mem_1rw_sync.v
+++ b/bsg_mem/bsg_mem_1rw_sync.v
@@ -14,11 +14,11 @@ module bsg_mem_1rw_sync #(parameter width_p=-1
                           )
    (input   clk_i
     , input reset_i
-    , input [width_p-1:0] data_i
+    , input [`BSG_SAFE_MINUS(width_p, 1):0] data_i
     , input [addr_width_lp-1:0] addr_i
     , input v_i
     , input w_i
-    , output logic [width_p-1:0]  data_o
+    , output logic [`BSG_SAFE_MINUS(width_p, 1):0]  data_o
     );
 
    wire clk_lo;

--- a/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.v
+++ b/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.v
@@ -13,12 +13,12 @@ module bsg_mem_1rw_sync_mask_write_bit #(
   , parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
 ) (input   clk_i
     , input reset_i
-    , input [width_p-1:0] data_i
+    , input [`BSG_SAFE_MINUS(width_p, 1):0] data_i
     , input [addr_width_lp-1:0] addr_i
     , input v_i
-    , input [width_p-1:0] w_mask_i
+    , input [`BSG_SAFE_MINUS(width_p, 1):0] w_mask_i
     , input w_i
-    , output [width_p-1:0]  data_o
+    , output [`BSG_SAFE_MINUS(width_p, 1):0]  data_o
 );
 
    wire clk_lo;

--- a/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_synth.v
+++ b/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_synth.v
@@ -17,15 +17,29 @@ module bsg_mem_1rw_sync_mask_write_bit_synth
    )
    (input   clk_i
     , input reset_i
-    , input [width_p-1:0] data_i
+    , input [`BSG_SAFE_MINUS(width_p, 1):0] data_i
     , input [addr_width_lp-1:0] addr_i
     , input v_i
-    , input [width_p-1:0] w_mask_i
+    , input [`BSG_SAFE_MINUS(width_p, 1):0] w_mask_i
     , input w_i
-    , output logic [width_p-1:0]  data_o
+    , output logic [`BSG_SAFE_MINUS(width_p, 1):0]  data_o
     );
 
    wire unused = reset_i;
+
+   if (width_p == 0)
+    begin: zero_width
+      wire unused0 = clk_i;
+      wire unused1 = data_i;
+      wire unused2 = addr_i;
+      wire unused3 = v_i;
+      wire unused4 = w_mask_i;
+      wire unused5 = w_i;
+
+      assign data_o = '0;
+    end
+   else
+    begin: non_zero_width
 
    logic [addr_width_lp-1:0] addr_r;
    logic [width_p-1:0] mem [els_p-1:0];
@@ -95,5 +109,5 @@ module bsg_mem_1rw_sync_mask_write_bit_synth
          if (w_mask_i[i])
            mem[addr_i][i] <= data_i[i];
 `endif
-
+   end
 endmodule

--- a/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_synth.v
+++ b/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_synth.v
@@ -28,18 +28,12 @@ module bsg_mem_1rw_sync_mask_write_bit_synth
    wire unused = reset_i;
 
    if (width_p == 0)
-    begin: zero_width
-      wire unused0 = clk_i;
-      wire unused1 = data_i;
-      wire unused2 = addr_i;
-      wire unused3 = v_i;
-      wire unused4 = w_mask_i;
-      wire unused5 = w_i;
-
+    begin: z
+      wire unused0 = &{clk_i, data_i, addr_i, v_i, w_mask_i, w_i};
       assign data_o = '0;
     end
    else
-    begin: non_zero_width
+    begin: nz
 
    logic [addr_width_lp-1:0] addr_r;
    logic [width_p-1:0] mem [els_p-1:0];

--- a/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v
+++ b/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v
@@ -15,11 +15,11 @@ module bsg_mem_1rw_sync_mask_write_byte #( parameter els_p = -1
    ,input w_i
 
    ,input [addr_width_lp-1:0]       addr_i
-   ,input [data_width_p-1:0]        data_i
+   ,input [`BSG_SAFE_MINUS(data_width_p, 1):0]        data_i
     // for each bit set in the mask, a byte is written
-   ,input [write_mask_width_lp-1:0] write_mask_i
+   ,input [`BSG_SAFE_MINUS(write_mask_width_lp, 1):0] write_mask_i
 
-   ,output logic [data_width_p-1:0] data_o
+   ,output logic [`BSG_SAFE_MINUS(data_width_p, 1):0] data_o
   );
 
    wire clk_lo;

--- a/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_synth.v
+++ b/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_synth.v
@@ -18,14 +18,29 @@ module bsg_mem_1rw_sync_mask_write_byte_synth
    ,input w_i
 
    ,input [addr_width_lp-1:0]       addr_i
-   ,input [data_width_p-1:0]        data_i
+   ,input [`BSG_SAFE_MINUS(data_width_p, 1):0]        data_i
     // for each bit set in the mask, a byte is written
-   ,input [write_mask_width_lp-1:0] write_mask_i
+   ,input [`BSG_SAFE_MINUS(write_mask_width_lp, 1):0] write_mask_i
 
-   ,output [data_width_p-1:0] data_o
+   ,output [`BSG_SAFE_MINUS(data_width_p, 1):0] data_o
   );
 
   genvar i;
+
+  if (data_width_p == 0)
+   begin: zero_width
+     wire unused0 = clk_i;
+     wire unused1 = reset_i;
+     wire unused2 = v_i;
+     wire unused3 = w_i;
+     wire [addr_width_lp-1:0] unused4 = addr_i;
+     wire unused4 = data_i;
+     wire unused5 = write_mask_i;
+
+     assign data_o = '0;
+   end
+  else
+   begin: non_zero_width
 
   for(i=0; i<write_mask_width_lp; i=i+1)
   begin: bk
@@ -43,5 +58,6 @@ module bsg_mem_1rw_sync_mask_write_byte_synth
                        ,.data_o (data_o[(i*8)+:8])
                       );
   end
+   end
 
 endmodule

--- a/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_synth.v
+++ b/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_synth.v
@@ -28,19 +28,12 @@ module bsg_mem_1rw_sync_mask_write_byte_synth
   genvar i;
 
   if (data_width_p == 0)
-   begin: zero_width
-     wire unused0 = clk_i;
-     wire unused1 = reset_i;
-     wire unused2 = v_i;
-     wire unused3 = w_i;
-     wire [addr_width_lp-1:0] unused4 = addr_i;
-     wire unused4 = data_i;
-     wire unused5 = write_mask_i;
-
+   begin: z
+     wire unused0 = &{clk_i, reset_i, v_i, w_i, addr_i, data_i, write_mask_i};
      assign data_o = '0;
    end
   else
-   begin: non_zero_width
+   begin: nz
 
   for(i=0; i<write_mask_width_lp; i=i+1)
   begin: bk

--- a/bsg_mem/bsg_mem_1rw_sync_synth.v
+++ b/bsg_mem/bsg_mem_1rw_sync_synth.v
@@ -17,13 +17,26 @@ module bsg_mem_1rw_sync_synth
    (input   clk_i
 	 	, input v_i
 		, input reset_i
-    , input [width_p-1:0] data_i
+    , input [`BSG_SAFE_MINUS(width_p, 1):0] data_i
     , input [addr_width_lp-1:0] addr_i
     , input w_i
-    , output logic [width_p-1:0]  data_o
+    , output logic [`BSG_SAFE_MINUS(width_p, 1):0]  data_o
     );
 
   wire unused = reset_i;
+
+  if (width_p == 0)
+   begin: zero_width
+     wire unused0 = clk_i;
+     wire unused1 = v_i;
+     wire unused2 = data_i;
+     wire [addr_width_lp-1:0] unused3 = addr_i;
+     wire unused4 = w_i;
+
+     assign data_o = '0;
+   end
+  else
+   begin: non_zero_width
 
   logic [addr_width_lp-1:0] addr_r;
   logic [width_p-1:0]    mem [els_p-1:0];
@@ -70,7 +83,7 @@ module bsg_mem_1rw_sync_synth
     if (v_i & w_i) 
       mem[addr_i] <= data_i;
 
-
+   end // non_zero_width
    // synopsys translate_off
    initial
      begin

--- a/bsg_mem/bsg_mem_1rw_sync_synth.v
+++ b/bsg_mem/bsg_mem_1rw_sync_synth.v
@@ -26,17 +26,12 @@ module bsg_mem_1rw_sync_synth
   wire unused = reset_i;
 
   if (width_p == 0)
-   begin: zero_width
-     wire unused0 = clk_i;
-     wire unused1 = v_i;
-     wire unused2 = data_i;
-     wire [addr_width_lp-1:0] unused3 = addr_i;
-     wire unused4 = w_i;
-
+   begin: z
+     wire unused0 = &{clk_i, v_i, data_i, addr_i, w_i};
      assign data_o = '0;
    end
   else
-   begin: non_zero_width
+   begin: nz
 
   logic [addr_width_lp-1:0] addr_r;
   logic [width_p-1:0]    mem [els_p-1:0];

--- a/bsg_mem/bsg_mem_2r1w.v
+++ b/bsg_mem/bsg_mem_2r1w.v
@@ -17,15 +17,15 @@ module bsg_mem_2r1w #(parameter width_p=-1
 
     , input                     w_v_i
     , input [addr_width_lp-1:0] w_addr_i
-    , input [width_p-1:0]       w_data_i
+    , input [`BSG_SAFE_MINUS(width_p, 1):0]       w_data_i
 
     , input                      r0_v_i
     , input [addr_width_lp-1:0]  r0_addr_i
-    , output logic [width_p-1:0] r0_data_o
+    , output logic [`BSG_SAFE_MINUS(width_p, 1):0] r0_data_o
 
     , input                      r1_v_i
     , input [addr_width_lp-1:0]  r1_addr_i
-    , output logic [width_p-1:0] r1_data_o
+    , output logic [`BSG_SAFE_MINUS(width_p, 1):0] r1_data_o
 
     );
 

--- a/bsg_mem/bsg_mem_2r1w_sync.v
+++ b/bsg_mem/bsg_mem_2r1w_sync.v
@@ -24,16 +24,16 @@ module bsg_mem_2r1w_sync #(parameter width_p=-1
 
     , input                     w_v_i
     , input [addr_width_lp-1:0] w_addr_i
-    , input [width_p-1:0]       w_data_i
+    , input [`BSG_SAFE_MINUS(width_p, 1):0]       w_data_i
 
     // currently unused
     , input                      r0_v_i
     , input [addr_width_lp-1:0]  r0_addr_i
-    , output logic [width_p-1:0] r0_data_o
+    , output logic [`BSG_SAFE_MINUS(width_p, 1):0] r0_data_o
 
     , input                      r1_v_i
     , input [addr_width_lp-1:0]  r1_addr_i
-    , output logic [width_p-1:0] r1_data_o
+    , output logic [`BSG_SAFE_MINUS(width_p, 1):0] r1_data_o
     );
 
    wire clk_lo;

--- a/bsg_mem/bsg_mem_2r1w_sync_synth.v
+++ b/bsg_mem/bsg_mem_2r1w_sync_synth.v
@@ -40,21 +40,13 @@ module bsg_mem_2r1w_sync_synth #(parameter width_p=-1
    wire                   unused = reset_i;
 
    if (width_p == 0)
-    begin: zero_width
-      wire unused0 = clk_i;
-      wire unused1 = w_v_i;
-      wire [addr_width_lp-1:0] unused2 = w_addr_i;
-      wire unused3 = w_data_i;
-      wire unused4 = r0_v_i;
-      wire [addr_width_lp-1:0] unused5 = r0_addr_i;
-      wire unused6 = r1_v_i;
-      wire [addr_width_lp-1:0] unused7 = r1_addr_i;
-
+    begin: z
+      wire unused0 = &{clk_i, w_v_i, w_addr_i, w_data_i, r0_v_i, r0_addr_i, r1_v_i, r1_addr_i};
       assign r0_data_o = '0;
       assign r1_data_o = '0;
     end
    else
-    begin: non_zero_width
+    begin: nz
 
    logic [width_p-1:0]    mem [els_p-1:0];
 

--- a/bsg_mem/bsg_mem_2r1w_sync_synth.v
+++ b/bsg_mem/bsg_mem_2r1w_sync_synth.v
@@ -25,21 +25,38 @@ module bsg_mem_2r1w_sync_synth #(parameter width_p=-1
 
     , input                     w_v_i
     , input [addr_width_lp-1:0] w_addr_i
-    , input [width_p-1:0]       w_data_i
+    , input [`BSG_SAFE_MINUS(width_p, 1):0]       w_data_i
 
     // currently unused
     , input                      r0_v_i
     , input [addr_width_lp-1:0]  r0_addr_i
-    , output logic [width_p-1:0] r0_data_o
+    , output logic [`BSG_SAFE_MINUS(width_p, 1):0] r0_data_o
 
     , input                      r1_v_i
     , input [addr_width_lp-1:0]  r1_addr_i
-    , output logic [width_p-1:0] r1_data_o
+    , output logic [`BSG_SAFE_MINUS(width_p, 1):0] r1_data_o
     );
 
-   logic [width_p-1:0]    mem [els_p-1:0];
-
    wire                   unused = reset_i;
+
+   if (width_p == 0)
+    begin: zero_width
+      wire unused0 = clk_i;
+      wire unused1 = w_v_i;
+      wire [addr_width_lp-1:0] unused2 = w_addr_i;
+      wire unused3 = w_data_i;
+      wire unused4 = r0_v_i;
+      wire [addr_width_lp-1:0] unused5 = r0_addr_i;
+      wire unused6 = r1_v_i;
+      wire [addr_width_lp-1:0] unused7 = r1_addr_i;
+
+      assign r0_data_o = '0;
+      assign r1_data_o = '0;
+    end
+   else
+    begin: non_zero_width
+
+   logic [width_p-1:0]    mem [els_p-1:0];
 
    // keep consistent with bsg_ip_cores/bsg_mem/bsg_mem_2r1w_sync.v
    // keep consistent with bsg_ip_cores/hard/bsg_mem/bsg_mem_2r1w_sync.v
@@ -86,4 +103,5 @@ module bsg_mem_2r1w_sync_synth #(parameter width_p=-1
      if (w_v_i)
        mem[w_addr_i] <= w_data_i;
 
+   end
 endmodule

--- a/bsg_mem/bsg_mem_2r1w_synth.v
+++ b/bsg_mem/bsg_mem_2r1w_synth.v
@@ -35,21 +35,13 @@ module bsg_mem_2r1w_synth #(parameter width_p=-1
    wire                   unused = w_reset_i;
 
    if (width_p == 0)
-    begin: zero_width
-      wire unused0 = w_clk_i;
-      wire unused1 = w_v_i;
-      wire [addr_width_lp-1:0] unused2 = w_addr_i;
-      wire unused3 = w_data_i;
-      wire unused4 = r0_v_i;
-      wire [addr_width_lp-1:0] unused5 = r0_addr_i;
-      wire unused6 = r1_v_i;
-      wire [addr_width_lp-1:0] unused7 = r1_addr_i;
-
+    begin: z
+      wire unused0 = &{w_clk_i, w_v_i, w_addr_i, w_data_i, r0_v_i, r0_addr_i, r1_v_i, r1_addr_i};
       assign r0_data_o = '0;
       assign r1_data_o = '0;
     end
    else
-    begin: non_zero_width
+    begin: nz
 
    logic [width_p-1:0]    mem [els_p-1:0];
 

--- a/bsg_mem/bsg_mem_2r1w_synth.v
+++ b/bsg_mem/bsg_mem_2r1w_synth.v
@@ -20,17 +20,36 @@ module bsg_mem_2r1w_synth #(parameter width_p=-1
 
     , input                     w_v_i
     , input [addr_width_lp-1:0] w_addr_i
-    , input [width_p-1:0]       w_data_i
+    , input [`BSG_SAFE_MINUS(width_p, 1):0]       w_data_i
 
     , input                      r0_v_i
     , input [addr_width_lp-1:0]  r0_addr_i
-    , output logic [width_p-1:0] r0_data_o
+    , output logic [`BSG_SAFE_MINUS(width_p, 1):0] r0_data_o
 
     , input                      r1_v_i
     , input [addr_width_lp-1:0]  r1_addr_i
-    , output logic [width_p-1:0] r1_data_o
+    , output logic [`BSG_SAFE_MINUS(width_p, 1):0] r1_data_o
 
     );
+
+   wire                   unused = w_reset_i;
+
+   if (width_p == 0)
+    begin: zero_width
+      wire unused0 = w_clk_i;
+      wire unused1 = w_v_i;
+      wire [addr_width_lp-1:0] unused2 = w_addr_i;
+      wire unused3 = w_data_i;
+      wire unused4 = r0_v_i;
+      wire [addr_width_lp-1:0] unused5 = r0_addr_i;
+      wire unused6 = r1_v_i;
+      wire [addr_width_lp-1:0] unused7 = r1_addr_i;
+
+      assign r0_data_o = '0;
+      assign r1_data_o = '0;
+    end
+   else
+    begin: non_zero_width
 
    logic [width_p-1:0]    mem [els_p-1:0];
 
@@ -38,12 +57,10 @@ module bsg_mem_2r1w_synth #(parameter width_p=-1
    assign r1_data_o = mem[r1_addr_i];
    assign r0_data_o = mem[r0_addr_i];
 
-   wire                   unused = w_reset_i;
-
    always_ff @(posedge w_clk_i)
      if (w_v_i)
        begin
           mem[w_addr_i] <= w_data_i;
        end
-
+   end
 endmodule

--- a/bsg_mem/bsg_mem_3r1w.v
+++ b/bsg_mem/bsg_mem_3r1w.v
@@ -21,30 +21,28 @@ module bsg_mem_3r1w #(parameter width_p=-1
 
     , input                      r0_v_i
     , input [addr_width_lp-1:0]  r0_addr_i
-    , output logic [width_p-1:0] r0_data_o
+    , output logic [`BSG_SAFE_MINUS(width_p, 1):0] r0_data_o
 
     , input                      r1_v_i
     , input [addr_width_lp-1:0]  r1_addr_i
-    , output logic [width_p-1:0] r1_data_o
+    , output logic [`BSG_SAFE_MINUS(width_p, 1):0] r1_data_o
 
     , input                      r2_v_i
     , input [addr_width_lp-1:0]  r2_addr_i
-    , output logic [width_p-1:0] r2_data_o
+    , output logic [`BSG_SAFE_MINUS(width_p, 1):0] r2_data_o
     );
 
-   logic [width_p-1:0]    mem [els_p-1:0];
+   bsg_mem_3r1w_synth
+    #(.width_p(width_p)
+     ,.els_p(els_p)
+     ,.read_write_same_addr_p(read_write_same_addr_p)
+     ) synth
+    (.*);
 
-   // this implementation ignores the r_v_i
-   assign r2_data_o = mem[r2_addr_i];
-   assign r1_data_o = mem[r1_addr_i];
-   assign r0_data_o = mem[r0_addr_i];
-
-   wire                   unused = w_reset_i;
-
+//synopsys translate_off
    always_ff @(negedge w_clk_i)
      if (w_v_i)
        begin
-//synopsys translate_off
           assert (w_addr_i < els_p)
             else $error("Invalid address %x to %m of size %x\n", w_addr_i, els_p);
 
@@ -56,16 +54,13 @@ module bsg_mem_3r1w #(parameter width_p=-1
 
           assert (!(r2_addr_i == w_addr_i && r2_v_i && !read_write_same_addr_p))
             else $error("%m: Attempt to read and write same address");
-//synopsys translate_on
 
-          mem[w_addr_i] <= w_data_i;
        end
-
 
    initial
      begin
         $display("## bsg_mem_3r1w: instantiating width_p=%d, els_p=%d, read_write_same_addr_p=%d (%m)",width_p,els_p,read_write_same_addr_p);
      end
-
+//synopsys translate_on
 
 endmodule

--- a/bsg_mem/bsg_mem_3r1w_sync.v
+++ b/bsg_mem/bsg_mem_3r1w_sync.v
@@ -30,15 +30,15 @@ module bsg_mem_3r1w_sync #(parameter width_p=-1
     // currently unused
     , input                      r0_v_i
     , input [addr_width_lp-1:0]  r0_addr_i
-    , output logic [width_p-1:0] r0_data_o
+    , output logic [`BSG_SAFE_MINUS(width_p, 1):0] r0_data_o
 
     , input                      r1_v_i
     , input [addr_width_lp-1:0]  r1_addr_i
-    , output logic [width_p-1:0] r1_data_o
+    , output logic [`BSG_SAFE_MINUS(width_p, 1):0] r1_data_o
 
     , input                      r2_v_i
     , input [addr_width_lp-1:0]  r2_addr_i
-    , output logic [width_p-1:0] r2_data_o
+    , output logic [`BSG_SAFE_MINUS(width_p, 1):0] r2_data_o
     );
 
    wire clk_lo;

--- a/bsg_mem/bsg_mem_3r1w_sync_synth.v
+++ b/bsg_mem/bsg_mem_3r1w_sync_synth.v
@@ -26,25 +26,45 @@ module bsg_mem_3r1w_sync_synth #(parameter width_p=-1
 
     , input                     w_v_i
     , input [addr_width_lp-1:0] w_addr_i
-    , input [width_p-1:0]       w_data_i
+    , input [`BSG_SAFE_MINUS(width_p, 1):0]       w_data_i
 
     // currently unused
     , input                      r0_v_i
     , input [addr_width_lp-1:0]  r0_addr_i
-    , output logic [width_p-1:0] r0_data_o
+    , output logic [`BSG_SAFE_MINUS(width_p, 1):0] r0_data_o
 
     , input                      r1_v_i
     , input [addr_width_lp-1:0]  r1_addr_i
-    , output logic [width_p-1:0] r1_data_o
+    , output logic [`BSG_SAFE_MINUS(width_p, 1):0] r1_data_o
 
     , input                      r2_v_i
     , input [addr_width_lp-1:0]  r2_addr_i
-    , output logic [width_p-1:0] r2_data_o
+    , output logic [`BSG_SAFE_MINUS(width_p, 1):0] r2_data_o
     );
 
-   logic [width_p-1:0]    mem [els_p-1:0];
-
    wire                   unused = reset_i;
+
+   if (width_p == 0)
+    begin: zero_width
+      wire unused0 = clk_i;
+      wire unused1 = w_v_i;
+      wire [addr_width_lp-1:0] unused2 = w_addr_i;
+      wire unused3 = w_data_i;
+      wire unused4 = r0_v_i;
+      wire [addr_width_lp-1:0] unused5 = r0_addr_i;
+      wire unused6 = r1_v_i;
+      wire [addr_width_lp-1:0] unused7 = r1_addr_i;
+      wire unused8 = r2_v_i;
+      wire [addr_width_lp-1:0] unused9 = r2_addr_i;
+
+      assign r0_data_o = '0;
+      assign r1_data_o = '0;
+      assign r2_data_o = '0;
+    end
+   else
+    begin: non_zero_width
+
+   logic [width_p-1:0]    mem [els_p-1:0];
 
    // keep consistent with bsg_ip_cores/bsg_mem/bsg_mem_3r1w_sync.v
    // keep consistent with bsg_ip_cores/hard/bsg_mem/bsg_mem_3r1w_sync.v
@@ -98,4 +118,5 @@ module bsg_mem_3r1w_sync_synth #(parameter width_p=-1
      if (w_v_i)
        mem[w_addr_i] <= w_data_i;
 
+    end
 endmodule

--- a/bsg_mem/bsg_mem_3r1w_sync_synth.v
+++ b/bsg_mem/bsg_mem_3r1w_sync_synth.v
@@ -45,24 +45,14 @@ module bsg_mem_3r1w_sync_synth #(parameter width_p=-1
    wire                   unused = reset_i;
 
    if (width_p == 0)
-    begin: zero_width
-      wire unused0 = clk_i;
-      wire unused1 = w_v_i;
-      wire [addr_width_lp-1:0] unused2 = w_addr_i;
-      wire unused3 = w_data_i;
-      wire unused4 = r0_v_i;
-      wire [addr_width_lp-1:0] unused5 = r0_addr_i;
-      wire unused6 = r1_v_i;
-      wire [addr_width_lp-1:0] unused7 = r1_addr_i;
-      wire unused8 = r2_v_i;
-      wire [addr_width_lp-1:0] unused9 = r2_addr_i;
-
+    begin: z
+      wire unused0 = &{clk_i, w_v_i, w_addr_i, w_data_i, r0_v_i, r0_addr_i, r1_v_i, r1_addr_i, r2_v_i, r2_addr_i};
       assign r0_data_o = '0;
       assign r1_data_o = '0;
       assign r2_data_o = '0;
     end
    else
-    begin: non_zero_width
+    begin: nz
 
    logic [width_p-1:0]    mem [els_p-1:0];
 

--- a/bsg_mem/bsg_mem_3r1w_synth.v
+++ b/bsg_mem/bsg_mem_3r1w_synth.v
@@ -21,20 +21,42 @@ module bsg_mem_3r1w_synth #(parameter width_p=-1
 
     , input                     w_v_i
     , input [addr_width_lp-1:0] w_addr_i
-    , input [width_p-1:0]       w_data_i
+    , input [`BSG_SAFE_MINUS(width_p, 1):0]       w_data_i
 
     , input                      r0_v_i
     , input [addr_width_lp-1:0]  r0_addr_i
-    , output logic [width_p-1:0] r0_data_o
+    , output logic [`BSG_SAFE_MINUS(width_p, 1):0] r0_data_o
 
     , input                      r1_v_i
     , input [addr_width_lp-1:0]  r1_addr_i
-    , output logic [width_p-1:0] r1_data_o
+    , output logic [`BSG_SAFE_MINUS(width_p, 1):0] r1_data_o
 
     , input                      r2_v_i
     , input [addr_width_lp-1:0]  r2_addr_i
-    , output logic [width_p-1:0] r2_data_o
+    , output logic [`BSG_SAFE_MINUS(width_p, 1):0] r2_data_o
     );
+
+   wire                   unused = w_reset_i;
+
+   if (width_p == 0)
+    begin: zero_width
+      wire unused0 = w_clk_i;
+      wire unused1 = w_v_i;
+      wire [addr_width_lp-1:0] unused2 = w_addr_i;
+      wire unused3 = w_data_i;
+      wire unused4 = r0_v_i;
+      wire [addr_width_lp-1:0] unused5 = r0_addr_i;
+      wire unused6 = r1_v_i;
+      wire [addr_width_lp-1:0] unused7 = r1_addr_i;
+      wire unused8 = r2_v_i;
+      wire [addr_width_lp-1:0] unused9 = r2_addr_i;
+
+      assign r0_data_o = '0;
+      assign r1_data_o = '0;
+      assign r2_data_o = '0;
+    end
+   else
+    begin: non_zero_width
 
    logic [width_p-1:0]    mem [els_p-1:0];
 
@@ -50,5 +72,5 @@ module bsg_mem_3r1w_synth #(parameter width_p=-1
        begin
           mem[w_addr_i] <= w_data_i;
        end
-
+    end
 endmodule

--- a/bsg_mem/bsg_mem_3r1w_synth.v
+++ b/bsg_mem/bsg_mem_3r1w_synth.v
@@ -39,24 +39,14 @@ module bsg_mem_3r1w_synth #(parameter width_p=-1
    wire                   unused = w_reset_i;
 
    if (width_p == 0)
-    begin: zero_width
-      wire unused0 = w_clk_i;
-      wire unused1 = w_v_i;
-      wire [addr_width_lp-1:0] unused2 = w_addr_i;
-      wire unused3 = w_data_i;
-      wire unused4 = r0_v_i;
-      wire [addr_width_lp-1:0] unused5 = r0_addr_i;
-      wire unused6 = r1_v_i;
-      wire [addr_width_lp-1:0] unused7 = r1_addr_i;
-      wire unused8 = r2_v_i;
-      wire [addr_width_lp-1:0] unused9 = r2_addr_i;
-
+    begin: z
+      wire unused0 = &{w_clk_i, w_v_i, w_addr_i, w_data_i, r0_v_i, r0_addr_i, r1_v_i, r1_addr_i, r2_v_i, r2_addr_i};
       assign r0_data_o = '0;
       assign r1_data_o = '0;
       assign r2_data_o = '0;
     end
    else
-    begin: non_zero_width
+    begin: nz
 
    logic [width_p-1:0]    mem [els_p-1:0];
 

--- a/bsg_misc/bsg_defines.v
+++ b/bsg_misc/bsg_defines.v
@@ -8,6 +8,7 @@
 `define BSG_SAFE_CLOG2(x) ( ((x)==1) ? 1 : $clog2((x)))
 `define BSG_IS_POW2(x) ( (1 << $clog2(x)) == (x))
 `define BSG_WIDTH(x) ($clog2(x+1))
+`define BSG_SAFE_MINUS(x, y) (x - y < 0) ? 0 : (x - y)
 
 // calculate ceil(x/y) 
 `define BSG_CDIV(x,y) (((x)+(y)-1)/(y))

--- a/bsg_misc/bsg_defines.v
+++ b/bsg_misc/bsg_defines.v
@@ -8,7 +8,7 @@
 `define BSG_SAFE_CLOG2(x) ( ((x)==1) ? 1 : $clog2((x)))
 `define BSG_IS_POW2(x) ( (1 << $clog2(x)) == (x))
 `define BSG_WIDTH(x) ($clog2(x+1))
-`define BSG_SAFE_MINUS(x, y) (x - y < 0) ? 0 : (x - y)
+`define BSG_SAFE_MINUS(x, y) (((x)-(y)) < 0) ? 0 : ((x)-(y))
 
 // calculate ceil(x/y) 
 `define BSG_CDIV(x,y) (((x)+(y)-1)/(y))

--- a/bsg_misc/bsg_lru_pseudo_tree_backup.v
+++ b/bsg_misc/bsg_lru_pseudo_tree_backup.v
@@ -59,22 +59,22 @@ module bsg_lru_pseudo_tree_backup
     assign modify_data_o = 1'b0;
   end
   else begin: lru
-    // backup LRU logic
-    // i = rank
-    for (genvar i = 0; i < lg_ways_lp; i++) begin
+  // backup LRU logic
+  // i = rank
+  for (genvar i = 0; i < lg_ways_lp; i++) begin
 
-      logic [(2**(i+1))-1:0] and_reduce;
+    logic [(2**(i+1))-1:0] and_reduce;
     
-      // j = bucket
-      for (genvar j = 0; j < (2**(i+1)); j++)
-        assign and_reduce[j] = &disabled_ways_i[(ways_p/(2**(i+1)))*j+:(ways_p/(2**(i+1)))];
+    // j = bucket
+    for (genvar j = 0; j < (2**(i+1)); j++)
+      assign and_reduce[j] = &disabled_ways_i[(ways_p/(2**(i+1)))*j+:(ways_p/(2**(i+1)))];
   
-      // k = start index in LRU bits
-      for (genvar k = 0; k < (2**(i+1))/2; k++) begin
-        assign modify_data_o[(2**i)-1+k] = and_reduce[2*k];
-        assign modify_mask_o[(2**i)-1+k] = |and_reduce[2*k+:2];
-      end
+    // k = start index in LRU bits
+    for (genvar k = 0; k < (2**(i+1))/2; k++) begin
+      assign modify_data_o[(2**i)-1+k] = and_reduce[2*k];
+      assign modify_mask_o[(2**i)-1+k] = |and_reduce[2*k+:2];
     end
+  end
   end
 
 endmodule

--- a/bsg_misc/bsg_lru_pseudo_tree_backup.v
+++ b/bsg_misc/bsg_lru_pseudo_tree_backup.v
@@ -49,25 +49,31 @@ module bsg_lru_pseudo_tree_backup
   )
   (
     input [ways_p-1:0] disabled_ways_i
-    , output logic [ways_p-2:0] modify_mask_o
-    , output logic [ways_p-2:0] modify_data_o
+    , output logic [`BSG_SAFE_MINUS(ways_p, 2):0] modify_mask_o
+    , output logic [`BSG_SAFE_MINUS(ways_p, 2):0] modify_data_o
   );
 
+  // If direct-mapped there is no meaning to backup LRU
+  if (ways_p == 1) begin: no_lru
+    assign modify_mask_o = 1'b1;
+    assign modify_data_o = 1'b0;
+  end
+  else begin: lru
+    // backup LRU logic
+    // i = rank
+    for (genvar i = 0; i < lg_ways_lp; i++) begin
 
-  // backup LRU logic
-  // i = rank
-  for (genvar i = 0; i < lg_ways_lp; i++) begin
-
-    logic [(2**(i+1))-1:0] and_reduce;
+      logic [(2**(i+1))-1:0] and_reduce;
     
-    // j = bucket
-    for (genvar j = 0; j < (2**(i+1)); j++)
-      assign and_reduce[j] = &disabled_ways_i[(ways_p/(2**(i+1)))*j+:(ways_p/(2**(i+1)))];
+      // j = bucket
+      for (genvar j = 0; j < (2**(i+1)); j++)
+        assign and_reduce[j] = &disabled_ways_i[(ways_p/(2**(i+1)))*j+:(ways_p/(2**(i+1)))];
   
-    // k = start index in LRU bits
-    for (genvar k = 0; k < (2**(i+1))/2; k++) begin
-      assign modify_data_o[(2**i)-1+k] = and_reduce[2*k];
-      assign modify_mask_o[(2**i)-1+k] = |and_reduce[2*k+:2];
+      // k = start index in LRU bits
+      for (genvar k = 0; k < (2**(i+1))/2; k++) begin
+        assign modify_data_o[(2**i)-1+k] = and_reduce[2*k];
+        assign modify_mask_o[(2**i)-1+k] = |and_reduce[2*k+:2];
+      end
     end
   end
 

--- a/bsg_misc/bsg_lru_pseudo_tree_decode.v
+++ b/bsg_misc/bsg_lru_pseudo_tree_decode.v
@@ -17,26 +17,32 @@ module bsg_lru_pseudo_tree_decode
     ,localparam lg_ways_lp = `BSG_SAFE_CLOG2(ways_p)
   )
   (input [lg_ways_lp-1:0]      way_id_i
-   , output logic [ways_p-2:0] data_o
-   , output logic [ways_p-2:0] mask_o
+   , output logic [`BSG_SAFE_MINUS(ways_p, 2):0] data_o
+   , output logic [`BSG_SAFE_MINUS(ways_p, 2):0] mask_o
   );
 
   genvar i;
-  generate 
-    for(i=0; i<ways_p-1; i++) begin: rof
-      // Mask generation
-	  if(i == 0) begin: fi
-	    assign mask_o[i] = 1'b1;
-	  end
-	  else if(i%2 == 1) begin: fi
-	    assign mask_o[i] = mask_o[(i-1)/2] & ~way_id_i[lg_ways_lp-`BSG_SAFE_CLOG2(i+2)+1];
-	  end
-	  else begin: fi
-	    assign mask_o[i] = mask_o[(i-2)/2] & way_id_i[lg_ways_lp-`BSG_SAFE_CLOG2(i+2)+1];
-	  end
+  generate
+    if (ways_p == 1) begin: no_lru
+      assign mask_o[0] = 1'b1;
+      assign data_o[0] = 1'b0;
+    end
+    else begin: lru 
+      for(i=0; i<ways_p-1; i++) begin: rof
+        // Mask generation
+	    if(i == 0) begin: fi
+	      assign mask_o[i] = 1'b1;
+	    end
+	    else if(i%2 == 1) begin: fi
+	      assign mask_o[i] = mask_o[(i-1)/2] & ~way_id_i[lg_ways_lp-`BSG_SAFE_CLOG2(i+2)+1];
+	    end
+	    else begin: fi
+	      assign mask_o[i] = mask_o[(i-2)/2] & way_id_i[lg_ways_lp-`BSG_SAFE_CLOG2(i+2)+1];
+	    end
 	  
-	  // Data generation
-	  assign data_o[i] = mask_o[i] & ~way_id_i[lg_ways_lp-`BSG_SAFE_CLOG2(i+2)];
+	    // Data generation
+	    assign data_o[i] = mask_o[i] & ~way_id_i[lg_ways_lp-`BSG_SAFE_CLOG2(i+2)];
+      end
     end
   endgenerate
 

--- a/bsg_misc/bsg_lru_pseudo_tree_decode.v
+++ b/bsg_misc/bsg_lru_pseudo_tree_decode.v
@@ -27,22 +27,22 @@ module bsg_lru_pseudo_tree_decode
       assign mask_o[0] = 1'b1;
       assign data_o[0] = 1'b0;
     end
-    else begin: lru 
-      for(i=0; i<ways_p-1; i++) begin: rof
-        // Mask generation
-	    if(i == 0) begin: fi
-	      assign mask_o[i] = 1'b1;
-	    end
-	    else if(i%2 == 1) begin: fi
-	      assign mask_o[i] = mask_o[(i-1)/2] & ~way_id_i[lg_ways_lp-`BSG_SAFE_CLOG2(i+2)+1];
-	    end
-	    else begin: fi
-	      assign mask_o[i] = mask_o[(i-2)/2] & way_id_i[lg_ways_lp-`BSG_SAFE_CLOG2(i+2)+1];
-	    end
+    else begin: lru
+    for(i=0; i<ways_p-1; i++) begin: rof
+      // Mask generation
+	  if(i == 0) begin: fi
+	    assign mask_o[i] = 1'b1;
+	  end
+	  else if(i%2 == 1) begin: fi
+	    assign mask_o[i] = mask_o[(i-1)/2] & ~way_id_i[lg_ways_lp-`BSG_SAFE_CLOG2(i+2)+1];
+	  end
+	  else begin: fi
+	    assign mask_o[i] = mask_o[(i-2)/2] & way_id_i[lg_ways_lp-`BSG_SAFE_CLOG2(i+2)+1];
+	  end
 	  
-	    // Data generation
-	    assign data_o[i] = mask_o[i] & ~way_id_i[lg_ways_lp-`BSG_SAFE_CLOG2(i+2)];
-      end
+	  // Data generation
+	  assign data_o[i] = mask_o[i] & ~way_id_i[lg_ways_lp-`BSG_SAFE_CLOG2(i+2)];
+    end
     end
   endgenerate
 

--- a/bsg_misc/bsg_lru_pseudo_tree_encode.v
+++ b/bsg_misc/bsg_lru_pseudo_tree_encode.v
@@ -41,28 +41,28 @@ module bsg_lru_pseudo_tree_encode
     assign way_id_o = 1'b0;
   end
   else begin: lru
-    for (genvar i = 0; i < lg_ways_lp; i++) begin: rank
+  for (genvar i = 0; i < lg_ways_lp; i++) begin: rank
 
-      if (i == 0) begin: z
+    if (i == 0) begin: z
 
-        // top way_id_o bit is just the lowest LRU bit
-        assign way_id_o[lg_ways_lp-1] = lru_i[0];  // root
+      // top way_id_o bit is just the lowest LRU bit
+      assign way_id_o[lg_ways_lp-1] = lru_i[0];  // root
 
-      end
-      else begin: nz
-        // each output way_id_o bit uses *all* of the way_id_o bits above it in the way_id_o vector
-        // as the select to a mux which has as input an exponentially growing (2^i) collection of unique LRU bits
-        bsg_mux #(
-          .width_p(1)
-          ,.els_p(2**i)
-        ) mux (
-          .data_i(lru_i[((2**i)-1)+:(2**i)])
-          ,.sel_i(way_id_o[lg_ways_lp-1-:i])
-          ,.data_o(way_id_o[lg_ways_lp-1-i])
-        );
-
-      end
     end
+    else begin: nz
+      // each output way_id_o bit uses *all* of the way_id_o bits above it in the way_id_o vector
+      // as the select to a mux which has as input an exponentially growing (2^i) collection of unique LRU bits
+      bsg_mux #(
+        .width_p(1)
+        ,.els_p(2**i)
+      ) mux (
+        .data_i(lru_i[((2**i)-1)+:(2**i)])
+        ,.sel_i(way_id_o[lg_ways_lp-1-:i])
+        ,.data_o(way_id_o[lg_ways_lp-1-i])
+      );
+
+    end
+  end
   end
 
 

--- a/bsg_misc/bsg_lru_pseudo_tree_encode.v
+++ b/bsg_misc/bsg_lru_pseudo_tree_encode.v
@@ -33,31 +33,35 @@ module bsg_lru_pseudo_tree_encode
     , parameter lg_ways_lp = `BSG_SAFE_CLOG2(ways_p)
   )
   (
-    input [ways_p-2:0] lru_i
+    input [`BSG_SAFE_MINUS(ways_p, 2):0] lru_i
     , output logic [lg_ways_lp-1:0] way_id_o
   );
 
+  if (ways_p == 1) begin: no_lru
+    assign way_id_o = 1'b0;
+  end
+  else begin: lru
+    for (genvar i = 0; i < lg_ways_lp; i++) begin: rank
 
-  for (genvar i = 0; i < lg_ways_lp; i++) begin: rank
+      if (i == 0) begin: z
 
-    if (i == 0) begin: z
+        // top way_id_o bit is just the lowest LRU bit
+        assign way_id_o[lg_ways_lp-1] = lru_i[0];  // root
 
-      // top way_id_o bit is just the lowest LRU bit
-      assign way_id_o[lg_ways_lp-1] = lru_i[0];  // root
+      end
+      else begin: nz
+        // each output way_id_o bit uses *all* of the way_id_o bits above it in the way_id_o vector
+        // as the select to a mux which has as input an exponentially growing (2^i) collection of unique LRU bits
+        bsg_mux #(
+          .width_p(1)
+          ,.els_p(2**i)
+        ) mux (
+          .data_i(lru_i[((2**i)-1)+:(2**i)])
+          ,.sel_i(way_id_o[lg_ways_lp-1-:i])
+          ,.data_o(way_id_o[lg_ways_lp-1-i])
+        );
 
-    end
-    else begin: nz
-      // each output way_id_o bit uses *all* of the way_id_o bits above it in the way_id_o vector
-      // as the select to a mux which has as input an exponentially growing (2^i) collection of unique LRU bits
-      bsg_mux #(
-        .width_p(1)
-        ,.els_p(2**i)
-      ) mux (
-        .data_i(lru_i[((2**i)-1)+:(2**i)])
-        ,.sel_i(way_id_o[lg_ways_lp-1-:i])
-        ,.data_o(way_id_o[lg_ways_lp-1-i])
-      );
-
+      end
     end
   end
 


### PR DESCRIPTION
This PR adds the BSG_SAFE_MINUS macro and supersedes #352 

The macro is used to allow for supporting a niche direct-mapped config in caches that are primarily set associative and hence have the LRU modules (effectively, this means "disabling" the LRU modules when used in a direct-mapped cache).

The macro is also used to support zero-width memories. One use case of zero width memories is the instantiation of a zero-width stat mem for a direct-mapped instruction cache.

I might have either added support to memories where it might not be used (i.e 2r1w or 3r1w?) or left out memories where it did not make sense to me to support zero width i.e (*_sync_mask_write_var?). Please do let me know if support should be removed/added for any of the memories modified in this PR. 