### PR TITLE
Adding gf12 macro defines for individual design memories

### DIFF
--- a/hard/gf_14/bsg_mem/bsg_mem_1r1w_sync.v
+++ b/hard/gf_14/bsg_mem/bsg_mem_1r1w_sync.v
@@ -1,26 +1,5 @@
 
-`define bsg_mem_1r1w_sync_macro(words,bits,mux)\
-  if (harden_p && els_p == words && width_p == bits)     \
-    begin: macro                                            \
-    gf14_1r1w_d``words``_w``bits``_m``mux                     \
-      mem (                                                    \
-      .CLKA   (clk_i)                                           \
-      ,.CLKB  (clk_i)                                           \
-      ,.CENA  (~r_v_i)                                         \
-      ,.AA    (r_addr_i)                                      \
-      ,.QA    (r_data_o)                                      \
-      ,.CENB  (~w_v_i)                                        \
-      ,.AB    (w_addr_i)                                      \
-      ,.DB    (w_data_i)                                      \
-      ,.EMAA  (3'b011)                                        \
-      ,.EMAB  (3'b011)                                        \
-      ,.EMASA (1'b0)                                          \
-      ,.STOV  (1'b0)                                          \
-      ,.RET1N (1'b1)                                          \
-    );                                                        \
-  end
-      
-      
+`include "bsg_mem_1r1w_sync_macros.vh"
 
 module bsg_mem_1r1w_sync
   #(parameter width_p=-1
@@ -45,12 +24,7 @@ module bsg_mem_1r1w_sync
     , output logic [width_p-1:0] r_data_o
   );
 
-
-  // TODO: Set hardened macro configs in this define
-  `ifdef BSG_MEM_HARD_1R1W_SYNC_MACROS
-  `BSG_MEM_HARD_1R1W_SYNC_MACROS
-  `endif
-  // or define them here
+  // TODO: Define more hardened macro configs here
   `bsg_mem_1r1w_sync_macro(32,92,1) else
     begin: notmacro
     bsg_mem_1r1w_sync_synth #(

--- a/hard/gf_14/bsg_mem/bsg_mem_1r1w_sync.v
+++ b/hard/gf_14/bsg_mem/bsg_mem_1r1w_sync.v
@@ -46,6 +46,11 @@ module bsg_mem_1r1w_sync
   );
 
 
+  // TODO: Set hardened macro configs in this define
+  `ifdef BSG_MEM_HARD_1R1W_SYNC_MACROS
+  `BSG_MEM_HARD_1R1W_SYNC_MACROS
+  `endif
+  // or define them here
   `bsg_mem_1r1w_sync_macro(32,92,1) else
     begin: notmacro
     bsg_mem_1r1w_sync_synth #(

--- a/hard/gf_14/bsg_mem/bsg_mem_1r1w_sync_macros.vh
+++ b/hard/gf_14/bsg_mem/bsg_mem_1r1w_sync_macros.vh
@@ -1,4 +1,7 @@
 
+`ifndef BSG_MEM_1R1W_SYNC_MACROS_VH
+`define BSG_MEM_1R1W_SYNC_MACROS_VH
+
 `define bsg_mem_1r1w_sync_macro(words,bits,mux)\
   if (harden_p && els_p == words && width_p == bits)          \
     begin: macro                                              \
@@ -20,3 +23,5 @@
     );                                                        \
   end
       
+`endif
+

--- a/hard/gf_14/bsg_mem/bsg_mem_1r1w_sync_macros.vh
+++ b/hard/gf_14/bsg_mem/bsg_mem_1r1w_sync_macros.vh
@@ -1,0 +1,22 @@
+
+`define bsg_mem_1r1w_sync_macro(words,bits,mux)\
+  if (harden_p && els_p == words && width_p == bits)          \
+    begin: macro                                              \
+    gf14_1r1w_d``words``_w``bits``_m``mux                     \
+      mem (                                                   \
+      .CLKA   (clk_i)                                         \
+      ,.CLKB  (clk_i)                                         \
+      ,.CENA  (~r_v_i)                                        \
+      ,.AA    (r_addr_i)                                      \
+      ,.QA    (r_data_o)                                      \
+      ,.CENB  (~w_v_i)                                        \
+      ,.AB    (w_addr_i)                                      \
+      ,.DB    (w_data_i)                                      \
+      ,.EMAA  (3'b011)                                        \
+      ,.EMAB  (3'b011)                                        \
+      ,.EMASA (1'b0)                                          \
+      ,.STOV  (1'b0)                                          \
+      ,.RET1N (1'b1)                                          \
+    );                                                        \
+  end
+      

--- a/hard/gf_14/bsg_mem/bsg_mem_1rw_sync.v
+++ b/hard/gf_14/bsg_mem/bsg_mem_1rw_sync.v
@@ -40,7 +40,10 @@ module bsg_mem_1rw_sync #( parameter width_p = -1
 
   wire unused = reset_i;
 
-  // TODO: Define more hardened macro configs here
+  // TODO: Set hardened macro configs in this define
+  `ifdef BSG_MEM_HARD_1RW_SYNC_MACROS
+  `BSG_MEM_HARD_1RW_SYNC_MACROS
+  `endif
   `bsg_mem_1rw_sync_macro(512,64,4) else
   `bsg_mem_1rw_sync_macro(256,96,2) else
   `bsg_mem_1rw_sync_macro(1024,46,4) else

--- a/hard/gf_14/bsg_mem/bsg_mem_1rw_sync.v
+++ b/hard/gf_14/bsg_mem/bsg_mem_1rw_sync.v
@@ -1,23 +1,5 @@
 
-`define bsg_mem_1rw_sync_macro(words,bits,mux)       \
-  if (harden_p && els_p == words && width_p == bits) \
-    begin: macro                                     \
-      gf14_1rw_d``words``_w``bits``_m``mux           \
-        mem                                          \
-          ( .CLK   ( clk_i  )                        \
-          , .A     ( addr_i )                        \
-          , .D     ( data_i )                        \
-          , .Q     ( data_o )                        \
-          , .CEN   ( ~v_i   )                        \
-          , .GWEN  ( ~w_i   )                        \
-          , .RET1N ( 1'b1   )                        \
-          , .STOV  ( 1'b0   )                        \
-          , .EMA   ( 3'b011 )                        \
-          , .EMAW  ( 2'b01  )                        \
-          , .EMAS  ( 1'b0   )                        \
-          );                                         \
-    end: macro
-
+`include "bsg_mem_1rw_sync_macros.vh"
 
 module bsg_mem_1rw_sync #( parameter width_p = -1
                          , parameter els_p = -1
@@ -40,10 +22,7 @@ module bsg_mem_1rw_sync #( parameter width_p = -1
 
   wire unused = reset_i;
 
-  // TODO: Set hardened macro configs in this define
-  `ifdef BSG_MEM_HARD_1RW_SYNC_MACROS
-  `BSG_MEM_HARD_1RW_SYNC_MACROS
-  `endif
+  // TODO: Define more hardened macro configs here
   `bsg_mem_1rw_sync_macro(512,64,4) else
   `bsg_mem_1rw_sync_macro(256,96,2) else
   `bsg_mem_1rw_sync_macro(1024,46,4) else
@@ -81,7 +60,7 @@ module bsg_mem_1rw_sync #( parameter width_p = -1
         end // block: s1r1w
       else
         begin: notmacro
-          bsg_mem_1rw_sync_synth # (.width_p(width_p), .els_p(els_p))
+          bsg_mem_1rw_sync_synth # (.width_p(width_p), .els_p(els_p), .latch_last_read_p(latch_last_read_p))
             synth
               (.*);
         end // block: notmacro

--- a/hard/gf_14/bsg_mem/bsg_mem_1rw_sync_macros.vh
+++ b/hard/gf_14/bsg_mem/bsg_mem_1rw_sync_macros.vh
@@ -1,4 +1,7 @@
 
+`ifndef BSG_MEM_1RW_SYNC_MACROS_VH
+`define BSG_MEM_1RW_SYNC_MACROS_VH
+
 `define bsg_mem_1rw_sync_macro(words,bits,mux)       \
   if (harden_p && els_p == words && width_p == bits) \
     begin: macro                                     \
@@ -17,4 +20,6 @@
           , .EMAS  ( 1'b0   )                        \
           );                                         \
     end: macro
+
+`endif
 

--- a/hard/gf_14/bsg_mem/bsg_mem_1rw_sync_macros.vh
+++ b/hard/gf_14/bsg_mem/bsg_mem_1rw_sync_macros.vh
@@ -1,0 +1,20 @@
+
+`define bsg_mem_1rw_sync_macro(words,bits,mux)       \
+  if (harden_p && els_p == words && width_p == bits) \
+    begin: macro                                     \
+      gf14_1rw_d``words``_w``bits``_m``mux           \
+        mem                                          \
+          ( .CLK   ( clk_i  )                        \
+          , .A     ( addr_i )                        \
+          , .D     ( data_i )                        \
+          , .Q     ( data_o )                        \
+          , .CEN   ( ~v_i   )                        \
+          , .GWEN  ( ~w_i   )                        \
+          , .RET1N ( 1'b1   )                        \
+          , .STOV  ( 1'b0   )                        \
+          , .EMA   ( 3'b011 )                        \
+          , .EMAW  ( 2'b01  )                        \
+          , .EMAS  ( 1'b0   )                        \
+          );                                         \
+    end: macro
+

--- a/hard/gf_14/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.v
+++ b/hard/gf_14/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.v
@@ -59,7 +59,11 @@ module bsg_mem_1rw_sync_mask_write_bit #( parameter width_p = -1
 
   wire unused = reset_i;
 
-  // TODO: Define more hardened macro configs here
+  // TODO: Set hardened macro configs in this define
+  `ifdef BSG_MEM_HARD_1RW_SYNC_MASK_WRITE_BIT_MACROS
+  `BSG_MEM_HARD_1RW_SYNC_MASK_WRITE_BIT_MACROS
+  `endif
+  // or define them here
   `bsg_mem_1rw_sync_mask_write_bit_macro( 64,15,4) else
   `bsg_mem_1rw_sync_mask_write_bit_macro( 64, 7,4) else
   `bsg_mem_1rw_sync_mask_write_bit_macro(256,48,2) else
@@ -73,31 +77,6 @@ module bsg_mem_1rw_sync_mask_write_bit #( parameter width_p = -1
   `bsg_mem_1rw_sync_mask_write_bit_macro(64,58,2) else
   `bsg_mem_1rw_sync_mask_write_bit_banked_macro(64,116,2,1) else
   
-  // HACKED VERSION OF THE FOLLOWING
-  // `bsg_mem_1rw_sync_mask_write_bit_macro_banks( 8,116,2,32) else
-  if (harden_p && els_p == 8 && width_p == 32*116)
-    begin: macro
-      genvar i;
-      for (i = 0; i < 32; i++)
-        begin: bank
-          gf14_1rw_d16_w116_m2_bit
-            mem
-              ( .CLK   ( clk_i                                 )
-              , .A     ( {1'b0, addr_i}                        )
-              , .D     ( data_i[i*(width_p/32)+:width_p/32]    )
-              , .Q     ( data_o[i*(width_p/32)+:width_p/32]    )
-              , .CEN   ( ~v_i                                  )
-              , .GWEN  ( ~w_i                                  )
-              , .WEN   ( ~w_mask_i[i*(width_p/32)+:width_p/32] )
-              , .RET1N ( 1'b1                                  )
-              , .STOV  ( 1'b0                                  )
-              , .EMA   ( 3'b010                                )
-              , .EMAW  ( 2'b00                                 )
-              , .EMAS  ( 1'b0                                  )
-              );
-        end: bank
-    end: macro
-  else
     begin: notmacro
       bsg_mem_1rw_sync_mask_write_bit_synth #(.width_p(width_p), .els_p(els_p))
         synth

--- a/hard/gf_14/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.v
+++ b/hard/gf_14/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.v
@@ -1,4 +1,6 @@
 
+`include "bsg_mem_1rw_sync_mask_write_bit_macros.vh"
+
 module bsg_mem_1rw_sync_mask_write_bit #( parameter width_p = -1
                                         , parameter els_p = -1
                                         , parameter addr_width_lp = `BSG_SAFE_CLOG2(els_p)

--- a/hard/gf_14/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.v
+++ b/hard/gf_14/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.v
@@ -1,46 +1,4 @@
 
-`define bsg_mem_1rw_sync_mask_write_bit_macro(words,bits,mux) \
-  if (harden_p && els_p == words && width_p == bits)          \
-    begin: macro                                              \
-      gf14_1rw_d``words``_w``bits``_m``mux``_bit              \
-        mem                                                   \
-          ( .CLK   ( clk_i     )                              \
-          , .A     ( addr_i    )                              \
-          , .D     ( data_i    )                              \
-          , .Q     ( data_o    )                              \
-          , .CEN   ( ~v_i      )                              \
-          , .GWEN  ( ~w_i      )                              \
-          , .WEN   ( ~w_mask_i )                              \
-          , .RET1N ( 1'b1      )                              \
-          , .STOV  ( 1'b0      )                              \
-          , .EMA   ( 3'b011    )                              \
-          , .EMAW  ( 2'b01     )                              \
-          , .EMAS  ( 1'b0      )                              \
-          );                                                  \
-    end: macro
-
-`define bsg_mem_1rw_sync_mask_write_banked_macro(words,bits,wbank,dbank) \
-  if (harden_p && els_p == words && width_p == bits) begin: macro \
-    bsg_mem_1rw_sync_mask_write_bit_banked #(                     \
-      .width_p(width_p)                                                     \
-      ,.els_p(els_p)                                                        \
-      ,.latch_last_read_p(latch_last_read_p)                                \
-      ,.num_width_bank_p(wbank)                                             \
-      ,.num_depth_bank_p(dbank)                                             \
-    ) bmem (                                                                \
-      .clk_i(clk_i)                                                         \
-      ,.reset_i(reset_i)                                                    \
-      ,.v_i(v_i)                                                            \
-      ,.w_i(w_i)                                                            \
-      ,.addr_i(addr_i)                                                      \
-      ,.data_i(data_i)                                                      \
-      ,.w_mask_i(w_mask_i)                                                  \
-      ,.data_o(data_o)                                                      \
-    );                                                                      \
-  end: macro
-
-
-
 module bsg_mem_1rw_sync_mask_write_bit #( parameter width_p = -1
                                         , parameter els_p = -1
                                         , parameter addr_width_lp = `BSG_SAFE_CLOG2(els_p)
@@ -59,11 +17,7 @@ module bsg_mem_1rw_sync_mask_write_bit #( parameter width_p = -1
 
   wire unused = reset_i;
 
-  // TODO: Set hardened macro configs in this define
-  `ifdef BSG_MEM_HARD_1RW_SYNC_MASK_WRITE_BIT_MACROS
-  `BSG_MEM_HARD_1RW_SYNC_MASK_WRITE_BIT_MACROS
-  `endif
-  // or define them here
+  // TODO: Define more hardened macro configs here
   `bsg_mem_1rw_sync_mask_write_bit_macro( 64,15,4) else
   `bsg_mem_1rw_sync_mask_write_bit_macro( 64, 7,4) else
   `bsg_mem_1rw_sync_mask_write_bit_macro(256,48,2) else
@@ -78,7 +32,7 @@ module bsg_mem_1rw_sync_mask_write_bit #( parameter width_p = -1
   `bsg_mem_1rw_sync_mask_write_bit_banked_macro(64,116,2,1) else
   
     begin: notmacro
-      bsg_mem_1rw_sync_mask_write_bit_synth #(.width_p(width_p), .els_p(els_p))
+      bsg_mem_1rw_sync_mask_write_bit_synth #(.width_p(width_p), .els_p(els_p), .latch_last_read_p(latch_last_read_p))
         synth
           (.*);
     end // block: notmacro

--- a/hard/gf_14/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_macros.vh
+++ b/hard/gf_14/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_macros.vh
@@ -1,4 +1,7 @@
 
+`ifndef BSG_MEM_1RW_SYNC_MASK_WRITE_BIT_MACROS
+`define BSG_MEM_1RW_SYNC_MASK_WRITE_BIT_MACROS
+
 `define bsg_mem_1rw_sync_mask_write_bit_macro(words,bits,mux) \
   if (harden_p && els_p == words && width_p == bits)          \
     begin: macro                                              \
@@ -19,7 +22,7 @@
           );                                                  \
     end: macro
 
-`define bsg_mem_1rw_sync_mask_write_banked_macro(words,bits,wbank,dbank) \
+`define bsg_mem_1rw_sync_mask_write_bit_banked_macro(words,bits,wbank,dbank) \
   if (harden_p && els_p == words && width_p == bits) begin: macro \
     bsg_mem_1rw_sync_mask_write_bit_banked #(                     \
       .width_p(width_p)                                                     \
@@ -38,4 +41,6 @@
       ,.data_o(data_o)                                                      \
     );                                                                      \
   end: macro
+
+`endif
 

--- a/hard/gf_14/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_macros.vh
+++ b/hard/gf_14/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_macros.vh
@@ -1,0 +1,41 @@
+
+`define bsg_mem_1rw_sync_mask_write_bit_macro(words,bits,mux) \
+  if (harden_p && els_p == words && width_p == bits)          \
+    begin: macro                                              \
+      gf14_1rw_d``words``_w``bits``_m``mux``_bit              \
+        mem                                                   \
+          ( .CLK   ( clk_i     )                              \
+          , .A     ( addr_i    )                              \
+          , .D     ( data_i    )                              \
+          , .Q     ( data_o    )                              \
+          , .CEN   ( ~v_i      )                              \
+          , .GWEN  ( ~w_i      )                              \
+          , .WEN   ( ~w_mask_i )                              \
+          , .RET1N ( 1'b1      )                              \
+          , .STOV  ( 1'b0      )                              \
+          , .EMA   ( 3'b011    )                              \
+          , .EMAW  ( 2'b01     )                              \
+          , .EMAS  ( 1'b0      )                              \
+          );                                                  \
+    end: macro
+
+`define bsg_mem_1rw_sync_mask_write_banked_macro(words,bits,wbank,dbank) \
+  if (harden_p && els_p == words && width_p == bits) begin: macro \
+    bsg_mem_1rw_sync_mask_write_bit_banked #(                     \
+      .width_p(width_p)                                                     \
+      ,.els_p(els_p)                                                        \
+      ,.latch_last_read_p(latch_last_read_p)                                \
+      ,.num_width_bank_p(wbank)                                             \
+      ,.num_depth_bank_p(dbank)                                             \
+    ) bmem (                                                                \
+      .clk_i(clk_i)                                                         \
+      ,.reset_i(reset_i)                                                    \
+      ,.v_i(v_i)                                                            \
+      ,.w_i(w_i)                                                            \
+      ,.addr_i(addr_i)                                                      \
+      ,.data_i(data_i)                                                      \
+      ,.w_mask_i(w_mask_i)                                                  \
+      ,.data_o(data_o)                                                      \
+    );                                                                      \
+  end: macro
+

--- a/hard/gf_14/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v
+++ b/hard/gf_14/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v
@@ -1,49 +1,5 @@
 
-`define bsg_mem_1rw_sync_mask_write_byte_macro(words,bits,mux) \
-  if (harden_p && els_p == words && data_width_p == bits)      \
-    begin: macro                                               \
-      wire [data_width_p-1:0] wen;                             \
-      genvar j;                                                \
-      for(j = 0; j < write_mask_width_lp; j++)                 \
-        assign wen[8*j+:8] = {8{write_mask_i[j]}};             \
-                                                               \
-      gf14_1rw_d``words``_w``bits``_m``mux``_byte              \
-        mem                                                    \
-          ( .CLK   ( clk_i  )                                  \
-          , .A     ( addr_i )                                  \
-          , .D     ( data_i )                                  \
-          , .Q     ( data_o )                                  \
-          , .CEN   ( ~v_i   )                                  \
-          , .GWEN  ( ~w_i   )                                  \
-          , .WEN   ( ~wen   )                                  \
-          , .RET1N ( 1'b1   )                                  \
-          , .STOV  ( 1'b0   )                                  \
-          , .EMA   ( 3'b011 )                                  \
-          , .EMAW  ( 2'b01  )                                  \
-          , .EMAS  ( 1'b0   )                                  \
-          );                                                   \
-    end: macro
-
-`define bsg_mem_1rw_sync_mask_write_byte_banked_macro(words,bits,wbank,dbank) \
-  if (harden_p && els_p == words && data_width_p == bits) begin: macro        \
-      bsg_mem_1rw_sync_mask_write_byte_banked #(                              \
-        .data_width_p(data_width_p)                                           \
-        ,.els_p(els_p)                                                        \
-        ,.latch_last_read_p(latch_last_read_p)                                \
-        ,.num_width_bank_p(wbank)                                             \
-        ,.num_depth_bank_p(dbank)                                             \
-      ) bmem (                                                                \
-        .clk_i(clk_i)                                                         \
-        ,.reset_i(reset_i)                                                    \
-        ,.v_i(v_i)                                                            \
-        ,.w_i(w_i)                                                            \
-        ,.addr_i(addr_i)                                                      \
-        ,.data_i(data_i)                                                      \
-        ,.write_mask_i(write_mask_i)                                          \
-        ,.data_o(data_o)                                                      \
-      );                                                                      \
-    end: macro
-  
+`include "bsg_mem_1rw_sync_mask_write_byte_macros.vh"
 
 module bsg_mem_1rw_sync_mask_write_byte #( parameter els_p = -1
                                          , parameter data_width_p = -1
@@ -65,11 +21,7 @@ module bsg_mem_1rw_sync_mask_write_byte #( parameter els_p = -1
 
   wire unused = reset_i;
 
-  // TODO: Set hardened macro configs in this define
-  `ifdef BSG_MEM_HARD_1RW_SYNC_MASK_WRITE_BYTE_MACROS
-  `BSG_MEM_HARD_1RW_SYNC_MASK_WRITE_BYTE_MACROS
-  `endif
-  // or define them here
+  // TODO: Define more hardened macro configs here
   `bsg_mem_1rw_sync_mask_write_byte_macro(512,64,2) else
   `bsg_mem_1rw_sync_mask_write_byte_macro(1024,32,4) else
   `bsg_mem_1rw_sync_mask_write_byte_macro(2048,64,4) else
@@ -78,7 +30,7 @@ module bsg_mem_1rw_sync_mask_write_byte #( parameter els_p = -1
   `bsg_mem_1rw_sync_mask_write_byte_banked_macro(1024,256,8,1) else
   // no hardened version found
     begin : notmacro
-      bsg_mem_1rw_sync_mask_write_byte_synth #(.data_width_p(data_width_p), .els_p(els_p))
+      bsg_mem_1rw_sync_mask_write_byte_synth #(.data_width_p(data_width_p), .els_p(els_p), .latch_last_read_p(latch_last_read_p))
         synth
           (.*);
     end // block: notmacro

--- a/hard/gf_14/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v
+++ b/hard/gf_14/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v
@@ -65,7 +65,11 @@ module bsg_mem_1rw_sync_mask_write_byte #( parameter els_p = -1
 
   wire unused = reset_i;
 
-  // TODO: Define more hardened macro configs here
+  // TODO: Set hardened macro configs in this define
+  `ifdef BSG_MEM_HARD_1RW_SYNC_MASK_WRITE_BYTE_MACROS
+  `BSG_MEM_HARD_1RW_SYNC_MASK_WRITE_BYTE_MACROS
+  `endif
+  // or define them here
   `bsg_mem_1rw_sync_mask_write_byte_macro(512,64,2) else
   `bsg_mem_1rw_sync_mask_write_byte_macro(1024,32,4) else
   `bsg_mem_1rw_sync_mask_write_byte_macro(2048,64,4) else

--- a/hard/gf_14/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_macros.vh
+++ b/hard/gf_14/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_macros.vh
@@ -1,4 +1,7 @@
 
+`ifndef BSG_MEM_1RW_SYNC_MASK_WRITE_BYTE_MACROS
+`define BSG_MEM_1RW_SYNC_MASK_WRITE_BYTE_MACROS
+
 `define bsg_mem_1rw_sync_mask_write_byte_macro(words,bits,mux) \
   if (harden_p && els_p == words && data_width_p == bits)      \
     begin: macro                                               \
@@ -43,4 +46,6 @@
         ,.data_o(data_o)                                                      \
       );                                                                      \
     end: macro
-  
+
+`endif
+

--- a/hard/gf_14/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_macros.vh
+++ b/hard/gf_14/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_macros.vh
@@ -1,0 +1,46 @@
+
+`define bsg_mem_1rw_sync_mask_write_byte_macro(words,bits,mux) \
+  if (harden_p && els_p == words && data_width_p == bits)      \
+    begin: macro                                               \
+      wire [data_width_p-1:0] wen;                             \
+      genvar j;                                                \
+      for(j = 0; j < write_mask_width_lp; j++)                 \
+        assign wen[8*j+:8] = {8{write_mask_i[j]}};             \
+                                                               \
+      gf14_1rw_d``words``_w``bits``_m``mux``_byte              \
+        mem                                                    \
+          ( .CLK   ( clk_i  )                                  \
+          , .A     ( addr_i )                                  \
+          , .D     ( data_i )                                  \
+          , .Q     ( data_o )                                  \
+          , .CEN   ( ~v_i   )                                  \
+          , .GWEN  ( ~w_i   )                                  \
+          , .WEN   ( ~wen   )                                  \
+          , .RET1N ( 1'b1   )                                  \
+          , .STOV  ( 1'b0   )                                  \
+          , .EMA   ( 3'b011 )                                  \
+          , .EMAW  ( 2'b01  )                                  \
+          , .EMAS  ( 1'b0   )                                  \
+          );                                                   \
+    end: macro
+
+`define bsg_mem_1rw_sync_mask_write_byte_banked_macro(words,bits,wbank,dbank) \
+  if (harden_p && els_p == words && data_width_p == bits) begin: macro        \
+      bsg_mem_1rw_sync_mask_write_byte_banked #(                              \
+        .data_width_p(data_width_p)                                           \
+        ,.els_p(els_p)                                                        \
+        ,.latch_last_read_p(latch_last_read_p)                                \
+        ,.num_width_bank_p(wbank)                                             \
+        ,.num_depth_bank_p(dbank)                                             \
+      ) bmem (                                                                \
+        .clk_i(clk_i)                                                         \
+        ,.reset_i(reset_i)                                                    \
+        ,.v_i(v_i)                                                            \
+        ,.w_i(w_i)                                                            \
+        ,.addr_i(addr_i)                                                      \
+        ,.data_i(data_i)                                                      \
+        ,.write_mask_i(write_mask_i)                                          \
+        ,.data_o(data_o)                                                      \
+      );                                                                      \
+    end: macro
+  

--- a/hard/gf_14/bsg_mem/bsg_mem_2r1w_sync.v
+++ b/hard/gf_14/bsg_mem/bsg_mem_2r1w_sync.v
@@ -62,7 +62,11 @@ module bsg_mem_2r1w_sync #( parameter width_p = -1
 
   wire unused = reset_i;
 
-  // TODO: Define more hardened macro configs here
+  // TODO: Set hardened macro configs in this define
+  `ifdef BSG_MEM_HARD_2R1W_SYNC_MACROS
+  `BSG_MEM_HARD_2R1W_SYNC_MACROS
+  `endif
+  // or define them here
   `bsg_mem_2r1w_sync_macro(32,64,1) else
   //`bsg_mem_2r1w_sync_macro(32,32,2) else
 

--- a/hard/gf_14/bsg_mem/bsg_mem_2r1w_sync.v
+++ b/hard/gf_14/bsg_mem/bsg_mem_2r1w_sync.v
@@ -1,40 +1,5 @@
 
-`define bsg_mem_2r1w_sync_macro(words,bits,mux)      \
-  if (harden_p && els_p == words && width_p == bits) \
-    begin: macro                                     \
-      gf14_1r1w_d``words``_w``bits``_m``mux          \
-        mem0                                         \
-          ( .CLKA  ( clk_i     )                     \
-          , .CLKB  ( clk_i     )                     \
-          , .CENA  ( ~r0_v_i   )                     \
-          , .AA    ( r0_addr_i )                     \
-          , .QA    ( r0_data_o )                     \
-          , .CENB  ( ~w_v_i    )                     \
-          , .AB    ( w_addr_i  )                     \
-          , .DB    ( w_data_i  )                     \
-          , .EMAA  ( 3'b011    )                     \
-          , .EMAB  ( 3'b011    )                     \
-          , .EMASA ( 1'b0      )                     \
-          , .STOV  ( 1'b0      )                     \
-          , .RET1N ( 1'b1      )                     \
-          );                                         \
-      gf14_1r1w_d``words``_w``bits``_m``mux          \
-        mem1                                         \
-          ( .CLKA  ( clk_i     )                     \
-          , .CLKB  ( clk_i     )                     \
-          , .CENA  ( ~r1_v_i   )                     \
-          , .AA    ( r1_addr_i )                     \
-          , .QA    ( r1_data_o )                     \
-          , .CENB  ( ~w_v_i    )                     \
-          , .AB    ( w_addr_i  )                     \
-          , .DB    ( w_data_i  )                     \
-          , .EMAA  ( 3'b011    )                     \
-          , .EMAB  ( 3'b011    )                     \
-          , .EMASA ( 1'b0      )                     \
-          , .STOV  ( 1'b0      )                     \
-          , .RET1N ( 1'b1      )                     \
-          );                                         \
-    end: macro
+`include "bsg_mem_2r1w_sync_macros.vh"
 
 module bsg_mem_2r1w_sync #( parameter width_p = -1
                           , parameter els_p = -1
@@ -42,7 +7,6 @@ module bsg_mem_2r1w_sync #( parameter width_p = -1
                           , parameter addr_width_lp = `BSG_SAFE_CLOG2(els_p)
                           , parameter harden_p = 1
                           , parameter substitute_2r1w_p = 0
-                          , parameter latch_last_read_p = 1
                           )
   ( input clk_i
   , input reset_i
@@ -62,11 +26,7 @@ module bsg_mem_2r1w_sync #( parameter width_p = -1
 
   wire unused = reset_i;
 
-  // TODO: Set hardened macro configs in this define
-  `ifdef BSG_MEM_HARD_2R1W_SYNC_MACROS
-  `BSG_MEM_HARD_2R1W_SYNC_MACROS
-  `endif
-  // or define them here
+  // TODO: Define more hardened macro configs here
   `bsg_mem_2r1w_sync_macro(32,64,1) else
   //`bsg_mem_2r1w_sync_macro(32,32,2) else
 
@@ -105,7 +65,7 @@ module bsg_mem_2r1w_sync #( parameter width_p = -1
         end // block: s1r1w
       else
         begin: notmacro
-          bsg_mem_2r1w_sync_synth #(.width_p(width_p), .els_p(els_p), .read_write_same_addr_p(read_write_same_addr_p), .harden_p(harden_p))
+          bsg_mem_2r1w_sync_synth #(.width_p(width_p), .els_p(els_p), .read_write_same_addr_p(read_write_same_addr_p))
             synth
               (.*);
         end // block: notmacro

--- a/hard/gf_14/bsg_mem/bsg_mem_2r1w_sync_macros.vh
+++ b/hard/gf_14/bsg_mem/bsg_mem_2r1w_sync_macros.vh
@@ -1,0 +1,38 @@
+
+`define bsg_mem_2r1w_sync_macro(words,bits,mux)      \
+  if (harden_p && els_p == words && width_p == bits) \
+    begin: macro                                     \
+      gf14_1r1w_d``words``_w``bits``_m``mux          \
+        mem0                                         \
+          ( .CLKA  ( clk_i     )                     \
+          , .CLKB  ( clk_i     )                     \
+          , .CENA  ( ~r0_v_i   )                     \
+          , .AA    ( r0_addr_i )                     \
+          , .QA    ( r0_data_o )                     \
+          , .CENB  ( ~w_v_i    )                     \
+          , .AB    ( w_addr_i  )                     \
+          , .DB    ( w_data_i  )                     \
+          , .EMAA  ( 3'b011    )                     \
+          , .EMAB  ( 3'b011    )                     \
+          , .EMASA ( 1'b0      )                     \
+          , .STOV  ( 1'b0      )                     \
+          , .RET1N ( 1'b1      )                     \
+          );                                         \
+      gf14_1r1w_d``words``_w``bits``_m``mux          \
+        mem1                                         \
+          ( .CLKA  ( clk_i     )                     \
+          , .CLKB  ( clk_i     )                     \
+          , .CENA  ( ~r1_v_i   )                     \
+          , .AA    ( r1_addr_i )                     \
+          , .QA    ( r1_data_o )                     \
+          , .CENB  ( ~w_v_i    )                     \
+          , .AB    ( w_addr_i  )                     \
+          , .DB    ( w_data_i  )                     \
+          , .EMAA  ( 3'b011    )                     \
+          , .EMAB  ( 3'b011    )                     \
+          , .EMASA ( 1'b0      )                     \
+          , .STOV  ( 1'b0      )                     \
+          , .RET1N ( 1'b1      )                     \
+          );                                         \
+    end: macro
+

--- a/hard/gf_14/bsg_mem/bsg_mem_2r1w_sync_macros.vh
+++ b/hard/gf_14/bsg_mem/bsg_mem_2r1w_sync_macros.vh
@@ -1,4 +1,7 @@
 
+`ifndef BSG_MEM_2R1W_SYNC_MACROS_VH
+`define BSG_MEM_2R1W_SYNC_MACROS_VH
+
 `define bsg_mem_2r1w_sync_macro(words,bits,mux)      \
   if (harden_p && els_p == words && width_p == bits) \
     begin: macro                                     \
@@ -35,4 +38,6 @@
           , .RET1N ( 1'b1      )                     \
           );                                         \
     end: macro
+
+`endif
 

--- a/hard/gf_14/bsg_mem/bsg_mem_3r1w_sync.v
+++ b/hard/gf_14/bsg_mem/bsg_mem_3r1w_sync.v
@@ -81,7 +81,11 @@ module bsg_mem_3r1w_sync #( parameter width_p = -1
 
   wire unused = reset_i;
 
-  // TODO: Define more hardened macro configs here
+  // TODO: Set hardened macro configs in this define
+  `ifdef BSG_MEM_HARD_3R1W_SYNC_MACROS
+  `BSG_MEM_HARD_3R1W_SYNC_MACROS
+  `endif
+  // or define them here
   `bsg_mem_3r1w_sync_macro(32,64,1) else
   //`bsg_mem_3r1w_sync_macro(32,32,2) else
 

--- a/hard/gf_14/bsg_mem/bsg_mem_3r1w_sync.v
+++ b/hard/gf_14/bsg_mem/bsg_mem_3r1w_sync.v
@@ -1,63 +1,11 @@
 
-`define bsg_mem_3r1w_sync_macro(words,bits,mux)      \
-  if (harden_p && els_p == words && width_p == bits) \
-    begin: macro                                     \
-      gf14_1r1w_d``words``_w``bits``_m``mux          \
-        mem0                                         \
-          ( .CLKA  ( clk_i     )                     \
-          , .CLKB  ( clk_i     )                     \
-          , .CENA  ( ~r0_v_i   )                     \
-          , .AA    ( r0_addr_i )                     \
-          , .QA    ( r0_data_o )                     \
-          , .CENB  ( ~w_v_i    )                     \
-          , .AB    ( w_addr_i  )                     \
-          , .DB    ( w_data_i  )                     \
-          , .EMAA  ( 3'b011    )                     \
-          , .EMAB  ( 3'b011    )                     \
-          , .EMASA ( 1'b0      )                     \
-          , .STOV  ( 1'b0      )                     \
-          , .RET1N ( 1'b1      )                     \
-          );                                         \
-      gf14_1r1w_d``words``_w``bits``_m``mux          \
-        mem1                                         \
-          ( .CLKA  ( clk_i     )                     \
-          , .CLKB  ( clk_i     )                     \
-          , .CENA  ( ~r1_v_i   )                     \
-          , .AA    ( r1_addr_i )                     \
-          , .QA    ( r1_data_o )                     \
-          , .CENB  ( ~w_v_i    )                     \
-          , .AB    ( w_addr_i  )                     \
-          , .DB    ( w_data_i  )                     \
-          , .EMAA  ( 3'b011    )                     \
-          , .EMAB  ( 3'b011    )                     \
-          , .EMASA ( 1'b0      )                     \
-          , .STOV  ( 1'b0      )                     \
-          , .RET1N ( 1'b1      )                     \
-          );                                         \
-      gf14_1r1w_d``words``_w``bits``_m``mux          \
-        mem2                                         \
-          ( .CLKA  ( clk_i     )                     \
-          , .CLKB  ( clk_i     )                     \
-          , .CENA  ( ~r2_v_i   )                     \
-          , .AA    ( r2_addr_i )                     \
-          , .QA    ( r2_data_o )                     \
-          , .CENB  ( ~w_v_i    )                     \
-          , .AB    ( w_addr_i  )                     \
-          , .DB    ( w_data_i  )                     \
-          , .EMAA  ( 3'b011    )                     \
-          , .EMAB  ( 3'b011    )                     \
-          , .EMASA ( 1'b0      )                     \
-          , .STOV  ( 1'b0      )                     \
-          , .RET1N ( 1'b1      )                     \
-          );                                         \
-    end: macro
+`include "bsg_mem_3r1w_sync_macros.vh"
 
 module bsg_mem_3r1w_sync #( parameter width_p = -1
                           , parameter els_p = -1
                           , parameter read_write_same_addr_p = 0
                           , parameter addr_width_lp = `BSG_SAFE_CLOG2(els_p)
                           , parameter harden_p = 1
-                          , parameter latch_last_read_p = 1
                           )
   ( input clk_i
   , input reset_i
@@ -81,17 +29,13 @@ module bsg_mem_3r1w_sync #( parameter width_p = -1
 
   wire unused = reset_i;
 
-  // TODO: Set hardened macro configs in this define
-  `ifdef BSG_MEM_HARD_3R1W_SYNC_MACROS
-  `BSG_MEM_HARD_3R1W_SYNC_MACROS
-  `endif
-  // or define them here
+  // TODO: Define more hardened macro configs here
   `bsg_mem_3r1w_sync_macro(32,64,1) else
   //`bsg_mem_3r1w_sync_macro(32,32,2) else
 
   // no hardened version found
    begin: notmacro
-     bsg_mem_3r1w_sync_synth #(.width_p(width_p), .els_p(els_p), .read_write_same_addr_p(read_write_same_addr_p), .harden_p(harden_p))
+     bsg_mem_3r1w_sync_synth #(.width_p(width_p), .els_p(els_p), .read_write_same_addr_p(read_write_same_addr_p))
       synth
        (.*);
    end // block: notmacro

--- a/hard/gf_14/bsg_mem/bsg_mem_3r1w_sync_macros.vh
+++ b/hard/gf_14/bsg_mem/bsg_mem_3r1w_sync_macros.vh
@@ -1,0 +1,54 @@
+
+`define bsg_mem_3r1w_sync_macro(words,bits,mux)      \
+  if (harden_p && els_p == words && width_p == bits) \
+    begin: macro                                     \
+      gf14_1r1w_d``words``_w``bits``_m``mux          \
+        mem0                                         \
+          ( .CLKA  ( clk_i     )                     \
+          , .CLKB  ( clk_i     )                     \
+          , .CENA  ( ~r0_v_i   )                     \
+          , .AA    ( r0_addr_i )                     \
+          , .QA    ( r0_data_o )                     \
+          , .CENB  ( ~w_v_i    )                     \
+          , .AB    ( w_addr_i  )                     \
+          , .DB    ( w_data_i  )                     \
+          , .EMAA  ( 3'b011    )                     \
+          , .EMAB  ( 3'b011    )                     \
+          , .EMASA ( 1'b0      )                     \
+          , .STOV  ( 1'b0      )                     \
+          , .RET1N ( 1'b1      )                     \
+          );                                         \
+      gf14_1r1w_d``words``_w``bits``_m``mux          \
+        mem1                                         \
+          ( .CLKA  ( clk_i     )                     \
+          , .CLKB  ( clk_i     )                     \
+          , .CENA  ( ~r1_v_i   )                     \
+          , .AA    ( r1_addr_i )                     \
+          , .QA    ( r1_data_o )                     \
+          , .CENB  ( ~w_v_i    )                     \
+          , .AB    ( w_addr_i  )                     \
+          , .DB    ( w_data_i  )                     \
+          , .EMAA  ( 3'b011    )                     \
+          , .EMAB  ( 3'b011    )                     \
+          , .EMASA ( 1'b0      )                     \
+          , .STOV  ( 1'b0      )                     \
+          , .RET1N ( 1'b1      )                     \
+          );                                         \
+      gf14_1r1w_d``words``_w``bits``_m``mux          \
+        mem2                                         \
+          ( .CLKA  ( clk_i     )                     \
+          , .CLKB  ( clk_i     )                     \
+          , .CENA  ( ~r2_v_i   )                     \
+          , .AA    ( r2_addr_i )                     \
+          , .QA    ( r2_data_o )                     \
+          , .CENB  ( ~w_v_i    )                     \
+          , .AB    ( w_addr_i  )                     \
+          , .DB    ( w_data_i  )                     \
+          , .EMAA  ( 3'b011    )                     \
+          , .EMAB  ( 3'b011    )                     \
+          , .EMASA ( 1'b0      )                     \
+          , .STOV  ( 1'b0      )                     \
+          , .RET1N ( 1'b1      )                     \
+          );                                         \
+    end: macro
+

--- a/hard/gf_14/bsg_mem/bsg_mem_3r1w_sync_macros.vh
+++ b/hard/gf_14/bsg_mem/bsg_mem_3r1w_sync_macros.vh
@@ -1,4 +1,7 @@
 
+`ifndef BSG_MEM_3R1W_SYNC_MACROS
+`define BSG_MEM_3R1W_SYNC_MACROS
+
 `define bsg_mem_3r1w_sync_macro(words,bits,mux)      \
   if (harden_p && els_p == words && width_p == bits) \
     begin: macro                                     \
@@ -51,4 +54,6 @@
           , .RET1N ( 1'b1      )                     \
           );                                         \
     end: macro
+
+`endif
 


### PR DESCRIPTION
This PR adds hooks to the hardened memories so that external designs can define their own macros without having to change the files here.  This has several advantages:
- Not having to maintain separate incompatible tapeout branches for each design
- Not all memories have an optimal configuration; this allows us to specialize per design
- Adds hooks for users who are straight compiling instead of using a "swap" methodology