### PR TITLE
Fixing width_p = 1 for bsg_priority_encode

### DIFF
--- a/bsg_misc/bsg_encode_one_hot.v
+++ b/bsg_misc/bsg_encode_one_hot.v
@@ -30,7 +30,7 @@ module bsg_encode_one_hot #(parameter width_p=8, parameter lo_to_hi_p=1, paramet
   
   // base case, also handle padding for non-power of two inputs
   assign v   [0] = lo_to_hi_p ? ((aligned_width_lp) ' (i)) :  i << (aligned_width_lp - width_p);
-  assign addr[0] = `BSG_UNDEFINED_IN_SIM('0);
+  assign addr[0] = '0;
   
   for (level = 1; level < levels_lp+1; level=level+1)
     begin : rof

--- a/bsg_misc/bsg_encode_one_hot.v
+++ b/bsg_misc/bsg_encode_one_hot.v
@@ -30,7 +30,7 @@ module bsg_encode_one_hot #(parameter width_p=8, parameter lo_to_hi_p=1, paramet
   
   // base case, also handle padding for non-power of two inputs
   assign v   [0] = lo_to_hi_p ? ((aligned_width_lp) ' (i)) :  i << (aligned_width_lp - width_p);
-  assign addr[0] = '0;
+  assign addr[0] = (width_p == 1) ? '0 : `BSG_UNDEFINED_IN_SIM('0);
   
   for (level = 1; level < levels_lp+1; level=level+1)
     begin : rof

--- a/bsg_misc/bsg_priority_encode_one_hot_out.v
+++ b/bsg_misc/bsg_priority_encode_one_hot_out.v
@@ -21,9 +21,12 @@ module bsg_priority_encode_one_hot_out #(parameter width_p      = "inv"
    logic [width_p-1:0] scan_lo;
 
    if (width_p == 1)
-     assign o = i;
+     begin: w1
+      assign o = i;
+      assign v_o = i ? 1'b1 : 1'b0;
+     end
    else
-     begin
+     begin: nw1
        bsg_scan #(.width_p(width_p)
                   ,.or_p      (1)
                   ,.lo_to_hi_p(lo_to_hi_p)

--- a/bsg_misc/bsg_priority_encode_one_hot_out.v
+++ b/bsg_misc/bsg_priority_encode_one_hot_out.v
@@ -23,7 +23,7 @@ module bsg_priority_encode_one_hot_out #(parameter width_p      = "inv"
    if (width_p == 1)
      begin: w1
       assign o = i;
-      assign v_o = i ? 1'b1 : 1'b0;
+      assign v_o = i;
      end
    else
      begin: nw1


### PR DESCRIPTION
This PR adds a fix to the priority encoder and its leaf modules to support width_p = 1.