### PR TITLE
Fix wormhole streamers to use passthrough_dynamic SIPO/PISO

### DIFF
--- a/bsg_dataflow/bsg_parallel_in_serial_out_passthrough.v
+++ b/bsg_dataflow/bsg_parallel_in_serial_out_passthrough.v
@@ -98,7 +98,7 @@ module bsg_parallel_in_serial_out_passthrough #( parameter width_p    = -1
         begin
           assert (v_i)
             else $error("v_i must be held high during the entire PISO transaction");
-          assert (data_i == initial_data_r)
+          assert (data_i === initial_data_r)
             else $error("data_i must be held constant during the entire PISO transaction");
         end
     end

--- a/bsg_noc/bsg_wormhole_stream_in.v
+++ b/bsg_noc/bsg_wormhole_stream_in.v
@@ -165,7 +165,7 @@ module bsg_wormhole_stream_in
       // set value is zero based and equal to (protocol beats - 1)
       // SIPO passthrough sends same cycle it receives last data input
       logic [pr_len_width_p-1:0] pr_data_cnt;
-      wire pr_data_consumed = (pr_data_cnt == '0);
+      wire pr_data_last = (pr_data_cnt == '0);
       bsg_counter_set_down
        #(.width_p(pr_len_width_p)
          ,.init_val_p('0)
@@ -176,7 +176,7 @@ module bsg_wormhole_stream_in
          ,.reset_i(reset_i)
          ,.set_i(hdr_v_i & hdr_ready_and_o)
          ,.val_i(pr_data_beats_i)
-         ,.down_i(data_v_i & data_ready_and_o & ~pr_data_consumed)
+         ,.down_i(data_v_i & data_ready_and_o & ~pr_data_last)
          ,.count_r_o(pr_data_cnt)
          );
 

--- a/bsg_noc/bsg_wormhole_stream_out.v
+++ b/bsg_noc/bsg_wormhole_stream_out.v
@@ -27,6 +27,7 @@
 //   ---------------------------------------------------------------
 //   | data   | data  | data  | data  | protocol info | len   cord |
 //   ---------------------------------------------------------------
+//   - header flits do not contain any data
 //
 //  Header will arrive at or before data and either can be acked at any time.
 //    Typical users of this module will simply ack the header to learn the 
@@ -49,6 +50,7 @@ module bsg_wormhole_stream_out
    // Higher level protocol information
    , parameter pr_hdr_width_p  = "inv"
    , parameter pr_data_width_p = "inv"
+   , parameter pr_len_width_p  = "inv"
 
    // Size of the wormhole header + the protocol header. The data starts afterwards.
    // Users may set this directly rather than relying on the protocol header derived default
@@ -66,6 +68,10 @@ module bsg_wormhole_stream_out
    , output [hdr_width_p-1:0]     hdr_o
    , output                       hdr_v_o
    , input                        hdr_ready_and_i
+   // number of protocol message data flits in arriving wormhole message
+   // arrives late when hdr_v_o & hdr_ready_and_i
+   // value is flits-1 (i.e., zero based)
+   , input [pr_len_width_p-1:0]   pr_data_flits_i
 
    // The protocol data information
    , output [pr_data_width_p-1:0] data_o
@@ -103,12 +109,51 @@ module bsg_wormhole_stream_out
   assign data_v_li = is_data & link_v_i;
   // Protocol data is less than a single flit-sized. We accept a large
   //   wormhole flit, then let the client process it piecemeal
-  if (flit_width_p >= pr_data_width_p)
+  if (flit_width_p > pr_data_width_p)
     begin : narrow
-      localparam [len_width_p-1:0] data_len_lp = `BSG_CDIV(flit_width_p, pr_data_width_p);
-      bsg_parallel_in_serial_out_passthrough
+      // flit_width_p > pr_data_width_p -> multiple protocol data per link flit
+      // and it is possible that last link flit is not completely filled with valid
+      // protocol data.
+
+      // number of protocol data flits per full link flit
+      localparam [len_width_p-1:0] max_els_lp = `BSG_CDIV(flit_width_p, pr_data_width_p);
+      localparam lg_max_els_lp = `BSG_SAFE_CLOG2(max_els_lp);
+      // PISO len_i is zero-based, i.e., input is len-1
+      localparam [lg_max_els_lp-1:0] piso_full_len_lp = max_els_lp - 1;
+
+      // PISO inputs
+      logic piso_first_lo;
+      logic [lg_max_els_lp-1:0] piso_len_li;
+
+      // count of protocol data flits to consume after current flit
+      // set late when hdr_v_o & hdr_ready_i
+      // set value is provided by consumer, derived from output header
+      logic [pr_len_width_p-1:0] pr_data_cnt;
+      wire pr_data_consumed = (pr_data_cnt == '0);
+      bsg_counter_set_down
+       #(.width_p(pr_len_width_p)
+         ,.init_val_p('0)
+         ,.set_and_down_exclusive_p(0)
+         )
+       pr_data_counter
+        (.clk_i(clk_i)
+         ,.reset_i(reset_i)
+         ,.set_i(hdr_v_o & hdr_ready_and_i)
+         ,.val_i(pr_data_flits_i)
+         ,.down_i(data_v_o & data_ready_and_i & ~pr_data_consumed)
+         ,.count_r_o(pr_data_cnt)
+         );
+
+      // for each PISO transaction, provide number of protocol flits to expect
+      assign piso_len_li = (data_ready_and_i & piso_first_lo)
+                           ? (pr_data_cnt >= piso_full_len_lp)
+                             ? piso_full_len_lp
+                             : lg_max_els_lp'(pr_data_cnt)
+                           : '0;
+
+      bsg_parallel_in_serial_out_passthrough_dynamic
        #(.width_p(pr_data_width_p)
-         ,.els_p(data_len_lp)
+         ,.max_els_p(max_els_lp)
          )
        data_piso
         (.clk_i(clk_i)
@@ -121,12 +166,16 @@ module bsg_wormhole_stream_out
          ,.data_o(data_o)
          ,.v_o(data_v_o)
          ,.ready_and_i(data_ready_and_i)
+
+         ,.first_o(piso_first_lo)
+         // must be presented when ready_and_i & first_o
+         ,.len_i(piso_len_li)
          );
     end
   else
     // Protocol data is 1 or multiple flit-sized. We aggregate wormhole data 
     //   until we have a full protocol data and then let the client process it
-    begin : narrow
+    begin : wide
       localparam [len_width_p-1:0] data_len_lp = `BSG_CDIV(pr_data_width_p, flit_width_p);
       bsg_serial_in_parallel_out_passthrough
        #(.width_p(flit_width_p)
@@ -145,7 +194,7 @@ module bsg_wormhole_stream_out
          ,.ready_and_i(data_ready_and_i)
          );
     end
-  
+
   // Identifies which flits are header vs data flits
   bsg_wormhole_stream_control
    #(.len_width_p(len_width_p)


### PR DESCRIPTION
This change modifies the wormhole streamer modules to use passthrough_dynamic variants of SIPO/PISO when protocol data width < link flit width. The streamer protocol client provides an expected number of data flits and then the wormhole streamer computes the number of protocol data flits per PISO/SIPO transaction.

Without this feature, the protocol client would need to send extra null data packets (SIPO) or drain null data packets (PISO) to completely fill or drain the SIPO/PISO, respectively.

~~This change allows the wormhole_stream_out module to drain invalid client data flits. This can occur when the input link flit width is greater than the output client protocol data width, if the client protocol message does not have a full link flit width of data. Without the drain, the client would be responsible for knowing the link flit width and draining extra, invalid data packets.~~