### PR TITLE
Added support to call DRAMSim3 StatsPrint with stats_snoop

### DIFF
--- a/bsg_test/bsg_dramsim3.cpp
+++ b/bsg_test/bsg_dramsim3.cpp
@@ -156,6 +156,17 @@ public:
         _memory_system->ClockTick();
     }
 
+    /////////////////
+    // Print Stats //
+    /////////////////
+    void printTagStats(uint32_t tag) {
+        _memory_system->PrintTagStats(tag);
+    }
+
+    void printFinalStats() {
+        _memory_system->PrintStats();
+    }
+
     //////////////////////////////
     // Query completed requests //
     //////////////////////////////
@@ -215,6 +226,15 @@ extern "C" void bsg_dramsim3_tick(BSGDRAMSim3 *dramsim3)
 }
 
 /**
+ * Print Stats
+ * @param[in] The tag to keep track of stats
+ */
+extern "C" void bsg_dramsim3_print_stats(BSGDRAMSim3 *dramsim3, uint32_t tag)
+{
+    dramsim3->printTagStats(tag);
+}
+
+/**
  * Check if the channel has complete a read request.
  * @param[in] ch The channel to check for completion.
  */
@@ -250,12 +270,12 @@ extern "C" addr_t bsg_dramsim3_get_write_done_addr(BSGDRAMSim3 *dramsim3, int ch
     return dramsim3->getWriteDoneAddr(ch);
 }
 
-
 /**
  * Cleanup code for the memory system.
  */
 extern "C" void bsg_dramsim3_exit(BSGDRAMSim3 *dramsim3)
 {
+    dramsim3->printFinalStats();
     delete dramsim3;
 }
 

--- a/bsg_test/bsg_nonsynth_dramsim3.v
+++ b/bsg_test/bsg_nonsynth_dramsim3.v
@@ -25,6 +25,7 @@ module bsg_nonsynth_dramsim3
     , parameter mem_addr_width_lp=$clog2(num_channels_p)+channel_addr_width_p
     , parameter data_mask_width_lp=(data_width_p>>3)
     , parameter byte_offset_width_lp=`BSG_SAFE_CLOG2(data_width_p>>3)
+    , parameter tag_width_p=32
   )
   (
     input clk_i
@@ -38,6 +39,11 @@ module bsg_nonsynth_dramsim3
     , input [num_channels_p-1:0] data_v_i
     , input [num_channels_p-1:0][data_width_p-1:0] data_i
     , input [num_channels_p-1:0][data_mask_width_lp-1:0] mask_i
+
+    //stats info
+    , input print_stat_v_i
+    , input [tag_width_p-1:0] print_stat_tag_i
+
     , output logic [num_channels_p-1:0] data_yumi_o 
 
     , output logic [num_channels_p-1:0] data_v_o
@@ -79,6 +85,9 @@ module bsg_nonsynth_dramsim3
   
   import "DPI-C" context function
     void    bsg_dramsim3_tick(input chandle dramsim3_handle);
+
+  import "DPI-C" context function
+    void    bsg_dramsim3_print_stats(input chandle dramsim3_handle, int unsigned tag);
   
   import "DPI-C" context function 
     void    bsg_dramsim3_exit(input chandle dramsim3_handle);
@@ -262,6 +271,13 @@ module bsg_nonsynth_dramsim3
     else begin
       data_v_o <= read_v_li;
       read_done_ch_addr_o <= read_done_ch_addr;
+    end
+  end
+
+  //print_stat
+  always_ff @ (negedge clk_i) begin
+    if ((reset_i === 0) & (print_stat_v_i === 1)) begin
+      bsg_dramsim3_print_stats(dramsim3_handle, print_stat_tag_i);
     end
   end
 


### PR DESCRIPTION
Part of changes for stat tag support for DRAMSim3
https://github.com/bespoke-silicon-group/bsg_replicant/commit/0f0525a543a948f62aafa3261d1e115fb376006e 
https://github.com/bsg-external/DRAMsim3/commit/c560aa2158dd825d415db63af967c1d347c28663