### PR TITLE
DRAMSim3 moves macros from source to header

### DIFF
--- a/bsg_test/bsg_dramsim3.vh
+++ b/bsg_test/bsg_dramsim3.vh
@@ -1,0 +1,30 @@
+`ifndef BSG_DRAMSIM3_VH
+`define BSG_DRAMSIM3_VH
+
+`define dramsim3_ba_width(num_ba_mp) $clog2(num_ba_mp)
+`define dramsim3_bg_width(num_bg_mp) $clog2(num_bg_mp)
+`define dramsim3_co_width(num_columns_mp) $clog2(num_columns_mp)
+`define dramsim3_ro_width(num_rows_mp) $clog2(num_rows_mp)
+`define dramsim3_ra_width(num_ranks_mp) $clog2(num_ranks_mp)
+`define dramsim3_byte_offset_width(data_width_mp) \
+  $clog2(data_width_mp>>3)
+
+`define dramsim3_ba_width_pkg(dram_pkg) \
+  `dramsim3_ba_width(dram_pkg::num_ba_p)
+
+`define dramsim3_bg_width_pkg(dram_pkg) \
+  `dramsim3_bg_width(dram_pkg::num_bg_p)
+
+`define dramsim3_co_width_pkg(dram_pkg) \
+  `dramsim3_co_width(dram_pkg::num_columns_p)
+
+`define dramsim3_ro_width_pkg(dram_pkg) \
+  `dramsim3_ro_width(dram_pkg::num_rows_p)
+
+`define dramsim3_ra_width_pkg(dram_pkg) \
+  `dramsim3_ra_width(dram_pkg::num_ranks_p)
+
+`define dramsim3_byte_offset_width_pkg(dram_pkg) \
+  `dramsim3_byte_offset_width(dram_pkg::data_width_p)
+
+`endif

--- a/bsg_test/bsg_dramsim3_pkg.v
+++ b/bsg_test/bsg_dramsim3_pkg.v
@@ -82,29 +82,3 @@ package bsg_dramsim3_lpddr3_8gb_x32_1600_pkg;
   } dram_ch_addr_s;
 
 endpackage // bsg_dramsim3_lpddr3_8gb_x32_1600_pkg
-
-`define dramsim3_ba_width(num_ba_mp) $clog2(num_ba_mp)
-`define dramsim3_bg_width(num_bg_mp) $clog2(num_bg_mp)
-`define dramsim3_co_width(num_columns_mp) $clog2(num_columns_mp)
-`define dramsim3_ro_width(num_rows_mp) $clog2(num_rows_mp)
-`define dramsim3_ra_width(num_ranks_mp) $clog2(num_ranks_mp)
-`define dramsim3_byte_offset_width(data_width_mp) \
-  $clog2(data_width_mp>>3)
-
-`define dramsim3_ba_width_pkg(dram_pkg) \
-  `dramsim3_ba_width(dram_pkg::num_ba_p)
-
-`define dramsim3_bg_width_pkg(dram_pkg) \
-  `dramsim3_bg_width(dram_pkg::num_bg_p)
-
-`define dramsim3_co_width_pkg(dram_pkg) \
-  `dramsim3_co_width(dram_pkg::num_columns_p)
-
-`define dramsim3_ro_width_pkg(dram_pkg) \
-  `dramsim3_ro_width(dram_pkg::num_rows_p)
-
-`define dramsim3_ra_width_pkg(dram_pkg) \
-  `dramsim3_ra_width(dram_pkg::num_ranks_p)
-
-`define dramsim3_byte_offset_width_pkg(dram_pkg) \
-  `dramsim3_byte_offset_width(dram_pkg::data_width_p)


### PR DESCRIPTION
Fixes #368 