### PR TITLE
Removing shadowed genvar

### DIFF
--- a/bsg_misc/bsg_scan.v
+++ b/bsg_misc/bsg_scan.v
@@ -116,7 +116,7 @@ module bsg_scan #(parameter width_p = -1
    // reverse bits
    if (lo_to_hi_p)
      //assign o = {<< {t[$clog2(width_p)]}};
-for (genvar j = 0; j < width_p; j++) begin
+    for (j = 0; j < width_p; j++) begin
       assign o[j] = t[$clog2(width_p)][width_p-1-j];
     end
 


### PR DESCRIPTION
genvar j is declared above; no need to redeclare it.

Causing warning in Verilator