### PR TITLE
VCS 2020 Variable initialization related fix

### DIFF
--- a/bsg_test/bsg_nonsynth_clock_gen.v
+++ b/bsg_test/bsg_nonsynth_clock_gen.v
@@ -13,6 +13,7 @@ module bsg_nonsynth_clock_gen
     $display("%m with cycle_time_p ",cycle_time_p);
     assert(cycle_time_p >= 2)
        else $error("cannot simulate cycle time less than 2");
+    o = 1;
   end
   
   always #(cycle_time_p/2.0) begin


### PR DESCRIPTION
There is an open discussion [here](https://github.com/bespoke-silicon-group/bsg_replicant/issues/638) about the simulation error using VCS 2020, and this PR attempts to fix that issue by initializing the clock generator output to 1. This should work with the async reset generator (triggered by the negative edge of input clock) to correctly assert the reset signal from simulation zero.