### PR TITLE
Fixing the bugs for LD/SD when data_width_p > 64

### DIFF
--- a/bsg_cache/bsg_cache.v
+++ b/bsg_cache/bsg_cache.v
@@ -681,7 +681,7 @@ module bsg_cache
 
     assign sbuf_data_in_mux_li[i] = {(data_width_p/slice_width_lp){slice_data}};
 
-    if (i == data_sel_mux_els_lp-1) begin: max_size
+    if (i == data_sel_mux_els_lp-1 && data_width_p <= 64) begin: max_size
       assign sbuf_mask_in_mux_li[i] = {data_mask_width_lp{1'b1}};    
     end 
     else begin: non_max_size

--- a/bsg_cache/bsg_cache.v
+++ b/bsg_cache/bsg_cache.v
@@ -681,29 +681,23 @@ module bsg_cache
 
     assign sbuf_data_in_mux_li[i] = {(data_width_p/slice_width_lp){slice_data}};
 
-    if (i == data_sel_mux_els_lp-1 && data_width_p <= 64) begin: max_size
-      assign sbuf_mask_in_mux_li[i] = {data_mask_width_lp{1'b1}};    
-    end 
-    else begin: non_max_size
+    logic [(data_width_p/slice_width_lp)-1:0] decode_lo;
 
-      logic [(data_width_p/slice_width_lp)-1:0] decode_lo;
+    bsg_decode #(
+      .num_out_p(data_width_p/slice_width_lp)
+    ) dec (
+      .i(addr_v_r[i+:`BSG_MAX(lg_data_mask_width_lp-i,1)])
+      ,.o(decode_lo)
+    );
 
-      bsg_decode #(
-        .num_out_p(data_width_p/slice_width_lp)
-      ) dec (
-        .i(addr_v_r[i+:`BSG_MAX(lg_data_mask_width_lp-i,1)])
-        ,.o(decode_lo)
-      );
+    bsg_expand_bitmask #(
+      .in_width_p(data_width_p/slice_width_lp)
+      ,.expand_p(2**i)
+    ) exp (
+      .i(decode_lo)
+      ,.o(sbuf_mask_in_mux_li[i])
+    );
 
-      bsg_expand_bitmask #(
-        .in_width_p(data_width_p/slice_width_lp)
-        ,.expand_p(2**i)
-      ) exp (
-        .i(decode_lo)
-        ,.o(sbuf_mask_in_mux_li[i])
-      );
-
-    end
   end
 
   // store buffer data,mask input

--- a/bsg_cache/bsg_cache.v
+++ b/bsg_cache/bsg_cache.v
@@ -771,13 +771,6 @@ module bsg_cache
 
   for (genvar i = 0; i < data_sel_mux_els_lp; i++) begin: ld_data_sel
 
-    if (i == data_sel_mux_els_lp-1) begin: max_size
-
-      assign ld_data_final_li[i] = snoop_or_ld_data;
-
-    end
-    else begin: non_max_size
-
       logic [(8*(2**i))-1:0] byte_sel;
 
       bsg_mux #(
@@ -792,7 +785,6 @@ module bsg_cache
       assign ld_data_final_li[i] = 
         {{(data_width_p-(8*(2**i))){decode_v_r.sigext_op & byte_sel[(8*(2**i))-1]}}, byte_sel};
 
-    end
 
   end
   

--- a/bsg_cache/bsg_cache.v
+++ b/bsg_cache/bsg_cache.v
@@ -681,22 +681,22 @@ module bsg_cache
 
     assign sbuf_data_in_mux_li[i] = {(data_width_p/slice_width_lp){slice_data}};
 
-    logic [(data_width_p/slice_width_lp)-1:0] decode_lo;
+      logic [(data_width_p/slice_width_lp)-1:0] decode_lo;
 
-    bsg_decode #(
-      .num_out_p(data_width_p/slice_width_lp)
-    ) dec (
-      .i(addr_v_r[i+:`BSG_MAX(lg_data_mask_width_lp-i,1)])
-      ,.o(decode_lo)
-    );
+      bsg_decode #(
+        .num_out_p(data_width_p/slice_width_lp)
+      ) dec (
+        .i(addr_v_r[i+:`BSG_MAX(lg_data_mask_width_lp-i,1)])
+        ,.o(decode_lo)
+      );
 
-    bsg_expand_bitmask #(
-      .in_width_p(data_width_p/slice_width_lp)
-      ,.expand_p(2**i)
-    ) exp (
-      .i(decode_lo)
-      ,.o(sbuf_mask_in_mux_li[i])
-    );
+      bsg_expand_bitmask #(
+        .in_width_p(data_width_p/slice_width_lp)
+        ,.expand_p(2**i)
+      ) exp (
+        .i(decode_lo)
+        ,.o(sbuf_mask_in_mux_li[i])
+      );
 
   end
 


### PR DESCRIPTION
## Motivation
To implement BP Stream Protocol between L1 and L2, we would like to make L2 cache slice have parameterizable data width, ranging from dword_width_p (64 bits) to cce_block_width_p (512 bits) with 2^n. However, there is a bug in the store buffer write mask for D (8 bytes) size when data_width_p is larger than 64 btis.

## Problem Description
When there is a SD operation, we expect data_mem_w_mask_li to be `8'hff` to write 64 bits, or 8 bytes data into the data_mem, like the following screenshot where the data_width_p==64.
![image](https://user-images.githubusercontent.com/26761214/103988893-ab16f800-5143-11eb-9d1e-c57ca9c4337d.png)

And when the data_width_p==128,  the data_mem_w_mask_li should be either  `16'h00ff` or `16'hff00` to write the lower half or the upper half of the 128 bits for a single SD op. However, the data_mem_w_mask_li becomes `16'hffff` and overwrites the other half mistakenly.
![image](https://user-images.githubusercontent.com/26761214/103989452-938c3f00-5144-11eb-9694-cc03584e3dee.png)

## Root Cause
Tracing the signals backward, the mask signal comes from sbuf_mask_in_mux_li. And there are at most 4 elements in sbuf_mask_in_mux_li, which are for W (1 byte), H(2 bytes), W(4 bytes), D(8 bytes) from index 0 to 3 correspondingly. Therefore, the focus is on `sbuf_mask_in_mux_li[data_sel_mux_els_lp-1]`, the max_size clause. (data_sel_mux_els_lp == 4 for 64 bits)
```
    if (i == data_sel_mux_els_lp-1) begin: max_size
      assign sbuf_mask_in_mux_li[i] = {data_mask_width_lp{1'b1}};    
    end 
    else begin: non_max_size

      logic [(data_width_p/slice_width_lp)-1:0] decode_lo;

      bsg_decode #(
        .num_out_p(data_width_p/slice_width_lp)
      ) dec (
        .i(addr_v_r[i+:`BSG_MAX(lg_data_mask_width_lp-i,1)])
        ,.o(decode_lo)
      );

      bsg_expand_bitmask #(
        .in_width_p(data_width_p/slice_width_lp)
        ,.expand_p(2**i)
      ) exp (
        .i(decode_lo)
        ,.o(sbuf_mask_in_mux_li[i])
      );

    end
```
The max_size clause optimizes out the decoding and expanding logic based on data_width_p used to be less than or equal to 64 bits for the max_size, and just sets all the bits for simplicity. For example, for data_width_p==64, max_size is D, then data_mask_width_lp ==(64>>3)==8, so we have the mask to be 8'hff.  For data_width_p==32, max_size is W, data_mask_width_lp ==(32>>3)==4, so we have the mask to be 4'hf.
However, when data_width_p==128, the new case we want to support, data_mask_width_lp==(128>>3)==16 and setting all the 16 bits to 1, while the max_size is still D, so the data_mem_w_mask_li of 16'hffff gives a bug.

## Solution
A simple solution is to add additional condition for the data_width_p for the max_size clauses
` if (i == data_sel_mux_els_lp-1 && data_width_p <= 64) begin: max_size`
to disable the max_size clause when data_width_p is larger than 64.
The expected sbuf_mask_in should be like this:
![image](https://user-images.githubusercontent.com/26761214/103989786-16ad9500-5145-11eb-90f3-230abe3293ce.png)


