### PR TITLE
Switch to assert final for bsg_circular_ptr, to satisfy VCS 2020

### DIFF
--- a/bsg_misc/bsg_circular_ptr.v
+++ b/bsg_misc/bsg_circular_ptr.v
@@ -69,7 +69,7 @@ module bsg_circular_ptr #(parameter slots_p     = -1
 	  // synopsys translate_off
           always_comb
             begin
-              assert( (ptr_n < slots_p) || (|ptr_n === 'X) || reset_i || (add_i > slots_p))
+              assert final( (ptr_n < slots_p) || (|ptr_n === 'X) || reset_i || (add_i > slots_p))
                 else $error("bsg_circular_ptr counter overflow (ptr_r=%b/add_i=%b/ptr_wrap=%b/ptr_n=%b)",ptr_r,add_i,ptr_wrap,ptr_n, slots_p);
             end
 	  // synopsys translate_on


### PR DESCRIPTION
When switching to VCS 2020, from VCS 2019 this assertion starts to fire. Whatever causes it does not seem to change the correctness, but it does cause error messages.

`assert final`, which waits until signals have stabilized, fixes the problem

Happy to add comments, etc.