### PR TITLE
Building a 1r1w memory using 1rw memories

### DIFF
--- a/bsg_mem/bsg_mem_1r1w_from_1rw_sync.v
+++ b/bsg_mem/bsg_mem_1r1w_from_1rw_sync.v
@@ -1,0 +1,100 @@
+// 1 read port, 1 write port memory implemented using two single port (1rw) memories
+//
+// reads are asynchronous
+
+`include "bsg_defines.v"
+
+module bsg_mem_1r1w_from_1rw_sync #(parameter width_p=-1
+                                   ,parameter els_p=-1
+                                   ,parameter read_write_same_addr_p=0
+                                   ,parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
+                                   ,parameter harden_p=0
+                                   ,parameter disable_collision_warning_p=1
+                                   ,parameter enable_clock_gating_p=0
+                                   )
+  (input clk_i
+  ,input reset_i
+  ,input                                        w_v_i
+  ,input [addr_width_lp-1:0]                    w_addr_i
+  ,input [`BSG_SAFE_MINUS(width_p, 1):0]        w_data_i
+  ,input                                        r_v_i
+  ,input [addr_width_lp-1:0]                    r_addr_i
+  ,output logic [`BSG_SAFE_MINUS(width_p, 1):0] r_data_o
+  );
+
+  logic [els_p-1:0] v_r;
+  logic mem_r;
+  wire v_r_wr_ptr = ~r_v_i | ~v_r[r_addr_i];
+  
+  always_ff @(posedge clk_i)
+    if (reset_i)
+      v_r <= '0;
+    else if (w_v_i)
+      v_r[w_addr_i] <= v_r_wr_ptr;
+
+  bsg_dff
+    #(.width_p(1))
+    mem_reg
+    (.clk_i(clk_i)
+    ,.data_i(v_r[r_addr_i])
+    ,.data_o(mem_r)
+    );
+
+  wire [1:0] w_li    = {w_v_i & v_r_wr_ptr, w_v_i & ~v_r_wr_ptr};
+  wire [1:0] v_li    = {(r_v_i & v_r[r_addr_i]) | w_li[1], (r_v_i & ~v_r[r_addr_i]) | w_li[0]};
+  wire [1:0][addr_width_lp-1:0]
+             addr_li = {w_li[1] ? w_addr_i : r_addr_i, w_li[0] ? w_addr_i : r_addr_i};
+  logic [1:0][width_p-1:0] data_lo;
+  assign r_data_o    = mem_r ? data_lo[1] : data_lo[0];
+
+   bsg_mem_1rw_sync
+    #(.width_p(width_p)
+     ,.els_p(els_p)
+     ,.enable_clock_gating_p(enable_clock_gating_p)
+     ) 
+    mem0
+     (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+     ,.data_i(w_data_i)
+     ,.addr_i(addr_li[0])
+     ,.v_i(v_li[0])
+     ,.w_i(w_li[0])
+     ,.data_o(data_lo[0])
+     );
+
+   bsg_mem_1rw_sync
+    #(.width_p(width_p)
+     ,.els_p(els_p)
+     ,.enable_clock_gating_p(enable_clock_gating_p)
+     )
+    mem1
+     (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+     ,.data_i(w_data_i)
+     ,.addr_i(addr_li[1])
+     ,.v_i(v_li[1])
+     ,.w_i(w_li[1])
+     ,.data_o(data_lo[1])
+     );
+
+   //synopsys translate_off
+   initial
+     begin
+        $display("## %L: instantiating width_p=%d, els_p=%d, read_write_same_addr_p=%d, harden_p=%d (%m)",width_p,els_p,read_write_same_addr_p,harden_p);
+     end
+
+   always_ff @(posedge clk_lo)
+     if (w_v_i)
+       begin
+          assert ((reset_i === 'X) || (reset_i === 1'b1) || (w_addr_i < els_p))
+            else $error("Invalid address %x to %m of size %x\n", w_addr_i, els_p);
+
+          assert ((reset_i === 'X) || (reset_i === 1'b1) || ~(r_addr_i == w_addr_i && w_v_i && r_v_i && !read_write_same_addr_p && !disable_collision_warning_p))
+            else
+              begin
+                 $error("X'ing matched read address %x (%m)",r_addr_i);
+              end
+       end
+   //synopsys translate_on
+
+endmodule

--- a/bsg_mem/bsg_mem_1r1w_from_1rw_sync.v
+++ b/bsg_mem/bsg_mem_1r1w_from_1rw_sync.v
@@ -5,13 +5,13 @@
 `include "bsg_defines.v"
 
 module bsg_mem_1r1w_from_1rw_sync #(parameter width_p=-1
-                                   ,parameter els_p=-1
-                                   ,parameter read_write_same_addr_p=0
-                                   ,parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
-                                   ,parameter harden_p=0
-                                   ,parameter disable_collision_warning_p=1
-                                   ,parameter enable_clock_gating_p=0
-                                   )
+                                        ,parameter els_p=-1
+                                        ,parameter read_write_same_addr_p=0
+                                        ,parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
+                                        ,parameter harden_p=0
+                                        ,parameter disable_collision_warning_p=1
+                                        ,parameter enable_clock_gating_p=0
+                                        )
   (input clk_i
   ,input reset_i
   ,input                                        w_v_i
@@ -23,29 +23,45 @@ module bsg_mem_1r1w_from_1rw_sync #(parameter width_p=-1
   );
 
   logic [els_p-1:0] v_r;
-  logic mem_r;
-  wire v_r_wr_ptr = ~r_v_i | ~v_r[r_addr_i];
+  logic [els_p_1:0] set_one_hot_li;
+  logic mem_select_r;
+
+  wire wr_ptr = ~r_v_i | ~v_r[r_addr_i];
+  always_comb
+    begin
+      set_one_hot_li = '0;
+      set_one_hot_li[0] = wr_ptr & w_v_i;
+      set_one_hot_li << w_addr_i;
+    end
   
-  always_ff @(posedge clk_i)
-    if (reset_i)
-      v_r <= '0;
-    else if (w_v_i)
-      v_r[w_addr_i] <= v_r_wr_ptr;
+  genvar i;
+  for(i = 0; i < els_p; i++)
+    begin: rof
+      bsg_dff_reset_set_clear
+        #(.width_p(els_p))
+        valid_reg
+        (.clk_i(clk_i)
+        ,.reset_i(reset_i)
+        ,.set_i(set_one_hot_li[i])
+        ,.clear_i('0)
+        ,.data_o(v_r[i])
+        );
+    end
 
   bsg_dff
     #(.width_p(1))
-    mem_reg
+    mem_select_reg
     (.clk_i(clk_i)
     ,.data_i(v_r[r_addr_i])
-    ,.data_o(mem_r)
+    ,.data_o(mem_select_r)
     );
 
-  wire [1:0] w_li    = {w_v_i & v_r_wr_ptr, w_v_i & ~v_r_wr_ptr};
+  wire [1:0] w_li    = {w_v_i & wr_ptr, w_v_i & ~wr_ptr};
   wire [1:0] v_li    = {(r_v_i & v_r[r_addr_i]) | w_li[1], (r_v_i & ~v_r[r_addr_i]) | w_li[0]};
   wire [1:0][addr_width_lp-1:0]
              addr_li = {w_li[1] ? w_addr_i : r_addr_i, w_li[0] ? w_addr_i : r_addr_i};
   logic [1:0][width_p-1:0] data_lo;
-  assign r_data_o    = mem_r ? data_lo[1] : data_lo[0];
+  assign r_data_o    = mem_select_r ? data_lo[1] : data_lo[0];
 
    bsg_mem_1rw_sync
     #(.width_p(width_p)

--- a/bsg_mem/bsg_mem_1r1w_sync_from_1rw_sync.v
+++ b/bsg_mem/bsg_mem_1r1w_sync_from_1rw_sync.v
@@ -22,31 +22,29 @@ module bsg_mem_1r1w_sync_from_1rw_sync #(parameter width_p=-1
   ,output logic [`BSG_SAFE_MINUS(width_p, 1):0] r_data_o
   );
 
-  logic [els_p-1:0] v_r;
-  logic [els_p_1:0] set_one_hot_li;
+  logic [els_p-1:0] v_r, v_n;
+  logic [els_p-1:0] w_addr_one_hot_lo;
   logic mem_select_r;
 
+  bsg_decode_with_v
+    #(num_out_p(els_p))
+    (.i(w_addr_i)
+    ,.v_i(w_v_i)
+    ,.o(w_addr_one_hot_lo)
+    );
+
   wire wr_ptr = ~r_v_i | ~v_r[r_addr_i];
-  always_comb
-    begin
-      set_one_hot_li = '0;
-      set_one_hot_li[0] = wr_ptr & w_v_i;
-      set_one_hot_li << w_addr_i;
-    end
-  
-  genvar i;
-  for(i = 0; i < els_p; i++)
-    begin: rof
-      bsg_dff_reset_set_clear
-        #(.width_p(els_p))
-        valid_reg
-        (.clk_i(clk_i)
-        ,.reset_i(reset_i)
-        ,.set_i(set_one_hot_li[i])
-        ,.clear_i('0)
-        ,.data_o(v_r[i])
-        );
-    end
+  assign v_n = {els_p{wr_ptr & w_v_i}} & w_addr_one_hot_lo;
+
+  bsg_dff_reset_set_clear
+    #(.width_p(els_p))
+    valid_reg
+    (.clk_i(clk_i)
+    ,.reset_i(reset_i)
+    ,.set_i(v_n)
+    ,.clear_i('0)
+    ,.data_o(v_r)
+    );
 
   bsg_dff
     #(.width_p(1))
@@ -114,3 +112,4 @@ module bsg_mem_1r1w_sync_from_1rw_sync #(parameter width_p=-1
    //synopsys translate_on
 
 endmodule
+

--- a/bsg_mem/bsg_mem_1r1w_sync_from_1rw_sync.v
+++ b/bsg_mem/bsg_mem_1r1w_sync_from_1rw_sync.v
@@ -4,7 +4,7 @@
 
 `include "bsg_defines.v"
 
-module bsg_mem_1r1w_from_1rw_sync #(parameter width_p=-1
+module bsg_mem_1r1w_sync_from_1rw_sync #(parameter width_p=-1
                                         ,parameter els_p=-1
                                         ,parameter read_write_same_addr_p=0
                                         ,parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)

--- a/testing/bsg_mem/bsg_mem_1r1w_from_1rw/Makefile
+++ b/testing/bsg_mem/bsg_mem_1r1w_from_1rw/Makefile
@@ -1,0 +1,62 @@
+
+export BASEJUMP_STL_DIR = $(shell git rev-parse --show-toplevel)
+include $(abspath $(BASEJUMP_STL_DIR)/../bsg_cadenv/cadenv.mk)
+ 
+HIGHLIGHT = grep --color -E '^|Error|Warning|Implicit wire is used|Too few instance port connections|Port connection width mismatch|Width mismatch'
+
+INCDIR = +incdir+$(BASEJUMP_STL_DIR)/bsg_misc
+INCDIR += +incdir+$(BASEJUMP_STL_DIR)/bsg_test
+INCDIR += +incdir+$(BASEJUMP_STL_DIR)/bsg_mem
+
+VCS_OPTS = +v2k
+VCS_OPTS += -R
+VCS_OPTS += +lint=all,noSVA-UA,noSVA-NSVU,noVCDE,noNS
+VCS_OPTS += -sverilog
+VCS_OPTS += -full64
+VCS_OPTS += -assert svaext
+VCS_OPTS += -timescale=1ps/1ps
+VCS_OPTS += +vcs+vcdpluson
+VCS_OPTS += -l vcs.log
+VCS_OPTS += -top testbench
+VCS_OPTS += -f sv.include
+
+# Scan parameter checking adapted from testing/bsg_mem/bsg_mem_1r1w/Makefile
+
+# this is a list of all variables you want to vary for the simulation
+scan_params = WIDTH_P ELS_P
+
+# this is a list of all values for each variable in the scan_params list
+# note; if you leave out values for a variable, then the product of the
+# sets is null, and nothing will run.
+WIDTH_P = 4 16 32 64 
+ELS_P   = 4  5 16
+
+# function that generates a string for each combination of the parameters;
+# spaces separated by "@" signs.
+bsg_param_scan = $(if $(1),$(foreach v__,$($(firstword $(1))),\
+                    $(call bsg_param_scan,$(filter-out $(firstword $(1)),\
+                    $(1)),$(2),$(3),$(4)@$(2)$(firstword $(1))$(3)$(v__))),\
+                    $(4))
+
+# this takes the parameters and creates a set of make targets, one for every 
+# combination of the parameters
+commands = $(call bsg_param_scan,$(scan_params),+define+,=)
+
+# default rule: run all of the targets.
+all: $(foreach x,$(commands),run.$(x))
+
+# this runs an individual target
+# we replace the @ with a space so that the parameters are used as 
+# command line options
+run.%:
+	$(VCS) $(VCS_OPTS) $(INCDIR) +define+WIDTH_P=$(firstword $(subst @, ,$*)) +define+ELS_P=$(word 2,$(subst @, ,$*)) | $(HIGHLIGHT)
+
+dve:
+	$(DVE) -full64 -vpd vcdplus.vpd
+
+clean:
+	rm -rf DVEfiles
+	rm -rf csrc
+	rm -rf simv.daidir simv.vdb
+	rm -f ucli.key vcdplus.vpd simv cm.log *.tar.gz vcs.log vc_hdrs.h
+	rm -rf stack.info.*

--- a/testing/bsg_mem/bsg_mem_1r1w_from_1rw/sv.include
+++ b/testing/bsg_mem/bsg_mem_1r1w_from_1rw/sv.include
@@ -1,0 +1,13 @@
+$BASEJUMP_STL_DIR/bsg_misc/bsg_decode.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_decode_with_v.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_dff.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_dff_reset_set_clear.v
+$BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1rw_sync.v
+$BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1rw_sync_synth.v
+$BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1r1w_sync_from_1rw_sync.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_dff_chain.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_cycle_counter.v
+$BASEJUMP_STL_DIR/bsg_test/bsg_nonsynth_clock_gen.v
+$BASEJUMP_STL_DIR/bsg_test/bsg_nonsynth_reset_gen.v
+$BASEJUMP_STL_DIR/bsg_test/bsg_nonsynth_random_gen.v
+testbench.v

--- a/testing/bsg_mem/bsg_mem_1r1w_from_1rw/testbench.v
+++ b/testing/bsg_mem/bsg_mem_1r1w_from_1rw/testbench.v
@@ -1,0 +1,165 @@
+// Testbench to test a 1r1w memory built from 1rw memories
+
+`define WIDTH_p 4
+`define ELS_P 4
+`define SEED_P 100
+`define CLK_PERIOD 20
+
+module testbench;
+
+  localparam els_lp = `ELS_P;
+  localparam width_lp = `WIDTH_P;
+  localparam addr_width_lp = `BSG_SAFE_CLOG2(els_lp);
+  localparam cycle_time_lp = `CLK_PERIOD;
+  localparam seed_lp = `SEED_P;
+
+  logic clk, reset;
+
+  bsg_nonsynth_clock_gen
+    #(.cycle_time_p(cycle_time_lp))
+   clock_gen
+    (.o(clk)
+    );
+
+  bsg_nonsynth_reset_gen
+    #(.num_clocks_p(1)
+     ,.reset_cycles_lo_p(0)
+     ,.reset_cycles_hi_p(10)
+     )
+   reset_gen
+    (.clk_i(clk)
+    ,.async_reset_o(reset)
+    );
+
+  initial begin
+    $display("\nTesting parameters: ");
+    $display("Memory Width: %d", width_lp);
+    $display("Memory Depth: %d\n", els_lp);
+    $display("========== Test begin ==========\n");
+  end
+
+  logic w_v_li, r_v_li;
+  logic [addr_width_lp-1:0] w_addr_n, w_addr_r, r_addr_n, r_addr_r, r_addr_rr;
+  logic [width_lp-1:0] w_data_li, w_data_r, w_data_rr, r_data_lo;
+  logic finish_n, finish_r;
+
+  bsg_mem_1r1w_sync_from_1rw_sync
+    #(.width_p(width_lp)
+     ,.els_p(els_lp)
+     ,.read_write_same_addr_p(0)
+     ,.disable_collision_warning_p(0)
+     )
+   DUT
+    (.clk_i(clk)
+    ,.reset_i(reset)
+    
+    ,.w_v_i(w_v_li)
+    ,.w_addr_i(w_addr_r)
+    ,.w_data_i(w_data_li)
+    
+    ,.r_v_i(r_v_li)
+    ,.r_addr_i(r_addr_r)
+    ,.r_data_o(r_data_lo)
+    );
+
+  // Delay reads from writes by 1 cycle
+  bsg_dff
+    #(.width_p(1))
+   r_v_reg
+    (.clk_i(clk)
+    ,.data_i(w_v_li)
+    ,.data_o(r_v_li)
+    );
+
+  // Generate write data randomly
+  bsg_nonsynth_random_gen
+    #(.width_p(width_lp)
+     ,.seed_p(seed_lp)
+     )
+   w_data_gen
+    (.clk_i(clk)
+    ,.reset_i(reset)
+    ,.yumi_i(1'b1)
+    ,.data_o(w_data_li)
+    );
+  
+  // Reads are synchronous and will appear on the next clock edge
+  // so delay the read valids for comparison
+  logic r_v_r;
+  bsg_dff
+    #(.width_p(1))
+   r_v_r_reg
+    (.clk_i(clk)
+    ,.data_i(r_v_li)
+    ,.data_o(r_v_r)
+    );
+
+  logic [addr_width_lp:0] count;
+  bsg_cycle_counter
+    #(.width_p(addr_width_lp+1)
+     ,.init_val_p(0)
+     )
+   cycle_counter
+    (.clk_i(clk)
+    ,.reset_i(reset)
+    
+    ,.ctr_r_o(count)
+    );
+
+  always_comb begin
+    w_v_li = 1'b0;
+    w_addr_n = w_addr_r;
+    r_addr_n = w_addr_r;
+    finish_n = 1'b0;
+
+    if (!reset) begin
+      if (count < els_lp) begin
+        w_v_li = 1'b1;
+        w_addr_n = w_addr_r + 1'b1;
+      end
+
+      if (count == els_lp)
+        finish_n = 1'b1;
+    end
+  end 
+
+  always_ff @(posedge clk) begin
+    if (reset) begin
+      w_addr_r <= '0;
+      w_data_r <= '0;
+      w_data_rr <= '0;
+      finish_r <= 1'b0;
+    end
+    else begin
+      w_addr_r <= w_addr_n;
+      w_data_r <= w_data_li;
+      w_data_rr <= w_data_r;
+      r_addr_r <= r_addr_n;
+      r_addr_rr <= r_addr_r;
+      finish_r <= finish_n;
+
+      if (finish_r) begin
+        $display("\n========== Test complete ==========\n");
+        $finish;
+      end
+    end
+  end
+
+  always_ff @(negedge clk) begin
+    if (!reset) begin
+      // Assertions
+      if (r_v_r === 1'b1)
+        assert((r_data_lo == w_data_rr))
+          else $error("%0t ps Read output (%x) not the same as written data (%x) for address (%x)", $time, r_data_lo, w_data_rr, r_addr_rr);
+
+    end
+    
+    // Monitors
+    // Note: Does not display writes to address 0. So, as long as the
+    // assertion does not fire, you are good to go
+    // if (w_v_li | r_v_r)
+    //   $display("@%0t ps\nWrites: valid: %x addr: %x data: %x\nReads: valid: %x addr: %x data: %x",
+    //     $time, w_v_li, w_addr_r, w_data_li, r_v_r, r_addr_rr, r_data_lo);
+  end
+  
+endmodule


### PR DESCRIPTION
This PR adds a 1r1w memory module built using 2 1rw sync memories.

The module uses a separate memory (v_r) that tracks which memories to read from and which memories to write to.

A hardened version of this converter was used in the development of register files for BlackParrot in the Free45 ASIC flow.