### PR TITLE
Make Handshake Signal of sipo_passthrough_dynamic Helpful

### DIFF
--- a/testing/bsg_dataflow/bsg_serial_in_parallel_out_passthrough_dynamic/.gitignore
+++ b/testing/bsg_dataflow/bsg_serial_in_parallel_out_passthrough_dynamic/.gitignore
@@ -1,0 +1,3 @@
+urgReport
+cov.vdb
+vc_hdrs.h

--- a/testing/bsg_dataflow/bsg_serial_in_parallel_out_passthrough_dynamic/Makefile
+++ b/testing/bsg_dataflow/bsg_serial_in_parallel_out_passthrough_dynamic/Makefile
@@ -1,0 +1,26 @@
+export BASEJUMP_STL_DIR = ../../..
+
+-include $(BASEJUMP_STL_DIR)/../bsg_cadenv/cadenv.mk
+
+INCDIR = +incdir+$(BASEJUMP_STL_DIR)/bsg_misc
+INCDIR += +incdir+$(BASEJUMP_STL_DIR)/bsg_noc
+INCDIR += +incdir+$(BASEJUMP_STL_DIR)/bsg_dataflow
+
+.PHONY: sim dve all
+
+all: sim
+
+sim:
+	vcs -R +lint=all,noSVA-UA,noSVA-NSVU,noVCDE -sverilog -full64 -f sv.include $(INCDIR) \
+		-debug_all -assert svaext -timescale=1ps/1ps +vcs+vcdpluson +vcs+loopreport -cm line+tgl -cm_dir cov
+	urg -full64 -dir cov
+
+dve:
+	dve -full64 -vpd vcdplus.vpd &
+
+clean:
+	rm -rf DVEfiles
+	rm -rf csrc
+	rm -rf simv.daidir simv.vdb
+	rm -f ucli.key vcdplus.vpd simv cm.log *.tar.gz
+	rm -rf trace.tr

--- a/testing/bsg_dataflow/bsg_serial_in_parallel_out_passthrough_dynamic/sv.include
+++ b/testing/bsg_dataflow/bsg_serial_in_parallel_out_passthrough_dynamic/sv.include
@@ -1,0 +1,17 @@
+
+$BASEJUMP_STL_DIR/bsg_dataflow/bsg_parallel_in_serial_out.v
+$BASEJUMP_STL_DIR/bsg_dataflow/bsg_serial_in_parallel_out_passthrough.v
+$BASEJUMP_STL_DIR/bsg_dataflow/bsg_two_fifo.v
+$BASEJUMP_STL_DIR/bsg_dataflow/bsg_one_fifo.v
+$BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1r1w.v
+$BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1r1w_synth.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_counter_clear_up_one_hot.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_counter_clear_up.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_dff_en.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_dff_reset.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_defines.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_mux.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_dff_reset_set_clear.v
+$BASEJUMP_STL_DIR/bsg_test/bsg_nonsynth_clock_gen.v
+$BASEJUMP_STL_DIR/bsg_test/bsg_nonsynth_reset_gen.v
+testbench.v

--- a/testing/bsg_dataflow/bsg_serial_in_parallel_out_passthrough_dynamic/sv.include
+++ b/testing/bsg_dataflow/bsg_serial_in_parallel_out_passthrough_dynamic/sv.include
@@ -1,14 +1,17 @@
 
 $BASEJUMP_STL_DIR/bsg_dataflow/bsg_parallel_in_serial_out.v
-$BASEJUMP_STL_DIR/bsg_dataflow/bsg_serial_in_parallel_out_passthrough.v
+$BASEJUMP_STL_DIR/bsg_dataflow/bsg_serial_in_parallel_out_passthrough_dynamic.v
 $BASEJUMP_STL_DIR/bsg_dataflow/bsg_two_fifo.v
 $BASEJUMP_STL_DIR/bsg_dataflow/bsg_one_fifo.v
 $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1r1w.v
 $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1r1w_synth.v
-$BASEJUMP_STL_DIR/bsg_misc/bsg_counter_clear_up_one_hot.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_counter_clear_up.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_decode.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_decode_with_v.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_dff_en.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_dff_en_bypass.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_dff_reset.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_dff_reset_en.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_defines.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_mux.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_dff_reset_set_clear.v

--- a/testing/bsg_dataflow/bsg_serial_in_parallel_out_passthrough_dynamic/testbench.v
+++ b/testing/bsg_dataflow/bsg_serial_in_parallel_out_passthrough_dynamic/testbench.v
@@ -32,8 +32,8 @@ module testbench;
   logic [narrow_width_lp-1:0] out_data_lo;
   logic out_v_lo, out_ready_li;
 
-  bsg_serial_in_parallel_out_passthrough
-   #(.width_p(narrow_width_lp), .els_p(els_lp))
+  bsg_serial_in_parallel_out_passthrough_dynamic
+   #(.width_p(narrow_width_lp), .max_els_p(els_lp))
    DUT
     (.clk_i(clk)
      ,.reset_i(reset)
@@ -45,6 +45,9 @@ module testbench;
      ,.data_o(in_data_lo)
      ,.v_o(in_v_lo)
      ,.ready_and_i(in_yumi_li)
+
+     ,.len_i(els_lp-1)
+     ,.first_o(/* unused */)
      );
 
   assign out_data_li = in_data_lo;

--- a/testing/bsg_dataflow/bsg_serial_in_parallel_out_passthrough_dynamic/testbench.v
+++ b/testing/bsg_dataflow/bsg_serial_in_parallel_out_passthrough_dynamic/testbench.v
@@ -1,0 +1,116 @@
+
+module testbench;
+
+  localparam wide_width_lp = 16;
+  localparam narrow_width_lp = 4;
+  localparam els_lp = wide_width_lp / narrow_width_lp;
+
+  logic clk;
+  bsg_nonsynth_clock_gen
+   #(.cycle_time_p(1000))
+   clock_gen
+    (.o(clk));
+
+  logic reset;
+  bsg_nonsynth_reset_gen
+   #(.num_clocks_p(1)
+     ,.reset_cycles_lo_p(4)
+     ,.reset_cycles_hi_p(4)
+     )
+   reset_gen
+    (.clk_i(clk)
+     ,.async_reset_o(reset)
+     );
+
+  logic [narrow_width_lp-1:0] in_data_li;
+  logic in_v_li, in_ready_lo;
+  logic [wide_width_lp-1:0] in_data_lo;
+  logic in_v_lo, in_yumi_li;
+
+  logic [wide_width_lp-1:0] out_data_li;
+  logic out_v_li, out_ready_lo;
+  logic [narrow_width_lp-1:0] out_data_lo;
+  logic out_v_lo, out_ready_li;
+
+  bsg_serial_in_parallel_out_passthrough
+   #(.width_p(narrow_width_lp), .els_p(els_lp))
+   DUT
+    (.clk_i(clk)
+     ,.reset_i(reset)
+
+     ,.data_i(in_data_li/els_lp)
+     ,.v_i(in_v_li)
+     ,.ready_and_o(in_ready_lo)
+
+     ,.data_o(in_data_lo)
+     ,.v_o(in_v_lo)
+     ,.ready_and_i(in_yumi_li)
+     );
+
+  assign out_data_li = in_data_lo;
+  assign out_v_li = in_v_lo;
+  assign in_yumi_li = out_ready_lo & out_v_li;
+
+  bsg_parallel_in_serial_out
+   #(.width_p(narrow_width_lp), .els_p(els_lp))
+   reverse
+    (.clk_i(clk)
+     ,.reset_i(reset)
+
+     ,.data_i(out_data_li)
+     ,.valid_i(out_v_li)
+     ,.ready_and_o(out_ready_lo)
+
+     ,.data_o(out_data_lo)
+     ,.valid_o(out_v_lo)
+     ,.yumi_i(out_ready_li & out_v_lo)
+     );
+
+  // Input block
+  initial
+    begin
+      in_data_li = '0;
+      in_v_li    = '0;
+
+      @(posedge clk);
+      @(negedge reset);
+      @(posedge clk);
+
+      for (integer i = 0; i < 400; i++)
+        begin
+          in_v_li = 1'b1;
+
+          @(posedge clk);
+          in_data_li = in_data_li + (in_ready_lo & in_v_li);
+          if (in_ready_lo & in_v_li)
+            $display("Sending %x", in_data_li/els_lp);
+        end
+    end
+
+  // Checking block
+  logic [narrow_width_lp-1:0] match_data_li;
+  initial
+    begin
+      out_ready_li  = '0;
+      match_data_li = '0;
+
+      @(posedge clk);
+      @(negedge reset);
+      @(posedge clk);
+
+      for (integer i = 0; i < 400; i++)
+        begin
+          out_ready_li = 1'b1;
+
+          match_data_li = match_data_li + (out_ready_li & out_v_lo);
+          @(negedge clk);
+          assert(~(out_ready_li & out_v_lo) || (match_data_li/els_lp == out_data_lo));
+          if (out_ready_li & out_v_lo)
+            $display("Receiving %x", out_data_lo);
+        end
+
+      $finish();
+    end
+
+endmodule
+


### PR DESCRIPTION
In baseline design, sipo_passthrough_dynamic dose not register the last data packet to minimze the hardware. 

```
assign v_o         = (v_i & is_last_cnt) | is_zero_len | is_waiting;
assign ready_and_o = (ready_and_i | ~is_last_cnt) & ~is_waiting;
```
However, if the module works together with a demanding "ready_and_i" from downstream and a demading "v_i" from upstream, when there is a multi data word and it comes to the last cnt, `ready_and_i` is low and therefore, `v_i` is also low. In this case, the sipo gets into a dead lock.

To solve this issue, we would like to make the both `v_o` and ` ready_and_o` helpful by registering the last data word without jeopardizing the performance. To do so, a state register, `is_full_r` is added. 

```
assign v_o         = (v_i & is_last_cnt) | is_full_r | is_zero_len | is_waiting;
assign ready_and_o = ~is_full_r & ~is_waiting;
```
With this change, `ready_and_o` is always helpful when there is available space for upcoming data word, and the data in `dff_en_bypass` are protected from unintended updates by helpful upstream data.