### PR TITLE
Explicitly size amo_support_p in bsg_cache

### DIFF
--- a/bsg_cache/bsg_cache.v
+++ b/bsg_cache/bsg_cache.v
@@ -22,8 +22,9 @@ module bsg_cache
     ,parameter sets_p="inv"
     ,parameter ways_p="inv"
 
-    ,parameter amo_support_p=(1 << e_cache_amo_swap)
-                             | (1 << e_cache_amo_or)
+    // Explicit size prevents size inference and allows for ((foo == bar) << e_cache_amo_swap)
+    ,parameter [31:0] amo_support_p=(1 << e_cache_amo_swap)
+                                    | (1 << e_cache_amo_or)
 
     // dma burst width
     ,parameter dma_data_width_p=data_width_p // default value. it can also be pow2 multiple of data_width_p.


### PR DESCRIPTION
Currently using a logical expression to derive the amo support level causes the parameter to infer that it is a 1-bit variable. This patch guarantees that it remains 32-bits no matter what is passed in