### PR TITLE
Fixed bug in DPI Clock Generator

### DIFF
--- a/bsg_test/bsg_nonsynth_dpi_clock_gen.cpp
+++ b/bsg_test/bsg_nonsynth_dpi_clock_gen.cpp
@@ -1,5 +1,4 @@
 #include <bsg_nonsynth_dpi_clock_gen.hpp>
-
 using namespace bsg_nonsynth_dpi;
 
 // Initializer for simuation time value in bsg_timekeeper
@@ -32,11 +31,12 @@ void bsg_timekeeper::next(){
         do {
                 next.tock();
 
+                temp.push(next);
+
                 pq.pop();
 
                 next = pq.top();
 
-                temp.push(next);
 
         } while(next_timeval == next.next_edge());
 
@@ -78,7 +78,7 @@ bsg_nonsynth_dpi_clock_gen::bsg_nonsynth_dpi_clock_gen(const long long cycle_tim
                                                        const char* hier) :
         clk(0),// To match the behavior of bsg_nonsynth_clock_gen, the
                // output clock is initially 0
-        cycle_time_p(cycle_time_p){ 
+        cycle_time_p(cycle_time_p){
 
         bool res;
         svScope prev;

--- a/testing/bsg_test/bsg_nonsynth_dpi/top.v
+++ b/testing/bsg_test/bsg_nonsynth_dpi/top.v
@@ -6,7 +6,7 @@ module top();
    // modules. There may be a cleaner way to do this but I haven't
    // found it yet.
 
-   logic     ns_clk, ns_reset, debug_o;
+   logic     ns_clk, ns_by2_clk, ns_reset, debug_o;
    parameter lc_cycle_time_p = 1000000;
 
    bsg_nonsynth_dpi_clock_gen
@@ -19,7 +19,7 @@ module top();
      #(.cycle_time_p(lc_cycle_time_p/2)
        )
    core_clk_gen2
-     (.o(ns_clk));
+     (.o(ns_by2_clk));
 
    bsg_nonsynth_reset_gen 
      #(
@@ -35,10 +35,15 @@ module top();
    
    int           cycle = 0;
 
+   always @(posedge ns_by2_clk) begin
+      cycle <= cycle +1;
+      if(debug_o)
+        $display("BSG DBGINFO: top by2 -- Cycle %d", cycle);
+   end
+
    always @(posedge ns_clk) begin
-     cycle <= cycle +1;
-     if(debug_o)
-       $display("BSG DBGINFO: top -- Cycle %d", cycle);
+      if(debug_o)
+        $display("BSG DBGINFO: top -- Cycle %d", cycle);
    end
    
    logic [width_lp-1:0] data_i;


### PR DESCRIPTION
* Swapped the order of pop and push - using a reference when poping will automatically update the reference.

Sort of fixes #421 