### PR TITLE
Update bsg_cache.v

### DIFF
--- a/bsg_cache/bsg_cache.v
+++ b/bsg_cache/bsg_cache.v
@@ -308,7 +308,7 @@ module bsg_cache
   logic [lg_ways_lp-1:0] tag_hit_way_id;
   logic tag_hit_found;
 
-  bsg_priority_encode #(
+  bsg_encode_one_hot #(
     .width_p(ways_p)
     ,.lo_to_hi_p(1)
   ) tag_hit_pe (


### PR DESCRIPTION
Tag hits should always be one_hot, so this is a little more efficient. I'm not missing some obscure use case where we want multiple matching entries am I?