### PR TITLE
Changing the special DONT_TOUCH instance names to BSG_DONT_TOUCH

### DIFF
--- a/hard/gf_14/README.md
+++ b/hard/gf_14/README.md
@@ -6,12 +6,12 @@ name during the chip implementation flow.
 
 ## Special Attributes
 
-Cell instances with the `*DONT_TOUCH*` in the name should get a dont_touch
+Cell instances with the `*BSG_DONT_TOUCH*` in the name should get a dont_touch
 attribute applied to these instances in the backend flow.
 
 All instances of library cell `*SYNC*DFF*` should automatically get a dont_touch
 attribute (regardless of the instance name).
 
-Cell instances with the `*NO_CLOCK_GATE*` in the name should get an attribute
+Cell instances with the `*BSG_NO_CLOCK_GATE*` in the name should get an attribute
 to prevent clock gating on this module/cell.
 

--- a/hard/gf_14/bsg_clk_gen/bsg_clk_gen_osc.v
+++ b/hard/gf_14/bsg_clk_gen/bsg_clk_gen_osc.v
@@ -128,7 +128,7 @@ module bsg_clk_gen_osc
    // should be ignored in synthesis
    assign #4000 fb_clk_del = fb_clk;
 
-   bsg_rp_clk_gen_atomic_delay_tuner  adt_DONT_TOUCH
+   bsg_rp_clk_gen_atomic_delay_tuner  adt_BSG_DONT_TOUCH
      (.i(fb_clk_del)
       ,.we_async_i (tag_trigger_r_async   )
       ,.we_inited_i(bsg_tag_trigger_i.en  )
@@ -142,7 +142,7 @@ module bsg_clk_gen_osc
    // this one inverts the output
    // captures config state on negative edge of input clock
 
-   bsg_rp_clk_gen_coarse_delay_tuner cdt_DONT_TOUCH
+   bsg_rp_clk_gen_coarse_delay_tuner cdt_BSG_DONT_TOUCH
      (.i                 (adt_lo)
       ,.we_i             (adt_to_cdt_trigger_lo)
       ,.async_reset_neg_i(async_reset_neg      )
@@ -155,7 +155,7 @@ module bsg_clk_gen_osc
    // captures config state on positive edge of (inverted) input clk
    // non-inverting
 
-   bsg_rp_clk_gen_fine_delay_tuner fdt_DONT_TOUCH
+   bsg_rp_clk_gen_fine_delay_tuner fdt_BSG_DONT_TOUCH
      (.i                 (cdt_lo)
       ,.we_i             (cdt_to_fdt_trigger_lo)
       ,.async_reset_neg_i(async_reset_neg)

--- a/hard/gf_14/bsg_misc/bsg_mux.v
+++ b/hard/gf_14/bsg_misc/bsg_mux.v
@@ -19,7 +19,7 @@ module bsg_mux #(parameter width_p="inv"
         for (j = 0; j < width_p; j=j+1)
           begin: rof
              // fast, but not too extreme
-             SC7P5T_MUX4X4_SSC16L BSG_BAL41MUX_DONT_TOUCH (.D0(data_i[0][j]), .D1(data_i[1][j]), .D2(data_i[2][j]), .D3(data_i[3][j]), .S0(sel_i[0]), .S1(sel_i[1]), .Z(data_o[j]));
+             SC7P5T_MUX4X4_SSC16L BSG_BAL41MUX_BSG_DONT_TOUCH (.D0(data_i[0][j]), .D1(data_i[1][j]), .D2(data_i[2][j]), .D3(data_i[3][j]), .S0(sel_i[0]), .S1(sel_i[1]), .Z(data_o[j]));
           end
      end
    else


### PR DESCRIPTION
Changing the special DONT_TOUCH instance names to BSG_DONT_TOUCH to be more consistent with other special variables in our cad flows. This also makes it more clear that this is a BSG feature and not something that EDA tools support by default.

The change of NO_CLOCK_GATE to BSG_NO_CLOCK_GATE is just a documentation error. The flow and RTL already uses BSG_NO_CLOCK_GATE.