### PR TITLE
channel tunnel support harden small fifo

### DIFF
--- a/bsg_dataflow/bsg_1_to_n_tagged_fifo.v
+++ b/bsg_dataflow/bsg_1_to_n_tagged_fifo.v
@@ -18,6 +18,7 @@ module bsg_1_to_n_tagged_fifo   #(parameter width_p                   = "inv"
                                   ,parameter els_p                    = "inv" // these are elements per channel
                                   ,parameter unbuffered_mask_p        = 0
                                   ,parameter use_pseudo_large_fifo_p  = 0
+                                  ,parameter use_harden_small_fifo_p  = 0
                                   ,parameter tag_width_lp        = `BSG_SAFE_CLOG2(num_out_p)
                                   )
    (input  clk_i
@@ -81,6 +82,7 @@ module bsg_1_to_n_tagged_fifo   #(parameter width_p                   = "inv"
           begin: buff
              bsg_fifo_1r1w_small #(.width_p(width_p)
                                    ,.els_p (els_p  )
+                                   ,.harden_p(use_harden_small_fifo_p)
                                    ) fifo
                (.clk_i
                 ,.reset_i

--- a/bsg_dataflow/bsg_channel_tunnel.v
+++ b/bsg_dataflow/bsg_channel_tunnel.v
@@ -65,6 +65,7 @@ module bsg_channel_tunnel #(parameter width_p        = 1
                             , num_in_p               = "inv"
                             , remote_credits_p       = "inv"
                             , use_pseudo_large_fifo_p = 0
+                            , use_harden_small_fifo_p = 0
                             , lg_remote_credits_lp   = $clog2(remote_credits_p+1)
                             , lg_credit_decimation_p = `BSG_MIN(lg_remote_credits_lp,4)
                             , tag_width_lp           = $clog2(num_in_p+1)
@@ -148,6 +149,7 @@ module bsg_channel_tunnel #(parameter width_p        = 1
                            ,.num_in_p              (num_in_p )
                            ,.remote_credits_p      (remote_credits_p)
                            ,.use_pseudo_large_fifo_p(use_pseudo_large_fifo_p)
+                           ,.use_harden_small_fifo_p(use_harden_small_fifo_p)
                            ,.lg_credit_decimation_p(lg_credit_decimation_p)
                            ) bcti
      (.clk_i

--- a/bsg_dataflow/bsg_channel_tunnel_in.v
+++ b/bsg_dataflow/bsg_channel_tunnel_in.v
@@ -13,6 +13,7 @@ module bsg_channel_tunnel_in #(parameter width_p = -1
                                , num_in_p = "inv"
                                , remote_credits_p = "inv"
                                , use_pseudo_large_fifo_p = 0
+                               , use_harden_small_fifo_p = 0
 
                                // determines when we send out credits remotely
                                // and consequently how much bandwidth is used on credits
@@ -59,6 +60,7 @@ module bsg_channel_tunnel_in #(parameter width_p = -1
                             // credit fifo is unbuffered
                             ,.unbuffered_mask_p (1 << num_in_p   )
                             ,.use_pseudo_large_fifo_p(use_pseudo_large_fifo_p)
+                            ,.use_harden_small_fifo_p(use_harden_small_fifo_p)
                             )
    b1_ntf
      (.clk_i


### PR DESCRIPTION
Pseudo large fifo is ideal when channel utilization is less than 50%. Hardened small fifo can be useful when attached to higher bandwidth io channel.