### PR TITLE
first step to get rid of =inv and -1 params [do not merge yet]

### DIFF
--- a/bsg_cache/bsg_cache.v
+++ b/bsg_cache/bsg_cache.v
@@ -13,14 +13,15 @@
 
 
 `include "bsg_defines.v"
+`include "bsg_cache.vh"
 
 module bsg_cache
   import bsg_cache_pkg::*;
-  #(parameter addr_width_p="inv"  // byte addr
-    ,parameter data_width_p="inv" // word size
-    ,parameter block_size_in_words_p="inv"
-    ,parameter sets_p="inv"
-    ,parameter ways_p="inv"
+  #(`BSG_INV_PARAM(addr_width_p) // byte addr
+    ,`BSG_INV_PARAM(data_width_p)  // word size
+    ,`BSG_INV_PARAM(block_size_in_words_p)
+    ,`BSG_INV_PARAM(sets_p)
+    ,`BSG_INV_PARAM(ways_p)
 
     // Explicit size prevents size inference and allows for ((foo == bar) << e_cache_amo_swap)
     ,parameter [31:0] amo_support_p=(1 << e_cache_amo_swap)
@@ -1047,3 +1048,5 @@ module bsg_cache
 
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_cache)

--- a/bsg_cache/bsg_cache.vh
+++ b/bsg_cache/bsg_cache.vh
@@ -1,0 +1,62 @@
+`ifndef BSG_CACHE_VH
+`define BSG_CACHE_VH
+  // bsg_cache_pkt_s
+  //
+  `define declare_bsg_cache_pkt_s(addr_width_mp, data_width_mp) \
+    typedef struct packed {                                     \
+      bsg_cache_opcode_e opcode;                                \
+      logic [addr_width_mp-1:0] addr;                           \
+      logic [data_width_mp-1:0] data;                           \
+      logic [(data_width_mp>>3)-1:0] mask;                      \
+    } bsg_cache_pkt_s
+
+  `define bsg_cache_pkt_width(addr_width_mp, data_width_mp) \
+    ($bits(bsg_cache_opcode_e)+addr_width_mp+data_width_mp+(data_width_mp>>3))
+
+  // bsg_cache_dma_pkt_s
+  //
+  `define declare_bsg_cache_dma_pkt_s(addr_width_mp) \
+    typedef struct packed {                          \
+      logic write_not_read;                          \
+      logic [addr_width_mp-1:0] addr;                \
+    } bsg_cache_dma_pkt_s
+
+  `define bsg_cache_dma_pkt_width(addr_width_mp)     \
+    (1+addr_width_mp)
+
+  // tag info s
+  //
+  `define declare_bsg_cache_tag_info_s(tag_width_mp) \
+    typedef struct packed {                   \
+      logic valid;                            \
+      logic lock;                             \
+      logic [tag_width_mp-1:0] tag;           \
+    } bsg_cache_tag_info_s
+
+  `define bsg_cache_tag_info_width(tag_width_mp) (tag_width_mp+2)
+
+  // stat info s
+  //
+  `define declare_bsg_cache_stat_info_s(ways_mp)    \
+    typedef struct packed {                         \
+      logic [ways_mp-1:0] dirty;                    \
+      logic [ways_mp-2:0] lru_bits;                 \
+    } bsg_cache_stat_info_s
+
+  `define bsg_cache_stat_info_width(ways_mp) \
+    (ways_mp+ways_mp-1)
+
+  // sbuf entry s
+  //
+  `define declare_bsg_cache_sbuf_entry_s(addr_width_mp, data_width_mp, ways_mp) \
+    typedef struct packed {                       \
+      logic [addr_width_mp-1:0] addr;             \
+      logic [data_width_mp-1:0] data;             \
+      logic [(data_width_mp>>3)-1:0] mask;        \
+      logic [`BSG_SAFE_CLOG2(ways_mp)-1:0] way_id;\
+    } bsg_cache_sbuf_entry_s
+
+  `define bsg_cache_sbuf_entry_width(addr_width_mp, data_width_mp, ways_mp) \
+    (addr_width_mp+data_width_mp+(data_width_mp>>3)+`BSG_SAFE_CLOG2(ways_mp))
+
+`endif //  `ifndef BSG_CACHE_VH

--- a/bsg_cache/bsg_cache_dma.v
+++ b/bsg_cache/bsg_cache_dma.v
@@ -8,6 +8,7 @@
  */
 
 `include "bsg_defines.v"
+`include "bsg_cache.vh"
 
 module bsg_cache_dma
   import bsg_cache_pkg::*;

--- a/bsg_cache/bsg_cache_miss.v
+++ b/bsg_cache/bsg_cache_miss.v
@@ -8,6 +8,7 @@
  */
 
 `include "bsg_defines.v"
+`include "bsg_cache.vh"
 
 module bsg_cache_miss
   import bsg_cache_pkg::*;

--- a/bsg_cache/bsg_cache_pkg.v
+++ b/bsg_cache/bsg_cache_pkg.v
@@ -92,18 +92,6 @@ package bsg_cache_pkg;
     ,AMOMAXU_D = 6'b111000    // atomic max unsigned
   } bsg_cache_opcode_e;
 
-  // bsg_cache_pkt_s
-  //
-  `define declare_bsg_cache_pkt_s(addr_width_mp, data_width_mp) \
-    typedef struct packed {                                     \
-      bsg_cache_opcode_e opcode;                                \
-      logic [addr_width_mp-1:0] addr;                           \
-      logic [data_width_mp-1:0] data;                           \
-      logic [(data_width_mp>>3)-1:0] mask;                      \
-    } bsg_cache_pkt_s
-
-  `define bsg_cache_pkt_width(addr_width_mp, data_width_mp) \
-    ($bits(bsg_cache_opcode_e)+addr_width_mp+data_width_mp+(data_width_mp>>3))
 
 
   // cache pkt decode
@@ -134,16 +122,6 @@ package bsg_cache_pkg;
   } bsg_cache_decode_s;
 
 
-  // bsg_cache_dma_pkt_s
-  //
-  `define declare_bsg_cache_dma_pkt_s(addr_width_mp) \
-    typedef struct packed {               \
-      logic write_not_read;               \
-      logic [addr_width_mp-1:0] addr;     \
-    } bsg_cache_dma_pkt_s
-
-  `define bsg_cache_dma_pkt_width(addr_width_mp)    \
-    (1+addr_width_mp)
 
   // dma opcode (one-hot)
   //
@@ -155,39 +133,5 @@ package bsg_cache_pkg;
     ,e_dma_send_evict_data  = 4'b1000
   } bsg_cache_dma_cmd_e;
 
-  // tag info s
-  //
-  `define declare_bsg_cache_tag_info_s(tag_width_mp) \
-    typedef struct packed {                   \
-      logic valid;                            \
-      logic lock;                           \
-      logic [tag_width_mp-1:0] tag;           \
-    } bsg_cache_tag_info_s
-
-  `define bsg_cache_tag_info_width(tag_width_mp) (tag_width_mp+2)
-
-  // stat info s
-  //
-  `define declare_bsg_cache_stat_info_s(ways_mp)    \
-    typedef struct packed {                         \
-      logic [ways_mp-1:0] dirty;                    \
-      logic [ways_mp-2:0] lru_bits;                 \
-    } bsg_cache_stat_info_s
-
-  `define bsg_cache_stat_info_width(ways_mp) \
-    (ways_mp+ways_mp-1)
-
-  // sbuf entry s
-  //
-  `define declare_bsg_cache_sbuf_entry_s(addr_width_mp, data_width_mp, ways_mp) \
-    typedef struct packed {                       \
-      logic [addr_width_mp-1:0] addr;             \
-      logic [data_width_mp-1:0] data;             \
-      logic [(data_width_mp>>3)-1:0] mask;        \
-      logic [`BSG_SAFE_CLOG2(ways_mp)-1:0] way_id;    \
-    } bsg_cache_sbuf_entry_s 
-
-  `define bsg_cache_sbuf_entry_width(addr_width_mp, data_width_mp, ways_mp) \
-    (addr_width_mp+data_width_mp+(data_width_mp>>3)+`BSG_SAFE_CLOG2(ways_mp))
 
 endpackage

--- a/bsg_cache/bsg_cache_sbuf.v
+++ b/bsg_cache/bsg_cache_sbuf.v
@@ -13,6 +13,7 @@
  */
 
 `include "bsg_defines.v"
+`include "bsg_cache.vh"
 
 module bsg_cache_sbuf
   import bsg_cache_pkg::*;

--- a/bsg_cache/bsg_cache_to_axi.v
+++ b/bsg_cache/bsg_cache_to_axi.v
@@ -5,6 +5,7 @@
  */
 
 `include "bsg_defines.v"
+`include "bsg_cache.vh"
 
 module bsg_cache_to_axi
   import bsg_cache_pkg::*;

--- a/bsg_cache/bsg_cache_to_dram_ctrl.v
+++ b/bsg_cache/bsg_cache_to_dram_ctrl.v
@@ -6,6 +6,7 @@
  */
 
 `include "bsg_defines.v"
+`include "bsg_cache.vh"
 
 module bsg_cache_to_dram_ctrl
   import bsg_cache_pkg::*;

--- a/bsg_cache/bsg_cache_to_test_dram.v
+++ b/bsg_cache/bsg_cache_to_test_dram.v
@@ -9,6 +9,7 @@
 
 
 `include "bsg_defines.v"
+`include "bsg_cache.vh"
 
 module bsg_cache_to_test_dram 
   import bsg_cache_pkg::*;

--- a/bsg_cache/bsg_nonsynth_cache_axe_tracer.v
+++ b/bsg_cache/bsg_nonsynth_cache_axe_tracer.v
@@ -10,6 +10,7 @@
 
 
 `include "bsg_defines.v"
+`include "bsg_cache.vh"
 
 module bsg_nonsynth_cache_axe_tracer
   import bsg_cache_pkg::*;

--- a/bsg_dataflow/bsg_1_to_n_tagged.v
+++ b/bsg_dataflow/bsg_1_to_n_tagged.v
@@ -17,7 +17,7 @@
 `include "bsg_defines.v"
 
 module bsg_1_to_n_tagged #(
-                           parameter num_out_p    = -1
+                           `BSG_INV_PARAM(num_out_p)
                            ,parameter tag_width_lp = `BSG_SAFE_CLOG2(num_out_p)
                            )
    (input  clk_i
@@ -55,5 +55,6 @@ module bsg_1_to_n_tagged #(
         assign yumi_o = ready_i[tag_i] & v_i;
      end
 
-endmodule
+endmodule // bsg_1_to_n_tagged
 
+`BSG_ABSTRACT_MODULE(bsg_1_to_n_tagged)

--- a/bsg_dataflow/bsg_1_to_n_tagged_fifo.v
+++ b/bsg_dataflow/bsg_1_to_n_tagged_fifo.v
@@ -13,10 +13,10 @@
 
 `include "bsg_defines.v"
 
-module bsg_1_to_n_tagged_fifo   #(parameter width_p                   = "inv"
-                                  ,parameter num_out_p                = -1
-                                  ,parameter els_p                    = "inv" // these are elements per channel
-                                  ,parameter unbuffered_mask_p        = 0
+module bsg_1_to_n_tagged_fifo   #(`BSG_INV_PARAM(width_p)
+                                  ,`BSG_INV_PARAM(num_out_p)
+                                  ,`BSG_INV_PARAM(els_p) // these are elements per channel
+                                  ,parameter unbuffered_mask_p        = '0
                                   ,parameter use_pseudo_large_fifo_p  = 0
                                   ,parameter harden_small_fifo_p      = 0
                                   ,parameter tag_width_lp        = `BSG_SAFE_CLOG2(num_out_p)
@@ -99,3 +99,5 @@ module bsg_1_to_n_tagged_fifo   #(parameter width_p                   = "inv"
      end
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_1_to_n_tagged_fifo)

--- a/bsg_dataflow/bsg_channel_tunnel.v
+++ b/bsg_dataflow/bsg_channel_tunnel.v
@@ -62,8 +62,8 @@
 `include "bsg_defines.v"
 
 module bsg_channel_tunnel #(parameter width_p        = 1
-                            , num_in_p               = "inv"
-                            , remote_credits_p       = "inv"
+                            , `BSG_INV_PARAM(num_in_p)
+                            , `BSG_INV_PARAM(remote_credits_p)
                             , use_pseudo_large_fifo_p = 0
                             , harden_small_fifo_p    = 0
                             , lg_remote_credits_lp   = $clog2(remote_credits_p+1)
@@ -170,5 +170,7 @@ module bsg_channel_tunnel #(parameter width_p        = 1
       );
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_channel_tunnel)
 
 

--- a/bsg_dataflow/bsg_channel_tunnel_in.v
+++ b/bsg_dataflow/bsg_channel_tunnel_in.v
@@ -9,9 +9,9 @@
 
 `include "bsg_defines.v"
 
-module bsg_channel_tunnel_in #(parameter width_p = -1
-                               , num_in_p = "inv"
-                               , remote_credits_p = "inv"
+module bsg_channel_tunnel_in #(`BSG_INV_PARAM(width_p)
+                               , `BSG_INV_PARAM(num_in_p)
+                               , `BSG_INV_PARAM(remote_credits_p)
                                , use_pseudo_large_fifo_p = 0
                                , harden_small_fifo_p = 0
 
@@ -103,3 +103,5 @@ module bsg_channel_tunnel_in #(parameter width_p = -1
      end
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_channel_tunnel_in)

--- a/bsg_dataflow/bsg_channel_tunnel_out.v
+++ b/bsg_dataflow/bsg_channel_tunnel_out.v
@@ -10,9 +10,9 @@
 `include "bsg_defines.v"
 
 module bsg_channel_tunnel_out #(
-                                parameter  width_p = -1
-                                , num_in_p = "inv"
-                                , remote_credits_p = "inv"
+                                `BSG_INV_PARAM(width_p)
+                                ,`BSG_INV_PARAM(num_in_p)
+                                ,`BSG_INV_PARAM(remote_credits_p)
 
                                 // determines when we send out credits remotely
                                 , lg_credit_decimation_p = 4
@@ -120,3 +120,5 @@ module bsg_channel_tunnel_out #(
       );
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_channel_tunnel_out)

--- a/bsg_dataflow/bsg_channel_tunnel_wormhole.v
+++ b/bsg_dataflow/bsg_channel_tunnel_wormhole.v
@@ -71,24 +71,24 @@ module  bsg_channel_tunnel_wormhole
 
  #(// Wormhole packet configurations
    // These parameters are properties of wormhole network
-   parameter width_p          = "inv"
-  ,parameter x_cord_width_p   = "inv"
-  ,parameter y_cord_width_p   = "inv"
-  ,parameter len_width_p      = "inv"
-  ,parameter reserved_width_p = "inv"
+   `BSG_INV_PARAM(width_p)
+   ,`BSG_INV_PARAM(x_cord_width_p)
+   ,`BSG_INV_PARAM(y_cord_width_p)
+   ,`BSG_INV_PARAM(len_width_p)
+   ,`BSG_INV_PARAM(reserved_width_p)
   
   // Total number of inputs multiplexed / demultiplexed within channel tunnel
   // Typically this should match number of wormhole traffic streams being merged
-  ,parameter num_in_p = "inv"
+  ,`BSG_INV_PARAM(num_in_p)
   
   // Max number of wormhole packets buffer can store
   // This is independent of how many flits each wormhole packet has
-  ,parameter remote_credits_p = "inv"
+  ,`BSG_INV_PARAM(remote_credits_p)
   
   // Max possible "wormhole packet payload length" setting
   // An n-flits wormhole packet has 1 header flit and (n-1) payload flits
   // This parameter determines the size of payload-flits buffer
-  ,parameter max_payload_flits_p = "inv"
+  ,`BSG_INV_PARAM(max_payload_flits_p)
   
   // How often does channel tunnel return credits to sender
   // Default value matches child module bsg_channel_tunnel
@@ -640,3 +640,5 @@ module  bsg_channel_tunnel_wormhole
   // synopsys translate_on
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_channel_tunnel_wormhole)

--- a/bsg_dataflow/bsg_fifo_1r1w_large.v
+++ b/bsg_dataflow/bsg_fifo_1r1w_large.v
@@ -110,8 +110,8 @@
 
 `include "bsg_defines.v"
 
-module bsg_fifo_1r1w_large #(parameter width_p           = -1
-                             , parameter els_p           = -1
+module bsg_fifo_1r1w_large #(`BSG_INV_PARAM(width_p)
+                             , `BSG_INV_PARAM(els_p)
                              )
    (input                  clk_i
     , input                reset_i
@@ -304,3 +304,5 @@ module bsg_fifo_1r1w_large #(parameter width_p           = -1
 
 endmodule
 
+
+`BSG_ABSTRACT_MODULE(bsg_fifo_1r1w_large)

--- a/bsg_dataflow/bsg_fifo_1r1w_small_hardened.v
+++ b/bsg_dataflow/bsg_fifo_1r1w_small_hardened.v
@@ -20,8 +20,8 @@
 
 `include "bsg_defines.v"
 
-module bsg_fifo_1r1w_small_hardened #( parameter width_p      = -1
-                            , parameter els_p        = -1
+module bsg_fifo_1r1w_small_hardened #(`BSG_INV_PARAM(width_p)
+                            , `BSG_INV_PARAM(els_p)
                             , parameter ready_THEN_valid_p = 0
                             )
     ( input                clk_i
@@ -143,3 +143,5 @@ module bsg_fifo_1r1w_small_hardened #( parameter width_p      = -1
    //synopsys translate_on
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_fifo_1r1w_small_hardened)

--- a/bsg_dataflow/bsg_one_fifo.v
+++ b/bsg_dataflow/bsg_one_fifo.v
@@ -16,7 +16,7 @@
 
 `include "bsg_defines.v"
 
-module bsg_one_fifo #(parameter width_p="inv"
+module bsg_one_fifo #(`BSG_INV_PARAM(width_p)
                       )
    (input clk_i
     , input reset_i
@@ -54,3 +54,5 @@ module bsg_one_fifo #(parameter width_p="inv"
   );
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_one_fifo)

--- a/bsg_dataflow/bsg_parallel_in_serial_out.v
+++ b/bsg_dataflow/bsg_parallel_in_serial_out.v
@@ -18,8 +18,8 @@
 
 module bsg_parallel_in_serial_out 
 
-   #(parameter width_p                 = -1
-    ,parameter els_p                   = -1
+   #(`BSG_INV_PARAM(width_p)
+    ,`BSG_INV_PARAM(els_p)
     ,parameter hi_to_lo_p              = 0 // sending from high bits to low bits
     ,parameter use_minimal_buffering_p = 0 // using single element buffer
     )
@@ -208,3 +208,5 @@ module bsg_parallel_in_serial_out
   end
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_parallel_in_serial_out)

--- a/bsg_dataflow/bsg_parallel_in_serial_out_dynamic.v
+++ b/bsg_dataflow/bsg_parallel_in_serial_out_dynamic.v
@@ -9,9 +9,9 @@
 
 module bsg_parallel_in_serial_out_dynamic
                                
- #(parameter width_p          = "inv"
-  ,parameter max_els_p        = "inv"
-  ,parameter lg_max_els_lp    = `BSG_SAFE_CLOG2(max_els_p)
+ #(`BSG_INV_PARAM(width_p)
+   ,`BSG_INV_PARAM(max_els_p)
+   ,parameter lg_max_els_lp    = `BSG_SAFE_CLOG2(max_els_p)
   )
   
   (input clk_i

--- a/bsg_dataflow/bsg_serial_in_parallel_out.v
+++ b/bsg_dataflow/bsg_serial_in_parallel_out.v
@@ -17,8 +17,8 @@
 
 `include "bsg_defines.v"
 
-module bsg_serial_in_parallel_out #(parameter   width_p   = -1
-                                    , parameter els_p     = -1
+module bsg_serial_in_parallel_out #(`BSG_INV_PARAM(width_p)
+                                    , `BSG_INV_PARAM(els_p)
                                     , parameter out_els_p = els_p)
    (input                 clk_i
     , input               reset_i
@@ -91,3 +91,6 @@ module bsg_serial_in_parallel_out #(parameter   width_p   = -1
   end
 
 endmodule
+
+
+`BSG_ABSTRACT_MODULE(bsg_serial_in_parallel_out)

--- a/bsg_dataflow/bsg_serial_in_parallel_out_full.v
+++ b/bsg_dataflow/bsg_serial_in_parallel_out_full.v
@@ -17,8 +17,8 @@
 
 module bsg_serial_in_parallel_out_full
 
- #(parameter width_p                 = "inv"
-  ,parameter els_p                   = "inv"
+ #(`BSG_INV_PARAM(width_p)
+   ,`BSG_INV_PARAM(els_p)
   ,parameter hi_to_lo_p              = 0
   ,parameter use_minimal_buffering_p = 0
   )
@@ -186,3 +186,4 @@ endmodule
 
 */
    
+`BSG_ABSTRACT_MODULE(bsg_serial_in_parallel_out_full)

--- a/bsg_dataflow/bsg_serial_in_parallel_out_passthrough.v
+++ b/bsg_dataflow/bsg_serial_in_parallel_out_passthrough.v
@@ -5,9 +5,9 @@
 `include "bsg_defines.v"
 
 module bsg_serial_in_parallel_out_passthrough
- #(parameter width_p      = "inv"
-   , parameter els_p      = "inv"
-   , parameter hi_to_lo_p = 0
+ #(`BSG_INV_PARAM(width_p)
+   , `BSG_INV_PARAM(els_p)
+   , hi_to_lo_p = 0
    )
   (input                                  clk_i
   , input                                 reset_i
@@ -84,3 +84,4 @@ module bsg_serial_in_parallel_out_passthrough
 
 endmodule
 
+`BSG_ABSTRACT_MODULE(bsg_serial_in_parallel_out_passthrough)

--- a/bsg_dataflow/bsg_two_fifo.v
+++ b/bsg_dataflow/bsg_two_fifo.v
@@ -25,7 +25,7 @@
 
 `include "bsg_defines.v"
 
-module bsg_two_fifo #(parameter width_p="inv"
+module bsg_two_fifo #(parameter `BSG_INV_PARAM(width_p)
                       , parameter verbose_p=0
                       // whether we should allow simultaneous enque and deque on full
                       , parameter allow_enq_deq_on_full_p=0
@@ -143,3 +143,5 @@ module bsg_two_fifo #(parameter width_p="inv"
    // synopsys translate_on
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_two_fifo)

--- a/bsg_mem/bsg_cam_1r1w.v
+++ b/bsg_mem/bsg_cam_1r1w.v
@@ -18,9 +18,9 @@
 `include "bsg_defines.v"
 
 module bsg_cam_1r1w
- #(parameter els_p                = "inv"
-   , parameter tag_width_p        = "inv"
-   , parameter data_width_p       = "inv"
+ #(`BSG_INV_PARAM(els_p)
+   , `BSG_INV_PARAM(tag_width_p)
+   , `BSG_INV_PARAM(data_width_p)
 
    // The replacement scheme for the CAM
    , parameter repl_scheme_p = "lru"
@@ -104,4 +104,6 @@ module bsg_cam_1r1w
   assign r_v_o = |tag_r_match_lo;
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_cam_1r1w)
 

--- a/bsg_mem/bsg_cam_1r1w_sync.v
+++ b/bsg_mem/bsg_cam_1r1w_sync.v
@@ -10,9 +10,9 @@
 `include "bsg_defines.v"
 
 module bsg_cam_1r1w_sync
- #(parameter els_p                = "inv"
-   , parameter tag_width_p        = "inv"
-   , parameter data_width_p       = "inv"
+ #(`BSG_INV_PARAM(els_p)
+   ,`BSG_INV_PARAM(tag_width_p)
+   ,`BSG_INV_PARAM(data_width_p)
 
    // The replacement scheme for the CAM
    , parameter repl_scheme_p = "lru"
@@ -72,3 +72,5 @@ module bsg_cam_1r1w_sync
 
 endmodule
 
+
+`BSG_ABSTRACT_MODULE(bsg_cam_1r1w_sync)

--- a/bsg_mem/bsg_cam_1r1w_sync_unmanaged.v
+++ b/bsg_mem/bsg_cam_1r1w_sync_unmanaged.v
@@ -10,9 +10,9 @@
 `include "bsg_defines.v"
 
 module bsg_cam_1r1w_sync_unmanaged
- #(parameter els_p                = "inv"
-   , parameter tag_width_p        = "inv"
-   , parameter data_width_p       = "inv"
+ #(`BSG_INV_PARAM(els_p)
+   , `BSG_INV_PARAM(tag_width_p)
+   , `BSG_INV_PARAM(data_width_p)
 
    , parameter safe_els_lp = `BSG_MAX(els_p,1)
    )
@@ -74,3 +74,4 @@ module bsg_cam_1r1w_sync_unmanaged
 
 endmodule
 
+`BSG_ABSTRACT_MODULE(bsg_cam_1r1w_sync_unmanaged)

--- a/bsg_mem/bsg_cam_1r1w_tag_array.v
+++ b/bsg_mem/bsg_cam_1r1w_tag_array.v
@@ -7,8 +7,8 @@
 `include "bsg_defines.v"
 
 module bsg_cam_1r1w_tag_array
- #(parameter width_p  = "inv"
-   , parameter els_p      = "inv"
+ #(`BSG_INV_PARAM(width_p)
+   , `BSG_INV_PARAM(els_p)
 
    , parameter multiple_entries_p = 0
 
@@ -86,3 +86,5 @@ module bsg_cam_1r1w_tag_array
   //synopsys translate_on
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_cam_1r1w_tag_array)

--- a/bsg_mem/bsg_cam_1r1w_unmanaged.v
+++ b/bsg_mem/bsg_cam_1r1w_unmanaged.v
@@ -10,9 +10,9 @@
 `include "bsg_defines.v"
 
 module bsg_cam_1r1w_unmanaged
- #(parameter els_p                = "inv"
-   , parameter tag_width_p        = "inv"
-   , parameter data_width_p       = "inv"
+ #(`BSG_INV_PARAM(els_p)
+   , `BSG_INV_PARAM(els_p)
+   , `BSG_INV_PARAM(data_width_p)
 
    , parameter safe_els_lp = `BSG_MAX(els_p,1)
    )
@@ -79,4 +79,6 @@ module bsg_cam_1r1w_unmanaged
   assign r_v_o = |tag_r_match_lo;
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_cam_1r1w_unmanaged)
 

--- a/bsg_mem/bsg_mem_1r1w.v
+++ b/bsg_mem/bsg_mem_1r1w.v
@@ -7,8 +7,8 @@
 
 `include "bsg_defines.v"
 
-module bsg_mem_1r1w #(parameter width_p=-1
-                      , parameter els_p=-1
+module bsg_mem_1r1w #(`BSG_INV_PARAM(width_p)
+                      ,`BSG_INV_PARAM(els_p)
                       , parameter read_write_same_addr_p=0
                       , parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
                       , parameter harden_p=0
@@ -57,3 +57,5 @@ module bsg_mem_1r1w #(parameter width_p=-1
    //synopsys translate_on
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_mem_1r1w)

--- a/bsg_mem/bsg_mem_1r1w_one_hot.v
+++ b/bsg_mem/bsg_mem_1r1w_one_hot.v
@@ -8,8 +8,8 @@
 
 `include "bsg_defines.v"
 
-module bsg_mem_1r1w_one_hot #(parameter width_p=-1
-                            , parameter els_p=-1
+module bsg_mem_1r1w_one_hot #(`BSG_INV_PARAM(width_p)
+                            , `BSG_INV_PARAM(els_p)
 
                             , parameter safe_els_lp=`BSG_MAX(els_p,1)
                             )
@@ -72,3 +72,5 @@ module bsg_mem_1r1w_one_hot #(parameter width_p=-1
    //synopsys translate_on
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_mem_1r1w_one_hot)

--- a/bsg_mem/bsg_mem_1r1w_sync.v
+++ b/bsg_mem/bsg_mem_1r1w_sync.v
@@ -12,8 +12,8 @@
 
 `include "bsg_defines.v"
 
-module bsg_mem_1r1w_sync #(parameter width_p=-1
-                           , parameter els_p=-1
+module bsg_mem_1r1w_sync #(`BSG_INV_PARAM(width_p)
+                           , `BSG_INV_PARAM(els_p)
                            , parameter read_write_same_addr_p=0
                            , parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
                            , parameter harden_p=0

--- a/bsg_mem/bsg_mem_1r1w_sync_synth.v
+++ b/bsg_mem/bsg_mem_1r1w_sync_synth.v
@@ -14,8 +14,8 @@
 
 `include "bsg_defines.v"
 
-module bsg_mem_1r1w_sync_synth #(parameter width_p=-1
-				 , parameter els_p=-1
+module bsg_mem_1r1w_sync_synth #(`BSG_INV_PARAM(width_p)
+				 , `BSG_INV_PARAM(els_p)
 				 , parameter read_write_same_addr_p=0
 				 , parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
 				 , parameter harden_p=0
@@ -81,3 +81,5 @@ module bsg_mem_1r1w_sync_synth #(parameter width_p=-1
 
    end
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_mem_1r1w_sync_synth)

--- a/bsg_mem/bsg_mem_1r1w_synth.v
+++ b/bsg_mem/bsg_mem_1r1w_synth.v
@@ -10,8 +10,8 @@
 
 `include "bsg_defines.v"
 
-module bsg_mem_1r1w_synth #(parameter width_p=-1
-			    ,parameter els_p=-1
+module bsg_mem_1r1w_synth #(`BSG_INV_PARAM(width_p)
+			    ,`BSG_INV_PARAM(els_p)
 			    ,parameter read_write_same_addr_p=0
 			    ,parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
 			    ,parameter harden_p=0)
@@ -54,3 +54,5 @@ module bsg_mem_1r1w_synth #(parameter width_p=-1
   end
    end
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_mem_1r1w_synth)

--- a/bsg_mem/bsg_mem_1rw_sync.v
+++ b/bsg_mem/bsg_mem_1rw_sync.v
@@ -6,8 +6,8 @@
 
 `include "bsg_defines.v"
 
-module bsg_mem_1rw_sync #(parameter width_p=-1
-                          , parameter els_p=-1
+module bsg_mem_1rw_sync #(`BSG_INV_PARAM(width_p)
+                          , `BSG_INV_PARAM(els_p)
                           , parameter latch_last_read_p=0
                           , parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
                           , parameter enable_clock_gating_p=0
@@ -55,3 +55,5 @@ module bsg_mem_1rw_sync #(parameter width_p=-1
     );
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_mem_1rw_sync)

--- a/bsg_mem/bsg_mem_1rw_sync_banked.v
+++ b/bsg_mem/bsg_mem_1rw_sync_banked.v
@@ -25,8 +25,8 @@
 `include "bsg_defines.v"
 
 module bsg_mem_1rw_sync_banked 
-  #(parameter width_p="inv"
-    , parameter els_p="inv"
+  #(`BSG_INV_PARAM(width_p)
+    , `BSG_INV_PARAM(els_p)
     , parameter latch_last_read_p=0
 
     , parameter num_width_bank_p=1
@@ -147,3 +147,5 @@ module bsg_mem_1rw_sync_banked
 
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_mem_1rw_sync_banked)

--- a/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_synth.v
+++ b/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_synth.v
@@ -10,8 +10,8 @@
 `include "bsg_defines.v"
 
 module bsg_mem_1rw_sync_mask_write_bit_synth
-  #(parameter width_p=-1
-    , parameter els_p=-1
+  #(`BSG_INV_PARAM(width_p)
+    , `BSG_INV_PARAM(els_p)
     , parameter latch_last_read_p=0
     , parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
    )
@@ -111,3 +111,5 @@ module bsg_mem_1rw_sync_mask_write_bit_synth
 `endif
    end
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_mem_1rw_sync_mask_write_bit_synth)

--- a/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v
+++ b/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v
@@ -1,6 +1,6 @@
 `include "bsg_defines.v"
 
-module bsg_mem_1rw_sync_mask_write_byte #( parameter els_p = -1
+module bsg_mem_1rw_sync_mask_write_byte #(`BSG_INV_PARAM(els_p)
                                           ,parameter addr_width_lp = `BSG_SAFE_CLOG2(els_p)
 
                                           ,parameter data_width_p = -1
@@ -66,3 +66,4 @@ module bsg_mem_1rw_sync_mask_write_byte #( parameter els_p = -1
 
    
 endmodule
+`BSG_ABSTRACT_MODULE(bsg_mem_1rw_sync_mask_write_byte)

--- a/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_synth.v
+++ b/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_synth.v
@@ -4,7 +4,7 @@
 `include "bsg_defines.v"
 
 module bsg_mem_1rw_sync_mask_write_byte_synth
-  #(parameter els_p = -1
+  #(`BSG_INV_PARAM(els_p)
     , parameter addr_width_lp = `BSG_SAFE_CLOG2(els_p)
     , parameter latch_last_read_p=0
 
@@ -55,3 +55,5 @@ module bsg_mem_1rw_sync_mask_write_byte_synth
    end
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_mem_1rw_sync_mask_write_byte_synth)

--- a/bsg_mem/bsg_mem_1rw_sync_synth.v
+++ b/bsg_mem/bsg_mem_1rw_sync_synth.v
@@ -9,8 +9,8 @@
 `include "bsg_defines.v"
 
 module bsg_mem_1rw_sync_synth
-  #(parameter width_p=-1
-    , parameter els_p=-1
+  #(`BSG_INV_PARAM(width_p)
+    , `BSG_INV_PARAM(els_p)
     , parameter latch_last_read_p=0
     , parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
     , parameter verbose_p=1
@@ -94,3 +94,5 @@ module bsg_mem_1rw_sync_synth
    // synopsys translate_on
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_mem_1rw_sync_synth)

--- a/bsg_misc/bsg_arb_round_robin.v
+++ b/bsg_misc/bsg_arb_round_robin.v
@@ -17,7 +17,7 @@
 
 `include "bsg_defines.v"
 
-module bsg_arb_round_robin #(parameter width_p=-1)
+module bsg_arb_round_robin #(`BSG_INV_PARAM(width_p))
   (input          clk_i
    , input        reset_i
 
@@ -70,3 +70,5 @@ module bsg_arb_round_robin #(parameter width_p=-1)
         end  
     end
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_arb_round_robin)

--- a/bsg_misc/bsg_array_concentrate_static.v
+++ b/bsg_misc/bsg_array_concentrate_static.v
@@ -1,8 +1,8 @@
 `include "bsg_defines.v"
 
 module bsg_array_concentrate_static 
-  #(parameter pattern_els_p="inv"
-    , parameter width_p="inv"
+  #(`BSG_INV_PARAM(pattern_els_p)
+    , `BSG_INV_PARAM(width_p)
     , dense_els_lp=$bits(pattern_els_p)
     , sparse_els_lp=`BSG_COUNTONES_SYNTH(pattern_els_p))
   (input    [dense_els_lp-1:0][width_p-1:0] i
@@ -20,3 +20,5 @@ module bsg_array_concentrate_static
      end
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_array_cocentrate_static)

--- a/bsg_misc/bsg_circular_ptr.v
+++ b/bsg_misc/bsg_circular_ptr.v
@@ -8,8 +8,8 @@
 // and points to slots_p slots.
 //
 
-module bsg_circular_ptr #(parameter slots_p     = -1
-                          , parameter max_add_p = -1
+module bsg_circular_ptr #(`BSG_INV_PARAM(slots_p)
+                          , `BSG_INV_PARAM(max_add_p)
                           // local param
                           , parameter ptr_width_lp = `BSG_SAFE_CLOG2(slots_p)
 			  )
@@ -75,3 +75,5 @@ module bsg_circular_ptr #(parameter slots_p     = -1
 	  // synopsys translate_on
 end
 endmodule // bsg_circular_ptr
+
+`BSG_ABSTRACT_MODULE(bsg_circular_ptr)

--- a/bsg_misc/bsg_counter_clear_up.v
+++ b/bsg_misc/bsg_counter_clear_up.v
@@ -5,7 +5,7 @@
 
 `include "bsg_defines.v"
 
-module bsg_counter_clear_up #(parameter max_val_p     = -1
+module bsg_counter_clear_up #(`BSG_INV_PARAM(max_val_p)
 			      // this originally had an "invalid" default value of -1
 			      // which is a bad choice for a counter
 			     ,parameter init_val_p   = `BSG_UNDEFINED_IN_SIM('0)

--- a/bsg_misc/bsg_counter_set_down.v
+++ b/bsg_misc/bsg_counter_set_down.v
@@ -5,7 +5,7 @@
 
 `include "bsg_defines.v"
 
-module bsg_counter_set_down #(parameter width_p="inv", parameter init_val_p='0, parameter set_and_down_exclusive_p=0)
+module bsg_counter_set_down #(`BSG_INV_PARAM(width_p), parameter init_val_p='0, parameter set_and_down_exclusive_p=0)
   (input clk_i
    , input reset_i
    , input set_i
@@ -63,3 +63,5 @@ module bsg_counter_set_down #(parameter width_p="inv", parameter init_val_p='0, 
 `endif
       
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_counter_set_down)

--- a/bsg_misc/bsg_crossbar_o_by_i.v
+++ b/bsg_misc/bsg_crossbar_o_by_i.v
@@ -3,9 +3,9 @@
 
 `include "bsg_defines.v"
 
-module bsg_crossbar_o_by_i #( parameter i_els_p = -1
-                             ,parameter o_els_p = -1
-                             ,parameter width_p = -1
+module bsg_crossbar_o_by_i #( `BSG_INV_PARAM(i_els_p)
+                             ,`BSG_INV_PARAM(o_els_p)
+                             ,`BSG_INV_PARAM(width_p)
                             )
   ( input  [i_els_p-1:0][width_p-1:0] i
    ,input  [o_els_p-1:0][i_els_p-1:0] sel_oi_one_hot_i
@@ -26,3 +26,5 @@ module bsg_crossbar_o_by_i #( parameter i_els_p = -1
   end
 
 endmodule // bsg_crossbar_o_by_i
+
+`BSG_ABSTRACT_MODULE(bsg_crossbar_o_by_i)

--- a/bsg_misc/bsg_decode_with_v.v
+++ b/bsg_misc/bsg_decode_with_v.v
@@ -1,6 +1,6 @@
 `include "bsg_defines.v"
 
-module bsg_decode_with_v #(num_out_p=-1)
+module bsg_decode_with_v #(`BSG_INV_PARAM(num_out_p))
    (
 
     input [`BSG_SAFE_CLOG2(num_out_p)-1:0] i
@@ -19,3 +19,5 @@ module bsg_decode_with_v #(num_out_p=-1)
    assign o = { (num_out_p) { v_i } } & lo;
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(num_out_p)

--- a/bsg_misc/bsg_dff.v
+++ b/bsg_misc/bsg_dff.v
@@ -1,7 +1,7 @@
 
 `include "bsg_defines.v"
 
-module bsg_dff #(width_p=-1
+module bsg_dff #(`BSG_INV_PARAM(width_p)
 		 ,harden_p=0
 		 ,strength_p=1   // set drive strength
 		 )
@@ -18,3 +18,5 @@ module bsg_dff #(width_p=-1
      data_r <= data_i;
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_dff)

--- a/bsg_misc/bsg_dff_en.v
+++ b/bsg_misc/bsg_dff_en.v
@@ -5,7 +5,7 @@
 
 `include "bsg_defines.v"
 
-module bsg_dff_en #(parameter width_p="inv"
+module bsg_dff_en #(`BSG_INV_PARAM(width_p)
                    ,parameter harden_p=1   // mbt fixme: maybe this should not be a default
                    ,parameter strength_p=1)
 (
@@ -26,3 +26,5 @@ module bsg_dff_en #(parameter width_p="inv"
   end
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_dff_en)

--- a/bsg_misc/bsg_dff_en_bypass.v
+++ b/bsg_misc/bsg_dff_en_bypass.v
@@ -7,7 +7,7 @@
 `include "bsg_defines.v"
 
 module bsg_dff_en_bypass
-  #(parameter width_p="inv"
+  #(`BSG_INV_PARAM(width_p)
     , parameter harden_p=0
     , parameter strength_p=0
   )
@@ -38,3 +38,5 @@ module bsg_dff_en_bypass
 
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_dff_en_bypass)

--- a/bsg_misc/bsg_dff_reset_en.v
+++ b/bsg_misc/bsg_dff_reset_en.v
@@ -5,7 +5,7 @@
 `include "bsg_defines.v"
 
 module bsg_dff_reset_en
-  #(parameter width_p="inv"
+  #(`BSG_INV_PARAM(width_p)
     , parameter reset_val_p=0
     , parameter harden_p=0
   )
@@ -33,3 +33,5 @@ module bsg_dff_reset_en
   end
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_dff_reset_en)

--- a/bsg_misc/bsg_hash_bank_reverse.v
+++ b/bsg_misc/bsg_hash_bank_reverse.v
@@ -6,7 +6,7 @@
 
 `include "bsg_defines.v"
 
-module bsg_hash_bank_reverse #(parameter banks_p="inv", width_p="inv", index_width_lp=$clog2((2**width_p+banks_p-1)/banks_p), lg_banks_lp=`BSG_SAFE_CLOG2(banks_p), debug_lp=0)
+module bsg_hash_bank_reverse #(`BSG_INV_PARAM(banks_p), `BSG_INV_PARAM(width_p), index_width_lp=$clog2((2**width_p+banks_p-1)/banks_p), lg_banks_lp=`BSG_SAFE_CLOG2(banks_p), debug_lp=0)
   (/* input clk,*/ 
 
    input [index_width_lp-1:0] index_i
@@ -121,3 +121,5 @@ module bsg_hash_bank_reverse #(parameter banks_p="inv", width_p="inv", index_wid
         end	
   
 endmodule	
+
+`BSG_ABSTRACT_MODULE(bsg_hash_bank_reverse)

--- a/bsg_misc/bsg_lru_pseudo_tree_decode.v
+++ b/bsg_misc/bsg_lru_pseudo_tree_decode.v
@@ -13,7 +13,7 @@
 `include "bsg_defines.v"
 
 module bsg_lru_pseudo_tree_decode
-  #(parameter ways_p        = "inv"
+  #(`BSG_INV_PARAM(ways_p)
     ,localparam lg_ways_lp = `BSG_SAFE_CLOG2(ways_p)
   )
   (input [lg_ways_lp-1:0]      way_id_i
@@ -47,3 +47,5 @@ module bsg_lru_pseudo_tree_decode
   endgenerate
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_lru_pseudo_tree_decode)

--- a/bsg_misc/bsg_lru_pseudo_tree_encode.v
+++ b/bsg_misc/bsg_lru_pseudo_tree_encode.v
@@ -29,7 +29,7 @@
 `include "bsg_defines.v"
 
 module bsg_lru_pseudo_tree_encode
-  #(parameter ways_p = "inv"
+  #(`BSG_INV_PARAM(ways_p)
     , parameter lg_ways_lp = `BSG_SAFE_CLOG2(ways_p)
   )
   (
@@ -68,3 +68,4 @@ module bsg_lru_pseudo_tree_encode
 
 endmodule
 
+`BSG_ABSTRACT_MODULE(bsg_lru_psuedo_tree_encode)

--- a/bsg_misc/bsg_mux_butterfly.v
+++ b/bsg_misc/bsg_mux_butterfly.v
@@ -32,9 +32,9 @@
 `include "bsg_defines.v"
 
 module bsg_mux_butterfly
-  #(parameter width_p="inv"
-    , parameter els_p="inv"
-    , localparam lg_els_lp=`BSG_SAFE_CLOG2(els_p)
+  #(`BSG_INV_PARAM(width_p)
+    , `BSG_INV_PARAM(els_p)
+    , lg_els_lp=`BSG_SAFE_CLOG2(els_p)
   )
   (
     input [els_p-1:0][width_p-1:0] data_i
@@ -63,3 +63,5 @@ module bsg_mux_butterfly
   assign data_o = data_stage[lg_els_lp];
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_mux_butterfly)

--- a/bsg_misc/bsg_mux_one_hot.v
+++ b/bsg_misc/bsg_mux_one_hot.v
@@ -1,7 +1,7 @@
 
 `include "bsg_defines.v"
 
-module bsg_mux_one_hot #(parameter width_p="inv"
+module bsg_mux_one_hot #(`BSG_INV_PARAM(width_p)
                          , els_p=1
 			 , harden_p=1
                          )
@@ -39,3 +39,4 @@ module bsg_mux_one_hot #(parameter width_p="inv"
 
 endmodule
 
+`BSG_ABSTRACT_MODULE(bsg_mux_one_hot)

--- a/bsg_misc/bsg_mux_segmented.v
+++ b/bsg_misc/bsg_mux_segmented.v
@@ -6,8 +6,8 @@
 
 `include "bsg_defines.v"
 
-module bsg_mux_segmented #(parameter segments_p="inv"
-                          ,parameter segment_width_p="inv"
+module bsg_mux_segmented #(`BSG_INV_PARAM(segments_p)
+                          ,`BSG_INV_PARAM(segment_width_p)
                           ,parameter data_width_lp=segments_p*segment_width_p)
 (
   input [data_width_lp-1:0] data0_i
@@ -24,3 +24,5 @@ module bsg_mux_segmented #(parameter segments_p="inv"
   end
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_mux_segmented)

--- a/bsg_misc/bsg_rotate_left.v
+++ b/bsg_misc/bsg_rotate_left.v
@@ -1,6 +1,6 @@
 `include "bsg_defines.v"
 
-module bsg_rotate_left #(width_p=-1)
+module bsg_rotate_left #(`BSG_INV_PARAM(width_p))
    (input [width_p-1:0] data_i
     , input [`BSG_SAFE_CLOG2(width_p)-1:0] rot_i
     , output [width_p-1:0] o
@@ -10,3 +10,5 @@ module bsg_rotate_left #(width_p=-1)
   assign o = temp[width_p*2-1:width_p];
    
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_rotate_left)

--- a/bsg_misc/bsg_rotate_right.v
+++ b/bsg_misc/bsg_rotate_right.v
@@ -1,6 +1,6 @@
 `include "bsg_defines.v"
 
-module bsg_rotate_right #(width_p=-1)
+module bsg_rotate_right #(`BSG_INV_PARAM(width_p))
    (input [width_p-1:0] data_i
     , input [`BSG_SAFE_CLOG2(width_p)-1:0] rot_i
     , output [width_p-1:0] o
@@ -10,3 +10,5 @@ module bsg_rotate_right #(width_p=-1)
    assign o = temp[0+:width_p];
    
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_rotate_right)

--- a/bsg_misc/bsg_round_robin_arb.py
+++ b/bsg_misc/bsg_round_robin_arb.py
@@ -124,7 +124,7 @@ print """// Round robin arbitration unit
 
 """
 
-print """module bsg_round_robin_arb #(inputs_p      = %s
+print """module bsg_round_robin_arb #(`BSG_INV_PARAM(inputs_p)
                                      ,lg_inputs_p   =`BSG_SAFE_CLOG2(inputs_p)
                                      ,reset_on_sr_p = 1'b0
                                      ,hold_on_sr_p  = 1'b0
@@ -234,4 +234,8 @@ else
       last_r <= (reset_i) ? (lg_inputs_p)'(0):last_n;
   end
 
-endmodule"""
+endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_round_robin_arb.v)
+
+"""

--- a/bsg_misc/bsg_round_robin_arb.v
+++ b/bsg_misc/bsg_round_robin_arb.v
@@ -16,7 +16,7 @@
 `include "bsg_defines.v"
 
 
-module bsg_round_robin_arb #(inputs_p      = -1
+module bsg_round_robin_arb #(`BSG_INV_PARAM(inputs_p)
                                      ,lg_inputs_p   =`BSG_SAFE_CLOG2(inputs_p)
                                      ,reset_on_sr_p = 1'b0
                                      ,hold_on_sr_p  = 1'b0
@@ -2450,3 +2450,5 @@ else
   end
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_round_robin_arb)

--- a/bsg_misc/bsg_scan.v
+++ b/bsg_misc/bsg_scan.v
@@ -9,7 +9,7 @@
 
 `include "bsg_defines.v"
 
-module bsg_scan #(parameter width_p = -1
+module bsg_scan #(`BSG_INV_PARAM(width_p)
                   , parameter xor_p = 0
                   , parameter and_p = 0
                   , parameter or_p = 0
@@ -127,3 +127,5 @@ module bsg_scan #(parameter width_p = -1
    //  $display("bsg_scan (xor_p %b and_p %b  or_p %b) %b = %b",xor_p[0],and_p[0],or_p[0],i,o);
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_scan)

--- a/bsg_noc/bsg_wormhole_concentrator.v
+++ b/bsg_noc/bsg_wormhole_concentrator.v
@@ -22,10 +22,10 @@
 
 module bsg_wormhole_concentrator
 
-  #(parameter flit_width_p        = "inv"
-   ,parameter len_width_p         = "inv"
-   ,parameter cid_width_p         = "inv"
-   ,parameter cord_width_p        = "inv"
+  #(`BSG_INV_PARAM(flit_width_p)
+    ,`BSG_INV_PARAM(len_width_p)
+    ,`BSG_INV_PARAM(cid_width_p)
+    ,`BSG_INV_PARAM(cord_width_p)
    ,parameter num_in_p            = 1
    ,parameter debug_lp            = 0
    ,parameter link_width_lp       = `bsg_ready_and_link_sif_width(flit_width_p)
@@ -108,3 +108,5 @@ module bsg_wormhole_concentrator
 
 endmodule
 
+
+`BSG_ABSTRACT_MODULE(bsg_wormhole_concentrator)

--- a/bsg_noc/bsg_wormhole_concentrator_in.v
+++ b/bsg_noc/bsg_wormhole_concentrator_in.v
@@ -22,10 +22,10 @@
 
 module bsg_wormhole_concentrator_in
 
-  #(parameter flit_width_p        = "inv"
-   ,parameter len_width_p         = "inv"
-   ,parameter cid_width_p         = "inv"
-   ,parameter cord_width_p        = "inv"
+  #(`BSG_INV_PARAM(flit_width_p)
+    ,`BSG_INV_PARAM(len_width_p)
+    ,`BSG_INV_PARAM(cid_width_p)
+    ,`BSG_INV_PARAM(cord_width_p)
    ,parameter num_in_p            = 1
    ,parameter debug_lp            = 0
    )
@@ -132,4 +132,6 @@ module bsg_wormhole_concentrator_in
     ,.data_o       (concentrated_link_o_cast.data)
     );
 
-endmodule
+endmodule // bsg_wormhole_concentrator_in
+
+`BSG_ABSTRACT_MODULE(bsg_wormhole_concentrator_in)

--- a/bsg_noc/bsg_wormhole_concentrator_out.v
+++ b/bsg_noc/bsg_wormhole_concentrator_out.v
@@ -22,10 +22,10 @@
 
 module bsg_wormhole_concentrator_out
 
-  #(parameter flit_width_p        = "inv"
-   ,parameter len_width_p         = "inv"
-   ,parameter cid_width_p         = "inv"
-   ,parameter cord_width_p        = "inv"
+  #(parameter `BSG_INV_PARAM(flit_width_p)
+    ,`BSG_INV_PARAM(len_width_p)
+    ,`BSG_INV_PARAM(cid_width_p)
+    ,`BSG_INV_PARAM(cord_width_p)
    ,parameter num_in_p            = 1
    ,parameter debug_lp            = 0
    )
@@ -134,3 +134,5 @@ module bsg_wormhole_concentrator_out
     end
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_wormhole_concentrator_out)

--- a/bsg_noc/bsg_wormhole_router.v
+++ b/bsg_noc/bsg_wormhole_router.v
@@ -5,7 +5,7 @@
 module bsg_wormhole_router
      import bsg_wormhole_router_pkg::StrictXY;
      import bsg_wormhole_router_pkg::StrictX;
-  #(parameter flit_width_p        = "inv"
+  #(`BSG_INV_PARAM(flit_width_p)
    ,parameter dims_p              = 2 // 1
    ,parameter dirs_lp         = dims_p*2+1
 
@@ -16,7 +16,7 @@ module bsg_wormhole_router
    ,parameter int cord_markers_pos_p[cord_dims_p:0] =   '{ 5, 4, 0 }  // '{5,0} //
    ,parameter bit [1:0][dirs_lp-1:0][dirs_lp-1:0] routing_matrix_p =  (dims_p == 2) ? StrictXY : StrictX
    ,parameter reverse_order_p       = 0
-   ,parameter len_width_p           = "inv"
+   ,`BSG_INV_PARAM(len_width_p)
    ,parameter debug_lp              = 0
    )
 
@@ -256,3 +256,5 @@ module bsg_wormhole_router
    );
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_wormhole_router)

--- a/bsg_noc/bsg_wormhole_router_input_control.v
+++ b/bsg_noc/bsg_wormhole_router_input_control.v
@@ -1,6 +1,6 @@
 `include "bsg_defines.v"
 
-module bsg_wormhole_router_input_control #(parameter output_dirs_p=-1, parameter payload_len_bits_p=-1)
+module bsg_wormhole_router_input_control #(`BSG_INV_PARAM(output_dirs_p), `BSG_INV_PARAM(payload_len_bits_p))
    (input clk_i
     , input reset_i
     , input fifo_v_i
@@ -41,3 +41,5 @@ module bsg_wormhole_router_input_control #(parameter output_dirs_p=-1, parameter
    assign detected_header_o = fifo_has_hdr;
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_wormhole_router_input_control)

--- a/hard/ultrascale_plus/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.v
+++ b/hard/ultrascale_plus/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.v
@@ -13,6 +13,7 @@
 *
 */
 
+`include "bsg_defines.v"
 
 module bsg_mem_1rw_sync_mask_write_bit #(
   parameter width_p = "inv"

--- a/testing/bsg_cache/axe_test/testbench.v
+++ b/testing/bsg_cache/axe_test/testbench.v
@@ -3,6 +3,8 @@
  *
  */
 
+`include "bsg_cache.vh"
+
 module testbench();
   import bsg_cache_pkg::*;
 

--- a/testing/bsg_cache/common/bsg_nonsynth_dma_model.v
+++ b/testing/bsg_cache/common/bsg_nonsynth_dma_model.v
@@ -3,6 +3,7 @@
  *
  */
 
+`include "bsg_cache.vh"
 
 module bsg_nonsynth_dma_model
   import bsg_cache_pkg::*;

--- a/testing/bsg_cache/dmc/bsg_test_master.v
+++ b/testing/bsg_cache/dmc/bsg_test_master.v
@@ -1,3 +1,5 @@
+`include "bsg_cache.vh"
+
 module bsg_test_master
   import bsg_cache_pkg::*;
   #(parameter num_cache_p="inv"

--- a/testing/bsg_cache/lock_test/testbench.v
+++ b/testing/bsg_cache/lock_test/testbench.v
@@ -1,3 +1,5 @@
+`include "bsg_cache.vh"
+
 module testbench();
 
   import bsg_cache_pkg::*;

--- a/testing/bsg_cache/regression_v2/testbench.v
+++ b/testing/bsg_cache/regression_v2/testbench.v
@@ -1,3 +1,5 @@
+`include "bsg_cache.vh"
+
 module testbench();
 
   import bsg_cache_pkg::*;

--- a/testing/bsg_test/dramsim3_bandwidth2/testbench.v
+++ b/testing/bsg_test/dramsim3_bandwidth2/testbench.v
@@ -1,5 +1,6 @@
 `include "bsg_nonsynth_dramsim3.svh"
 
+`include "bsg_cache.vh"
 
 `define dram_pkg bsg_dramsim3_hbm2_4gb_x128_pkg
 


### PR DESCRIPTION
Probably should wait until after the tapeout before merging this. Various tools (i.e. Vivado) end up doing a lot of extra computation when parsing our verilog because it interprets "inv" and -1 as very large numbers that allocate large amounts of memory, so we use the spiffy new macros for doing abstract modules "the right way."   On BP, Vivado requires around 20 GB of memory and 18 minutes to chew through the files because of these kinds of issues.

This also factors the defines for bsg_cache into a separate include file.