### PR TITLE
Adding pinmissing lint exception for BSG_ABSTRACT_MODULE

### DIFF
--- a/bsg_misc/bsg_defines.v
+++ b/bsg_misc/bsg_defines.v
@@ -18,7 +18,10 @@
 //    module name. Such an instance is called a top-level instance."
 //  
 
-`define BSG_ABSTRACT_MODULE(fn) module fn``__abstract(); if (0) fn not_used(); endmodule
+`define BSG_ABSTRACT_MODULE(fn) \
+    /*verilator lint_off PINMISSING*/ \
+    module fn``__abstract(); if (0) fn not_used(); endmodule \
+    /*verilator lint_on PINMISSING*/
 
 // macro for defining invalid parameter; with the abstract module declaration
 // it should be sufficient to omit the "inv" but we include this for tool portability


### PR DESCRIPTION
This + https://github.com/verilator/verilator/pull/3026 fixes #446 and allows verilator to work with BSG_ABSTRACT_MODULE construct