### PR TITLE
Fifo 1r1w small hardened bug fix

### DIFF
--- a/testing/bsg_dataflow/bsg_fifo_1r1w_small_hardened/Makefile
+++ b/testing/bsg_dataflow/bsg_fifo_1r1w_small_hardened/Makefile
@@ -9,12 +9,12 @@ export BASEJUMP_STL_DIR = ../../..
 include $(BSG_CADENV_DIR)/cadenv.mk
 
 run:
-	$(VCS_BIN)/vcs -full64 -sverilog -timescale=1ps/1ps -f ./filelist -debug_pp -R -top bsg_fifo_1r1w_small_hardened_tester +vcs+vcdpluson
+	$(VCS_BIN)/vcs -full64 -sverilog -timescale=1ps/1ps -f ./filelist -debug_pp -R -top bsg_fifo_1r1w_small_hardened_tester +vcs+vcdpluson -assert svaext
     
 view:
 	$(VCS_BIN)/dve -full64 -vpd vcdplus.vpd &
 
-junk = csrc DVEfiles simv.daidir *.old *.vpd simv *.key
+junk = csrc DVEfiles simv.daidir *.old *.vpd simv *.key vc_hdrs.h
 
 clean:
 	rm -rf $(junk)

--- a/testing/bsg_dataflow/bsg_fifo_1r1w_small_hardened/Makefile
+++ b/testing/bsg_dataflow/bsg_fifo_1r1w_small_hardened/Makefile
@@ -1,20 +1,42 @@
 
 # Workspace directory
-dir = ../../../..
-
-export BSG_CADENV_DIR = $(dir)/bsg_cadenv
-export BASEJUMP_STL_DIR = ../../..
+export TOP_DIR = $(abspath .)
+export BSG_CADENV_DIR = $(TOP_DIR)/../../../../bsg_cadenv
+export BASEJUMP_STL_DIR = $(TOP_DIR)/../../..
 
 # Environment
 include $(BSG_CADENV_DIR)/cadenv.mk
 
-run:
-	$(VCS_BIN)/vcs -full64 -sverilog -timescale=1ps/1ps -f ./filelist -debug_pp -R -top bsg_fifo_1r1w_small_hardened_tester +vcs+vcdpluson -assert svaext
-    
-view:
-	$(VCS_BIN)/dve -full64 -vpd vcdplus.vpd &
+PERIODS := 2 3 5 7 11
+CLK_SPEEDS := $(foreach MASTER, $(PERIODS), \
+                  $(foreach FIFO, $(PERIODS), \
+                      $(foreach CLIENT, $(PERIODS), \
+                          $(MASTER)-$(FIFO)-$(CLIENT))))
 
-junk = csrc DVEfiles simv.daidir *.old *.vpd simv *.key vc_hdrs.h
+RUNS := $(foreach CLK_SPEED_P, $(CLK_SPEEDS), \
+            run-$(CLK_SPEED_P))
+
+run: $(RUNS)
+run-%:
+	mkdir run-$*;
+	cd run-$* && \
+        $(VCS_BIN)/vcs -full64 -sverilog -timescale=1ps/1ps -f $(TOP_DIR)/filelist -debug_pp -R -top bsg_fifo_1r1w_small_hardened_tester +vcs+vcdpluson -assert svaext +vcs+lic+wait \
+        -pvalue+top_master_clk_period_p=$(word 1, $(subst -, ,$*)) \
+        -pvalue+top_piso_clk_period_p=$(word 2, $(subst -, ,$*)) \
+        -pvalue+top_client_clk_period_p=$(word 3, $(subst -, ,$*)) \
+        > run-$*.log
+
+view-%:
+	cd run-$* && \
+        $(VCS_BIN)/dve -full64 -vpd vcdplus.vpd &
+
+check:
+	@echo 'Number of tests passed:'
+	@grep -r PASS */*.log | wc -l
+	@echo 'Number of tests failed:'
+	@grep -r FAIL */*.log | wc -l
+
+junk = csrc DVEfiles simv.daidir *.old *.vpd simv *.key vc_hdrs.h run-*
 
 clean:
 	rm -rf $(junk)

--- a/testing/bsg_dataflow/bsg_fifo_1r1w_small_hardened/README
+++ b/testing/bsg_dataflow/bsg_fifo_1r1w_small_hardened/README
@@ -2,8 +2,8 @@ First time run of test
 
 $ cd basejump_stl/testing/bsg_dataflow/bsg_fifo_1r1w_small_hardened
 $ git clone https://bitbucket.org/taylor-bsg/bsg_cadenv.git ../../../../bsg_cadenv
-$ make run
-$ make view
+$ make -j125
+$ make check
 
 
 Clean generated files

--- a/testing/bsg_dataflow/bsg_fifo_1r1w_small_hardened/bsg_fifo_1r1w_small_hardened_test_node.v
+++ b/testing/bsg_dataflow/bsg_fifo_1r1w_small_hardened/bsg_fifo_1r1w_small_hardened_test_node.v
@@ -144,7 +144,7 @@ module bsg_fifo_1r1w_small_hardened_test_node
         if (node_reset_i)
             error_o <= 0;
         else
-            if (resp_in_v && data_check != resp_in_data)
+            if (resp_in_v && data_check !== resp_in_data)
               begin
                 $error("%m mismatched resp data %x %x",data_check, resp_in_data);
                 error_o <= 1;

--- a/testing/bsg_dataflow/bsg_fifo_1r1w_small_hardened/bsg_fifo_1r1w_small_hardened_tester.v
+++ b/testing/bsg_dataflow/bsg_fifo_1r1w_small_hardened/bsg_fifo_1r1w_small_hardened_tester.v
@@ -109,7 +109,7 @@ module bsg_fifo_1r1w_small_hardened_tester
   // Simulation of Clock
   always #4 master_clk = ~master_clk;
   always #4 fifo_clk   = ~fifo_clk;
-  always #4 client_clk = ~client_clk;
+  always #16 client_clk = ~client_clk;
   
   
   initial 

--- a/testing/bsg_dataflow/bsg_fifo_1r1w_small_hardened/bsg_fifo_1r1w_small_hardened_tester.v
+++ b/testing/bsg_dataflow/bsg_fifo_1r1w_small_hardened/bsg_fifo_1r1w_small_hardened_tester.v
@@ -11,7 +11,12 @@
 module bsg_fifo_1r1w_small_hardened_tester
 
  #(
-   parameter width_p  = 64
+   // dynamic parameters
+   parameter top_master_clk_period_p     = 5
+  ,parameter top_fifo_clk_period_p       = 5
+  ,parameter top_client_clk_period_p     = 5
+   // static parameters
+  ,parameter width_p  = 64
   ,parameter els_p    = 16
   ,parameter channel_width_p = 8
   )
@@ -107,9 +112,9 @@ module bsg_fifo_1r1w_small_hardened_tester
   
   
   // Simulation of Clock
-  always #4 master_clk = ~master_clk;
-  always #4 fifo_clk   = ~fifo_clk;
-  always #16 client_clk = ~client_clk;
+  always #(top_master_clk_period_p) master_clk = ~master_clk;
+  always #(top_fifo_clk_period_p)   fifo_clk   = ~fifo_clk;
+  always #(top_client_clk_period_p) client_clk = ~client_clk;
   
   
   initial 

--- a/testing/bsg_dataflow/bsg_fifo_1r1w_small_hardened/filelist
+++ b/testing/bsg_dataflow/bsg_fifo_1r1w_small_hardened/filelist
@@ -69,7 +69,7 @@ $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router.v
 $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_concentrator.v
 $BASEJUMP_STL_DIR/bsg_fsb/bsg_fsb_pkg.v
 
-./bsg_fifo_1r1w_small_hardened_tester.v
-./bsg_fifo_1r1w_small_hardened_test_node.v
+$TOP_DIR/bsg_fifo_1r1w_small_hardened_tester.v
+$TOP_DIR/bsg_fifo_1r1w_small_hardened_test_node.v
 
 


### PR DESCRIPTION
This PR fixes the bug that data_o turns X when fifo is full.
Comments and README are updated.
Testbench is updated to cover all possible combination of clock speeds to catch the bug.

To run regression:
$ cd basejump_stl/testing/bsg_dataflow/bsg_fifo_1r1w_small_hardened
$ git clone https://bitbucket.org/taylor-bsg/bsg_cadenv.git ../../../../bsg_cadenv
$ make -j125
$ make check

All 125 tests should pass. With buggy fifo_1r1w_fifo_small there should be 20 failed tests.