### PR TITLE
fixes syntax error

### DIFF
--- a/bsg_test/bsg_nonsynth_dpi_gpio.v
+++ b/bsg_test/bsg_nonsynth_dpi_gpio.v
@@ -22,7 +22,7 @@
 `include "bsg_defines.v"
 
 module bsg_nonsynth_dpi_gpio
-   #(parameter int width_p = 1)
+   #(parameter int width_p = 1
      ,parameter bit [width_p-1:0] init_o_p = '0
      ,parameter bit use_input_p = '0
      ,parameter bit use_output_p = '0


### PR DESCRIPTION
Fixes a syntax error introduced during a refactor of the invalid parameter settings.

I don't have merge perms on this repo, so to whoever approves this, can you please merge it immediately? Thank you. 