### PR TITLE
Adding declfilename waiver to bsg_defines

### DIFF
--- a/bsg_misc/bsg_defines.v
+++ b/bsg_misc/bsg_defines.v
@@ -24,9 +24,11 @@
 //  
 
 `define BSG_ABSTRACT_MODULE(fn) \
+    /*verilator lint_off DECLFILENAME*/ \
     /*verilator lint_off PINMISSING*/ \
     module fn``__abstract(); if (0) fn not_used(); endmodule \
-    /*verilator lint_on PINMISSING*/
+    /*verilator lint_on PINMISSING*/ \
+    /*verilator lint_on DECLFILENAME*/ \
 
 // macro for defining invalid parameter; with the abstract module declaration
 // it should be sufficient to omit the "inv" but we include this for tool portability

--- a/bsg_misc/bsg_defines.v
+++ b/bsg_misc/bsg_defines.v
@@ -28,7 +28,7 @@
     /*verilator lint_off PINMISSING*/ \
     module fn``__abstract(); if (0) fn not_used(); endmodule \
     /*verilator lint_on PINMISSING*/ \
-    /*verilator lint_on DECLFILENAME*/ \
+    /*verilator lint_on DECLFILENAME*/
 
 // macro for defining invalid parameter; with the abstract module declaration
 // it should be sufficient to omit the "inv" but we include this for tool portability


### PR DESCRIPTION
Verilator doesn't like the module name (foobar_abstract) mismatching the file name (foobar.v), this waiver lets it be ignored without disabling the check overall.