### PR TITLE
Changing info in bsg_mesh_router_buffered to assertion

### DIFF
--- a/bsg_noc/bsg_mesh_router_buffered.v
+++ b/bsg_noc/bsg_mesh_router_buffered.v
@@ -72,8 +72,8 @@ module bsg_mesh_router_buffered
 
       // synopsys translate_off
       always @(negedge clk_i)
-        if (link_o_cast[i].v)
-          $display("## warning %m: stubbed port %x received word %x",i,link_i_cast[i].data);
+        assert (~link_o_cast[i].v)
+          $warning("## stubbed port %x received word %x",i,link_i_cast[i].data);
       // synopsys translate_on
     end
     else begin: fi


### PR DESCRIPTION
Assertions are more flexible than displays i.e. they can be disabled and enabled during times of reset, as well as searched for in waveforms.

This is needed to prevent spurious reset errors in Verilator on the Manycore