### PR TITLE
Fixing latch for verilator

### DIFF
--- a/bsg_misc/bsg_dlatch.v
+++ b/bsg_misc/bsg_dlatch.v
@@ -11,11 +11,14 @@ module bsg_dlatch #(parameter `BSG_INV_PARAM(width_p)
   if (i_know_this_is_a_bad_idea_p == 0)
     $fatal( 1, "Error: you must admit this is a bad idea before you are allowed to use the bsg_dlatch module!" );
 
+  logic [width_p-1:0] data_r;
   always_latch
     begin
       if (clk_i)
-        data_o <= data_i;
+        data_r <= data_i;
     end
+
+  assign data_o = data_r;
 
 endmodule
 

--- a/bsg_misc/bsg_latch.v
+++ b/bsg_misc/bsg_latch.v
@@ -16,6 +16,8 @@ module bsg_latch
     if (clk_i)
       data_r <= data_i;
 
+  // Version 4.213 of Verilator doesn't detect latches
+  //   for data_o merged with data_r
   assign data_o = data_r;
   
 endmodule


### PR DESCRIPTION
Verilator 4.213 does not recognize assignments to outputs as a latch. The proposed patch should have no inference change on synthesis