### PR TITLE
Adding memory macros for TSMC 28

### DIFF
--- a/hard/tsmc_28/bsg_mem/bsg_mem_1r1w_sync_macros.vh
+++ b/hard/tsmc_28/bsg_mem/bsg_mem_1r1w_sync_macros.vh
@@ -44,7 +44,7 @@ if (els_p == words && width_p == bits)                          \
              ,.CEBB     ( ~r_v_i        )                       \
              ,.CLKB     ( clk_i         )                       \
              ,.QB       ( r_data_o      )                       \
-                                                                \
+             /* According to TSMC, other settings are for debug only */ \
              ,.WTSEL    ( 2'b01         )                       \
              ,.RTSEL    ( 2'b01         )                       \
              ,.VG       ( 1'b1          )                       \
@@ -71,6 +71,7 @@ if (els_p == words && width_p == bits)                          \
              ,.CLKB     ( clk_i         )                       \
              ,.QB       ( r_data_o      )                       \
                                                                 \
+             /* According to TSMC, other settings are for debug only */ \
              ,.WTSEL    ( 2'b00         )                       \
              ,.RTSEL    ( 2'b00         )                       \
              ,.PTSEL    ( 2'b00         )                       \

--- a/hard/tsmc_28/bsg_mem/bsg_mem_1r1w_sync_macros.vh
+++ b/hard/tsmc_28/bsg_mem/bsg_mem_1r1w_sync_macros.vh
@@ -10,9 +10,9 @@
 //
 
 `define bsg_mem_1r1w_sync_2rf_macro(words,bits,tag) \
-if (els_p == words && width_p == bits)                          \
+if (harden_p && els_p == words && width_p == bits)              \
   begin: macro                                                  \
-          tsmc28_1r1w_d``words``_w``bits``_``tag``_2rf mem \
+          tsmc28_1r1w_d``words``_w``bits``_``tag``_2rf mem      \
             (                                                   \
               .AA       ( w_addr_i      )                       \
              ,.D        ( w_data_i      )                       \
@@ -27,9 +27,9 @@ if (els_p == words && width_p == bits)                          \
   end
 
 `define bsg_mem_1r1w_sync_2sram_macro(words,bits,tag) \
-if (els_p == words && width_p == bits)                          \
+if (harden_p && els_p == words && width_p == bits)              \
   begin: macro                                                  \
-          tsmc28_2rw_d``words``_w``bits``_``tag``_2sram mem \
+          tsmc28_2rw_d``words``_w``bits``_``tag``_2sram mem     \
             (                                                   \
               .AA       ( w_addr_i      )                       \
              ,.DA       ( w_data_i      )                       \
@@ -54,9 +54,9 @@ if (els_p == words && width_p == bits)                          \
   end
 
 `define bsg_mem_1r1w_sync_2hdsram_macro(words,bits,tag) \
-if (els_p == words && width_p == bits)                          \
+if (harden_p && els_p == words && width_p == bits)              \
   begin: macro                                                  \
-          tsmc28_2rw_d``words``_w``bits``_``tag``_2hdsram mem  \
+          tsmc28_2rw_d``words``_w``bits``_``tag``_2hdsram mem   \
             (                                                   \
               .AA       ( w_addr_i      )                       \
              ,.DA       ( w_data_i      )                       \

--- a/hard/tsmc_28/bsg_mem/bsg_mem_1r1w_sync_macros.vh
+++ b/hard/tsmc_28/bsg_mem/bsg_mem_1r1w_sync_macros.vh
@@ -78,4 +78,24 @@ if (harden_p && els_p == words && width_p == bits)              \
             );                                                  \
   end
 
+`define bsg_mem_1r1w_sync_banked_macro(words,bits,wbank,dbank) \
+  if (harden_p && els_p == words && width_p == bits) begin: macro \
+    bsg_mem_1r1w_sync_banked #(                                             \
+      .width_p(width_p)                                                     \
+      ,.els_p(els_p)                                                        \
+      ,.read_write_same_addr_p(read_write_same_addr_p)                      \
+      ,.num_width_bank_p(wbank)                                             \
+      ,.num_depth_bank_p(dbank)                                             \
+    ) bmem (                                                                \
+      .clk_i(clk_i)                                                         \
+      ,.reset_i(reset_i)                                                    \
+      ,.w_v_i(w_v_i)                                                        \
+      ,.w_addr_i(w_addr_i)                                                  \
+      ,.w_data_i(w_data_i)                                                  \
+      ,.r_v_i(r_v_i)                                                        \
+      ,.r_addr_i(r_addr_i)                                                  \
+      ,.r_data_o(r_data_o)                                                  \
+    );                                                                      \
+  end: macro
+
 `endif

--- a/hard/tsmc_28/bsg_mem/bsg_mem_1r1w_sync_macros.vh
+++ b/hard/tsmc_28/bsg_mem/bsg_mem_1r1w_sync_macros.vh
@@ -39,8 +39,8 @@ if (harden_p && els_p == words && width_p == bits)              \
              ,.QA       (               )                       \
                                                                 \
              ,.AB       ( r_addr_i      )                       \
-             ,.DB       ( '1            )                       \
-             ,.WEBB     ( '1            )                       \
+             ,.DB       ( {bits{1'b1}}  )                       \
+             ,.WEBB     ( 1'b1          )                       \
              ,.CEBB     ( ~r_v_i        )                       \
              ,.CLKB     ( clk_i         )                       \
              ,.QB       ( r_data_o      )                       \
@@ -66,8 +66,8 @@ if (harden_p && els_p == words && width_p == bits)              \
              ,.QA       (               )                       \
                                                                 \
              ,.AB       ( r_addr_i      )                       \
-             ,.DB       ( '1            )                       \
-             ,.WEBB     ( '1            )                       \
+             ,.DB       ( {bits{1'b1}}  )                       \
+             ,.WEBB     ( 1'b1          )                       \
              ,.CEBB     ( ~r_v_i        )                       \
              ,.QB       ( r_data_o      )                       \
                                                                 \

--- a/hard/tsmc_28/bsg_mem/bsg_mem_1r1w_sync_macros.vh
+++ b/hard/tsmc_28/bsg_mem/bsg_mem_1r1w_sync_macros.vh
@@ -44,6 +44,7 @@ if (els_p == words && width_p == bits)                          \
              ,.CEBB     ( ~r_v_i        )                       \
              ,.CLKB     ( clk_i         )                       \
              ,.QB       ( r_data_o      )                       \
+                                                                \
              /* According to TSMC, other settings are for debug only */ \
              ,.WTSEL    ( 2'b01         )                       \
              ,.RTSEL    ( 2'b01         )                       \
@@ -61,14 +62,13 @@ if (els_p == words && width_p == bits)                          \
              ,.DA       ( w_data_i      )                       \
              ,.WEBA     ( ~w_v_i        )                       \
              ,.CEBA     ( ~w_v_i        )                       \
-             ,.CLKA     ( clk_i         )                       \
+             ,.CLK      ( clk_i         )                       \
              ,.QA       (               )                       \
                                                                 \
              ,.AB       ( r_addr_i      )                       \
              ,.DB       ( '1            )                       \
              ,.WEBB     ( '1            )                       \
              ,.CEBB     ( ~r_v_i        )                       \
-             ,.CLKB     ( clk_i         )                       \
              ,.QB       ( r_data_o      )                       \
                                                                 \
              /* According to TSMC, other settings are for debug only */ \

--- a/hard/tsmc_28/bsg_mem/bsg_mem_1r1w_sync_macros.vh
+++ b/hard/tsmc_28/bsg_mem/bsg_mem_1r1w_sync_macros.vh
@@ -1,0 +1,80 @@
+`ifndef BSG_MEM_1R1W_SYNC_MACROS_VH
+`define BSG_MEM_1R1W_SYNC_MACROS_VH
+
+//
+// Synchronous 2-port ram.
+//
+// When read and write with the same address, the behavior depends on which
+// clock arrives first, and the read/write clock MUST be separated at least
+// twrcc, otherwise will incur indeterminate result. 
+//
+
+`define bsg_mem_1r1w_sync_2rf_macro(words,bits,tag) \
+if (els_p == words && width_p == bits)                          \
+  begin: macro                                                  \
+          tsmc28_1r1w_d``words``_w``bits``_``tag``_2rf mem \
+            (                                                   \
+              .AA       ( w_addr_i      )                       \
+             ,.D        ( w_data_i      )                       \
+             ,.WEB      ( ~w_v_i        )                       \
+             ,.CLKW     ( clk_i         )                       \
+                                                                \
+             ,.AB       ( r_addr_i      )                       \
+             ,.REB      ( ~r_v_i        )                       \
+             ,.CLKR     ( clk_i         )                       \
+             ,.Q        ( r_data_o      )                       \
+            );                                                  \
+  end
+
+`define bsg_mem_1r1w_sync_mask_write_2sram_macro(words,bits,tag) \
+if (els_p == words && width_p == bits)                          \
+  begin: macro                                                  \
+          tsmc28_2rw_d``words``_w``bits``_``tag``_2sram mem \
+            (                                                   \
+              .AA       ( w_addr_i      )                       \
+             ,.DA       ( w_data_i      )                       \
+             ,.WEBA     ( ~w_v_i        )                       \
+             ,.CEBA     ( ~w_v_i        )                       \
+             ,.CLKA     ( clk_i         )                       \
+             ,.QA       (               )                       \
+                                                                \
+             ,.AB       ( r_addr_i      )                       \
+             ,.DB       ( '1            )                       \
+             ,.WEBB     ( '1            )                       \
+             ,.CEBB     ( ~r_v_i        )                       \
+             ,.CLKB     ( clk_i         )                       \
+             ,.QB       ( r_data_o      )                       \
+                                                                \
+             ,.WTSEL    ( 2'b01         )                       \
+             ,.RTSEL    ( 2'b01         )                       \
+             ,.VG       ( 1'b1          )                       \
+             ,.VS       ( 1'b1          )                       \
+            );                                                  \
+  end
+
+`define bsg_mem_1r1w_sync_mask_write_2hdsram_macro(words,bits,tag) \
+if (els_p == words && width_p == bits)                          \
+  begin: macro                                                  \
+          tsmc28_2rw_d``words``_w``bits``_``tag``_2hdsram mem  \
+            (                                                   \
+              .AA       ( w_addr_i      )                       \
+             ,.DA       ( w_data_i      )                       \
+             ,.WEBA     ( ~w_v_i        )                       \
+             ,.CEBA     ( ~w_v_i        )                       \
+             ,.CLKA     ( clk_i         )                       \
+             ,.QA       (               )                       \
+                                                                \
+             ,.AB       ( r_addr_i      )                       \
+             ,.DB       ( '1            )                       \
+             ,.WEBB     ( '1            )                       \
+             ,.CEBB     ( ~r_v_i        )                       \
+             ,.CLKB     ( clk_i         )                       \
+             ,.QB       ( r_data_o      )                       \
+                                                                \
+             ,.WTSEL    ( 2'b00         )                       \
+             ,.RTSEL    ( 2'b00         )                       \
+             ,.PTSEL    ( 2'b00         )                       \
+            );                                                  \
+  end
+
+`endif

--- a/hard/tsmc_28/bsg_mem/bsg_mem_1r1w_sync_macros.vh
+++ b/hard/tsmc_28/bsg_mem/bsg_mem_1r1w_sync_macros.vh
@@ -26,7 +26,7 @@ if (els_p == words && width_p == bits)                          \
             );                                                  \
   end
 
-`define bsg_mem_1r1w_sync_mask_write_2sram_macro(words,bits,tag) \
+`define bsg_mem_1r1w_sync_2sram_macro(words,bits,tag) \
 if (els_p == words && width_p == bits)                          \
   begin: macro                                                  \
           tsmc28_2rw_d``words``_w``bits``_``tag``_2sram mem \
@@ -52,7 +52,7 @@ if (els_p == words && width_p == bits)                          \
             );                                                  \
   end
 
-`define bsg_mem_1r1w_sync_mask_write_2hdsram_macro(words,bits,tag) \
+`define bsg_mem_1r1w_sync_2hdsram_macro(words,bits,tag) \
 if (els_p == words && width_p == bits)                          \
   begin: macro                                                  \
           tsmc28_2rw_d``words``_w``bits``_``tag``_2hdsram mem  \

--- a/hard/tsmc_28/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit_macros.vh
+++ b/hard/tsmc_28/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit_macros.vh
@@ -1,7 +1,7 @@
 `ifndef BSG_MEM_1R1W_SYNC_MASK_WRITE_BIT_MACROS_VH
 `define BSG_MEM_1R1W_SYNC_MASK_WRITE_BIT_MACROS_VH
 
-`define bsg_mem_1r1w_sync_mask_write_2rf_bit_macro(words,bits,tag) \
+`define bsg_mem_1r1w_sync_mask_write_bit_2rf_macro(words,bits,tag) \
 if (els_p == words && width_p == bits)                          \
   begin: macro                                                  \
           tsmc28_1r1w_d``words``_w``bits``_``tag``_bit_2rf mem \
@@ -19,7 +19,7 @@ if (els_p == words && width_p == bits)                          \
             );                                                  \
   end
 
-`define bsg_mem_1r1w_sync_mask_write_2sram_bit_macro(words,bits,tag) \
+`define bsg_mem_1r1w_sync_mask_write_bit_2sram_macro(words,bits,tag) \
 if (els_p == words && width_p == bits)                          \
   begin: macro                                                  \
           tsmc28_2rw_d``words``_w``bits``_``tag``_bit_2sram mem \
@@ -48,7 +48,7 @@ if (els_p == words && width_p == bits)                          \
             );                                                  \
   end
 
-`define bsg_mem_1r1w_sync_mask_write_2hdsram_bit_macro(words,bits,tag) \
+`define bsg_mem_1r1w_sync_mask_write_bit_2hdsram_macro(words,bits,tag) \
 if (els_p == words && width_p == bits)                          \
   begin: macro                                                  \
           tsmc28_2rw_d``words``_w``bits``_``tag``_bit_2hdsram mem \

--- a/hard/tsmc_28/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit_macros.vh
+++ b/hard/tsmc_28/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit_macros.vh
@@ -58,7 +58,7 @@ if (els_p == words && width_p == bits)                          \
              ,.BWEBA    ( ~w_mask_i     )                       \
              ,.WEBA     ( ~w_v_i        )                       \
              ,.CEBA     ( ~w_v_i        )                       \
-             ,.CLKA     ( clk_i         )                       \
+             ,.CLK      ( clk_i         )                       \
              ,.QA       (               )                       \
                                                                 \
              ,.AB       ( r_addr_i      )                       \
@@ -66,7 +66,6 @@ if (els_p == words && width_p == bits)                          \
              ,.BWEBB    ( '1            )                       \
              ,.WEBB     ( '1            )                       \
              ,.CEBB     ( ~r_v_i        )                       \
-             ,.CLKB     ( clk_i         )                       \
              ,.QB       ( r_data_o      )                       \
                                                                 \
              /* According to TSMC, other settings are for debug only */ \

--- a/hard/tsmc_28/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit_macros.vh
+++ b/hard/tsmc_28/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit_macros.vh
@@ -1,0 +1,77 @@
+`ifndef BSG_MEM_1R1W_SYNC_MASK_WRITE_BIT_MACROS_VH
+`define BSG_MEM_1R1W_SYNC_MASK_WRITE_BIT_MACROS_VH
+
+`define bsg_mem_1r1w_sync_mask_write_2rf_bit_macro(words,bits,tag) \
+if (els_p == words && width_p == bits)                          \
+  begin: macro                                                  \
+          tsmc28_1r1w_d``words``_w``bits``_``tag``_bit_2rf mem \
+            (                                                   \
+              .AA       ( w_addr_i      )                       \
+             ,.D        ( w_data_i      )                       \
+             ,.WEB      ( ~w_v_i        )                       \
+             ,.BWEB     ( ~w_mask_i     )                       \
+             ,.CLKW     ( clk_i         )                       \
+                                                                \
+             ,.AB       ( r_addr_i      )                       \
+             ,.REB      ( ~r_v_i        )                       \
+             ,.CLKR     ( clk_i         )                       \
+             ,.Q        ( r_data_o      )                       \
+            );                                                  \
+  end
+
+`define bsg_mem_1r1w_sync_mask_write_2sram_bit_macro(words,bits,tag) \
+if (els_p == words && width_p == bits)                          \
+  begin: macro                                                  \
+          tsmc28_2rw_d``words``_w``bits``_``tag``_bit_2sram mem \
+            (                                                   \
+              .AA       ( w_addr_i      )                       \
+             ,.DA       ( w_data_i      )                       \
+             ,.BWEBA    ( ~w_mask_i     )                       \
+             ,.WEBA     ( ~w_v_i        )                       \
+             ,.CEBA     ( ~w_v_i        )                       \
+             ,.CLKA     ( clk_i         )                       \
+             ,.QA       (               )                       \
+                                                                \
+             ,.AB       ( r_addr_i      )                       \
+             ,.DB       ( '1            )                       \
+             ,.BWEBB    ( '1            )                       \
+             ,.WEBB     ( '1            )                       \
+             ,.CEBB     ( ~r_v_i        )                       \
+             ,.CLKB     ( clk_i         )                       \
+             ,.QB       ( r_data_o      )                       \
+                                                                \
+             ,.WTSEL    ( 2'b01         )                       \
+             ,.RTSEL    ( 2'b01         )                       \
+             ,.VG       ( 1'b1          )                       \
+             ,.VS       ( 1'b1          )                       \
+            );                                                  \
+  end
+
+`define bsg_mem_1r1w_sync_mask_write_2hdsram_bit_macro(words,bits,tag) \
+if (els_p == words && width_p == bits)                          \
+  begin: macro                                                  \
+          tsmc28_2rw_d``words``_w``bits``_``tag``_bit_2hdsram mem \
+            (                                                   \
+              .AA       ( w_addr_i      )                       \
+             ,.DA       ( w_data_i      )                       \
+             ,.BWEBA    ( ~w_mask_i     )                       \
+             ,.WEBA     ( ~w_v_i        )                       \
+             ,.CEBA     ( ~w_v_i        )                       \
+             ,.CLKA     ( clk_i         )                       \
+             ,.QA       (               )                       \
+                                                                \
+             ,.AB       ( r_addr_i      )                       \
+             ,.DB       ( '1            )                       \
+             ,.BWEBB    ( '1            )                       \
+             ,.WEBB     ( '1            )                       \
+             ,.CEBB     ( ~r_v_i        )                       \
+             ,.CLKB     ( clk_i         )                       \
+             ,.QB       ( r_data_o      )                       \
+                                                                \
+             ,.WTSEL    ( 2'b00         )                       \
+             ,.RTSEL    ( 2'b00         )                       \
+             ,.PTSEL    ( 2'b00         )                       \
+            );                                                  \
+  end
+
+`endif 

--- a/hard/tsmc_28/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit_macros.vh
+++ b/hard/tsmc_28/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit_macros.vh
@@ -33,9 +33,9 @@ if (harden_p && els_p == words && width_p == bits)              \
              ,.QA       (               )                       \
                                                                 \
              ,.AB       ( r_addr_i      )                       \
-             ,.DB       ( '1            )                       \
-             ,.BWEBB    ( '1            )                       \
-             ,.WEBB     ( '1            )                       \
+             ,.DB       ( {bits{1'b1}}  )                       \
+             ,.BWEBB    ( {bits{1'b1}}  )                       \
+             ,.WEBB     ( 1'b1          )                       \
              ,.CEBB     ( ~r_v_i        )                       \
              ,.CLKB     ( clk_i         )                       \
              ,.QB       ( r_data_o      )                       \
@@ -62,9 +62,9 @@ if (harden_p && els_p == words && width_p == bits)              \
              ,.QA       (               )                       \
                                                                 \
              ,.AB       ( r_addr_i      )                       \
-             ,.DB       ( '1            )                       \
-             ,.BWEBB    ( '1            )                       \
-             ,.WEBB     ( '1            )                       \
+             ,.DB       ( {bits{1'b1}}  )                       \
+             ,.BWEBB    ( {bits{1'b1}}  )                       \
+             ,.WEBB     ( 1'b1          )                       \
              ,.CEBB     ( ~r_v_i        )                       \
              ,.QB       ( r_data_o      )                       \
                                                                 \

--- a/hard/tsmc_28/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit_macros.vh
+++ b/hard/tsmc_28/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit_macros.vh
@@ -40,6 +40,7 @@ if (els_p == words && width_p == bits)                          \
              ,.CLKB     ( clk_i         )                       \
              ,.QB       ( r_data_o      )                       \
                                                                 \
+             /* According to TSMC, other settings are for debug only */ \
              ,.WTSEL    ( 2'b01         )                       \
              ,.RTSEL    ( 2'b01         )                       \
              ,.VG       ( 1'b1          )                       \
@@ -68,6 +69,7 @@ if (els_p == words && width_p == bits)                          \
              ,.CLKB     ( clk_i         )                       \
              ,.QB       ( r_data_o      )                       \
                                                                 \
+             /* According to TSMC, other settings are for debug only */ \
              ,.WTSEL    ( 2'b00         )                       \
              ,.RTSEL    ( 2'b00         )                       \
              ,.PTSEL    ( 2'b00         )                       \

--- a/hard/tsmc_28/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit_macros.vh
+++ b/hard/tsmc_28/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit_macros.vh
@@ -2,9 +2,9 @@
 `define BSG_MEM_1R1W_SYNC_MASK_WRITE_BIT_MACROS_VH
 
 `define bsg_mem_1r1w_sync_mask_write_bit_2rf_macro(words,bits,tag) \
-if (els_p == words && width_p == bits)                          \
+if (harden_p && els_p == words && width_p == bits)              \
   begin: macro                                                  \
-          tsmc28_1r1w_d``words``_w``bits``_``tag``_bit_2rf mem \
+          tsmc28_1r1w_d``words``_w``bits``_``tag``_bit_2rf mem  \
             (                                                   \
               .AA       ( w_addr_i      )                       \
              ,.D        ( w_data_i      )                       \
@@ -20,7 +20,7 @@ if (els_p == words && width_p == bits)                          \
   end
 
 `define bsg_mem_1r1w_sync_mask_write_bit_2sram_macro(words,bits,tag) \
-if (els_p == words && width_p == bits)                          \
+if (harden_p && els_p == words && width_p == bits)              \
   begin: macro                                                  \
           tsmc28_2rw_d``words``_w``bits``_``tag``_bit_2sram mem \
             (                                                   \
@@ -49,7 +49,7 @@ if (els_p == words && width_p == bits)                          \
   end
 
 `define bsg_mem_1r1w_sync_mask_write_bit_2hdsram_macro(words,bits,tag) \
-if (els_p == words && width_p == bits)                          \
+if (harden_p && els_p == words && width_p == bits)              \
   begin: macro                                                  \
           tsmc28_2rw_d``words``_w``bits``_``tag``_bit_2hdsram mem \
             (                                                   \

--- a/hard/tsmc_28/bsg_mem/bsg_mem_1r1w_sync_mask_write_byte_macros.vh
+++ b/hard/tsmc_28/bsg_mem/bsg_mem_1r1w_sync_mask_write_byte_macros.vh
@@ -1,0 +1,36 @@
+`ifndef BSG_MEM_1R1W_SYNC_MASK_WRITE_BYTE_MACROS_VH
+`define BSG_MEM_1R1W_SYNC_MASK_WRITE_BYTE_MACROS_VH
+
+//
+// Synchronous 2-port ram.
+//
+// When read and write with the same address, the behavior depends on which
+// clock arrives first, and the read/write clock MUST be separated at least
+// twrcc, otherwise will incur indeterminate result. 
+//
+
+`define bsg_mem_1r1w_sync_mask_write_2rf_byte_macro(words,bits,tag) \
+  `bsg_mem_1r1w_sync_mask_write_byte_macro(words,bits)
+`define bsg_mem_1r1w_sync_mask_write_2sram_byte_macro(words,bits,tag) \
+  `bsg_mem_1r1w_sync_mask_write_byte_macro(words,bits)
+`define bsg_mem_1r1w_sync_mask_write_2hdsram_byte_macro(words,bits,tag) \
+  `bsg_mem_1r1w_sync_mask_write_byte_macro(words,bits)
+
+`define bsg_mem_1r1w_sync_mask_write_byte_macro(words,bits) \
+if (els_p == words && width_p == bits)                          \
+  begin: wrap                                                   \
+    logic [width_p-1:0] w_mask_li;                              \
+    bsg_expand_bitmask                                          \
+     #(.in_width_p(write_mask_width_lp), .expand_p(8))          \
+     wmask_expand                                               \
+      (.i(w_mask_i)                                             \
+       ,.o(w_mask_li)                                           \
+       );                                                       \
+                                                                \
+    bsg_mem_1r1w_sync_mask_write_bit                            \
+     #(.width_p(width_p), .els_p(els_p))                        \
+     bit_mem                                                    \
+      (.w_mask_i(w_mask_li), .*);                               \
+  end
+
+`endif 

--- a/hard/tsmc_28/bsg_mem/bsg_mem_1r1w_sync_mask_write_byte_macros.vh
+++ b/hard/tsmc_28/bsg_mem/bsg_mem_1r1w_sync_mask_write_byte_macros.vh
@@ -17,7 +17,7 @@
   `bsg_mem_1r1w_sync_mask_write_byte_macro(words,bits)
 
 `define bsg_mem_1r1w_sync_mask_write_byte_macro(words,bits) \
-if (els_p == words && width_p == bits)                          \
+if (harden_p && els_p == words && width_p == bits)              \
   begin: wrap                                                   \
     logic [width_p-1:0] w_mask_li;                              \
     bsg_expand_bitmask                                          \

--- a/hard/tsmc_28/bsg_mem/bsg_mem_1r1w_sync_mask_write_byte_macros.vh
+++ b/hard/tsmc_28/bsg_mem/bsg_mem_1r1w_sync_mask_write_byte_macros.vh
@@ -9,11 +9,11 @@
 // twrcc, otherwise will incur indeterminate result. 
 //
 
-`define bsg_mem_1r1w_sync_mask_write_2rf_byte_macro(words,bits,tag) \
+`define bsg_mem_1r1w_sync_mask_write_byte_2rf_macro(words,bits,tag) \
   `bsg_mem_1r1w_sync_mask_write_byte_macro(words,bits)
-`define bsg_mem_1r1w_sync_mask_write_2sram_byte_macro(words,bits,tag) \
+`define bsg_mem_1r1w_sync_mask_write_byte_2sram_macro(words,bits,tag) \
   `bsg_mem_1r1w_sync_mask_write_byte_macro(words,bits)
-`define bsg_mem_1r1w_sync_mask_write_2hdsram_byte_macro(words,bits,tag) \
+`define bsg_mem_1r1w_sync_mask_write_byte_2hdsram_macro(words,bits,tag) \
   `bsg_mem_1r1w_sync_mask_write_byte_macro(words,bits)
 
 `define bsg_mem_1r1w_sync_mask_write_byte_macro(words,bits) \

--- a/hard/tsmc_28/bsg_mem/bsg_mem_1rw_sync_macros.vh
+++ b/hard/tsmc_28/bsg_mem/bsg_mem_1rw_sync_macros.vh
@@ -1,0 +1,67 @@
+`ifndef BSG_MEM_1RW_SYNC_MACROS_VH
+`define BSG_MEM_1RW_SYNC_MACROS_VH
+
+`define bsg_mem_1rw_sync_1rf_macro(words,bits,tag)       \
+  if (harden_p && els_p == words && width_p == bits) \
+    begin: macro                                     \
+          tsmc28_1rw_d``words``_w``bits``_``tag``_1rf mem  \
+            (                                                   \
+              .CLK      ( clk_i         )                       \
+             ,.CEB      ( ~v_i          )                       \
+             ,.WEB      ( ~w_i          )                       \
+             ,.A        ( addr_i        )                       \
+             ,.D        ( data_i        )                       \
+             ,.Q        ( data_o        )                       \
+            );                                                  \
+    end
+
+`define bsg_mem_1rw_sync_1sram_macro(words,bits,tag)       \
+  if (harden_p && els_p == words && width_p == bits) \
+    begin: macro                                     \
+          tsmc28_1rw_d``words``_w``bits``_``tag``_1sram mem  \
+            (                                                   \
+              .CLK      ( clk_i         )                       \
+             ,.CEB      ( ~v_i          )                       \
+             ,.WEB      ( ~w_i          )                       \
+             ,.A        ( addr_i        )                       \
+             ,.D        ( data_i        )                       \
+             ,.Q        ( data_o        )                       \
+            );                                                  \
+    end
+
+`define bsg_mem_1rw_sync_1hdsram_macro(words,bits,tag)       \
+  if (harden_p && els_p == words && width_p == bits) \
+    begin: macro                                     \
+          tsmc28_1rw_d``words``_w``bits``_``tag``_1hdsram mem  \
+            (                                                   \
+              .CLK      ( clk_i         )                       \
+             ,.CEB      ( ~v_i          )                       \
+             ,.WEB      ( ~w_i          )                       \
+             ,.A        ( addr_i        )                       \
+             ,.D        ( data_i        )                       \
+             ,.Q        ( data_o        )                       \
+             ,.RTSEL    ( 2'b01         )                       \
+             ,.WTSEL    ( 2'b00         )                       \
+            );                                                  \
+    end
+
+`define bsg_mem_1rw_sync_banked_macro(words,bits,wbank,dbank) \
+  if (harden_p && els_p == words && width_p == bits) begin: macro \
+    bsg_mem_1rw_sync_banked #(                                              \
+      .width_p(width_p)                                                     \
+      ,.els_p(els_p)                                                        \
+      ,.latch_last_read_p(latch_last_read_p)                                \
+      ,.num_width_bank_p(wbank)                                             \
+      ,.num_depth_bank_p(dbank)                                             \
+    ) bmem (                                                                \
+      .clk_i(clk_i)                                                         \
+      ,.reset_i(reset_i)                                                    \
+      ,.v_i(v_i)                                                            \
+      ,.w_i(w_i)                                                            \
+      ,.addr_i(addr_i)                                                      \
+      ,.data_i(data_i)                                                      \
+      ,.data_o(data_o)                                                      \
+    );                                                                      \
+  end: macro
+
+`endif

--- a/hard/tsmc_28/bsg_mem/bsg_mem_1rw_sync_macros.vh
+++ b/hard/tsmc_28/bsg_mem/bsg_mem_1rw_sync_macros.vh
@@ -32,6 +32,9 @@
 `define bsg_mem_1rw_sync_1hdsram_macro(words,bits,tag)       \
   if (harden_p && els_p == words && width_p == bits) \
     begin: macro                                     \
+      wire [1:0] m1ss_rtsel = 2'b10; wire [1:0] m1ss_wtsel = 2'b00; \
+      wire [1:0] m2ss_rtsel = 2'b10; wire [1:0] m2ss_wtsel = 2'b00; \
+      wire [1:0] m4ss_rtsel = 2'b00; wire [1:0] m4ss_wtsel = 2'b00; \
           tsmc28_1rw_d``words``_w``bits``_``tag``_1hdsram mem  \
             (                                                   \
               .CLK      ( clk_i         )                       \
@@ -41,8 +44,8 @@
              ,.D        ( data_i        )                       \
              ,.Q        ( data_o        )                       \
              /* According to TSMC, other settings are for debug only */ \
-             ,.RTSEL    ( 2'b01         )                       \
-             ,.WTSEL    ( 2'b00         )                       \
+             ,.RTSEL    ( ``tag``_rtsel  )                      \
+             ,.WTSEL    ( ``tag``_wtsel  )                      \
             );                                                  \
     end
 

--- a/hard/tsmc_28/bsg_mem/bsg_mem_1rw_sync_macros.vh
+++ b/hard/tsmc_28/bsg_mem/bsg_mem_1rw_sync_macros.vh
@@ -40,6 +40,7 @@
              ,.A        ( addr_i        )                       \
              ,.D        ( data_i        )                       \
              ,.Q        ( data_o        )                       \
+             /* According to TSMC, other settings are for debug only */ \
              ,.RTSEL    ( 2'b01         )                       \
              ,.WTSEL    ( 2'b00         )                       \
             );                                                  \

--- a/hard/tsmc_28/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_macros.vh
+++ b/hard/tsmc_28/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_macros.vh
@@ -13,7 +13,6 @@
              ,.A        ( addr_i        )                       \
              ,.D        ( data_i        )                       \
              ,.Q        ( data_o        )                       \
-             ,.CLKW     ( clk_i         )                       \
             );                                                  \
     end
 
@@ -29,7 +28,6 @@
              ,.A        ( addr_i        )                       \
              ,.D        ( data_i        )                       \
              ,.Q        ( data_o        )                       \
-             ,.CLKW     ( clk_i         )                       \
             );                                                  \
     end
 

--- a/hard/tsmc_28/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_macros.vh
+++ b/hard/tsmc_28/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_macros.vh
@@ -1,0 +1,73 @@
+`ifndef BSG_MEM_1RW_SYNC_MASK_WRITE_BIT_MACROS_VH
+`define BSG_MEM_1RW_SYNC_MASK_WRITE_BIT_MACROS_VH
+
+`define bsg_mem_1rw_sync_mask_write_bit_1rf_macro(words,bits,tag)       \
+  if (harden_p && els_p == words && width_p == bits) \
+    begin: macro                                     \
+          tsmc28_1rw_d``words``_w``bits``_``tag``_bit_1rf mem  \
+            (                                                   \
+              .CLK      ( clk_i         )                       \
+             ,.CEB      ( ~v_i          )                       \
+             ,.WEB      ( ~w_i          )                       \
+             ,.BWEB     ( ~w_mask_i     )                       \
+             ,.A        ( addr_i        )                       \
+             ,.D        ( data_i        )                       \
+             ,.Q        ( data_o        )                       \
+             ,.CLKW     ( clk_i         )                       \
+            );                                                  \
+    end
+
+`define bsg_mem_1rw_sync_mask_write_bit_1sram_macro(words,bits,tag)       \
+  if (harden_p && els_p == words && width_p == bits) \
+    begin: macro                                     \
+          tsmc28_1rw_d``words``_w``bits``_``tag``_bit_1sram mem  \
+            (                                                   \
+              .CLK      ( clk_i         )                       \
+             ,.CEB      ( ~v_i          )                       \
+             ,.WEB      ( ~w_i          )                       \
+             ,.BWEB     ( ~w_mask_i     )                       \
+             ,.A        ( addr_i        )                       \
+             ,.D        ( data_i        )                       \
+             ,.Q        ( data_o        )                       \
+             ,.CLKW     ( clk_i         )                       \
+            );                                                  \
+    end
+
+`define bsg_mem_1rw_sync_mask_write_bit_1hdsram_macro(words,bits,tag)       \
+  if (harden_p && els_p == words && width_p == bits) \
+    begin: macro                                     \
+          tsmc28_1rw_d``words``_w``bits``_``tag``_bit_1hdsram mem  \
+            (                                                   \
+              .CLK      ( clk_i         )                       \
+             ,.CEB      ( ~v_i          )                       \
+             ,.WEB      ( ~w_i          )                       \
+             ,.BWEB     ( ~w_mask_i     )                       \
+             ,.A        ( addr_i        )                       \
+             ,.D        ( data_i        )                       \
+             ,.Q        ( data_o        )                       \
+             ,.RTSEL    ( 2'b01         )                       \
+             ,.WTSEL    ( 2'b00         )                       \
+            );                                                  \
+    end
+
+`define bsg_mem_1rw_sync_mask_write_bit_banked_macro(words,bits,wbank,dbank) \
+  if (harden_p && els_p == words && width_p == bits) begin: macro \
+    bsg_mem_1rw_sync_mask_write_bit_banked #(                     \
+      .width_p(width_p)                                                     \
+      ,.els_p(els_p)                                                        \
+      ,.latch_last_read_p(latch_last_read_p)                                \
+      ,.num_width_bank_p(wbank)                                             \
+      ,.num_depth_bank_p(dbank)                                             \
+    ) bmem (                                                                \
+      .clk_i(clk_i)                                                         \
+      ,.reset_i(reset_i)                                                    \
+      ,.v_i(v_i)                                                            \
+      ,.w_i(w_i)                                                            \
+      ,.addr_i(addr_i)                                                      \
+      ,.data_i(data_i)                                                      \
+      ,.w_mask_i(w_mask_i)                                                  \
+      ,.data_o(data_o)                                                      \
+    );                                                                      \
+  end: macro
+
+`endif

--- a/hard/tsmc_28/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_macros.vh
+++ b/hard/tsmc_28/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_macros.vh
@@ -33,7 +33,10 @@
 
 `define bsg_mem_1rw_sync_mask_write_bit_1hdsram_macro(words,bits,tag)       \
   if (harden_p && els_p == words && width_p == bits) \
-    begin: macro                                     \
+    begin: macro                                                    \
+      wire [1:0] m1ss_rtsel = 2'b10; wire [1:0] m1ss_wtsel = 2'b00; \
+      wire [1:0] m2ss_rtsel = 2'b10; wire [1:0] m2ss_wtsel = 2'b00; \
+      wire [1:0] m4ss_rtsel = 2'b00; wire [1:0] m4ss_wtsel = 2'b00; \
           tsmc28_1rw_d``words``_w``bits``_``tag``_bit_1hdsram mem  \
             (                                                   \
               .CLK      ( clk_i         )                       \
@@ -44,8 +47,8 @@
              ,.D        ( data_i        )                       \
              ,.Q        ( data_o        )                       \
              /* According to TSMC, other settings are for debug only */ \
-             ,.RTSEL    ( 2'b01         )                       \
-             ,.WTSEL    ( 2'b00         )                       \
+             ,.RTSEL    ( ``tag``_rtsel )                       \
+             ,.WTSEL    ( ``tag``_wtsel )                       \
             );                                                  \
     end
 

--- a/hard/tsmc_28/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_macros.vh
+++ b/hard/tsmc_28/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_macros.vh
@@ -45,6 +45,7 @@
              ,.A        ( addr_i        )                       \
              ,.D        ( data_i        )                       \
              ,.Q        ( data_o        )                       \
+             /* According to TSMC, other settings are for debug only */ \
              ,.RTSEL    ( 2'b01         )                       \
              ,.WTSEL    ( 2'b00         )                       \
             );                                                  \

--- a/hard/tsmc_28/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_macros.vh
+++ b/hard/tsmc_28/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_macros.vh
@@ -9,7 +9,7 @@
   `bsg_mem_1rw_sync_mask_write_byte_macro(words,bits)
 
 `define bsg_mem_1rw_sync_mask_write_byte_macro(words,bits) \
-if (els_p == words && data_width_p == bits)                     \
+if (harden_p && els_p == words && data_width_p == bits)         \
   begin: wrap                                                   \
     logic [data_width_p-1:0] w_mask_li;                         \
     bsg_expand_bitmask                                          \

--- a/hard/tsmc_28/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_macros.vh
+++ b/hard/tsmc_28/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_macros.vh
@@ -1,0 +1,48 @@
+`ifndef BSG_MEM_1RW_SYNC_MASK_WRITE_BYTE_MACROS_VH
+`define BSG_MEM_1RW_SYNC_MASK_WRITE_BYTE_MACROS_VH
+
+`define bsg_mem_1rw_sync_mask_write_byte_1rf_macro(words,bits,tag) \
+  `bsg_mem_1rw_sync_mask_write_byte_macro(words,bits)
+`define bsg_mem_1rw_sync_mask_write_byte_1sram_macro(words,bits,tag) \
+  `bsg_mem_1rw_sync_mask_write_byte_macro(words,bits)
+`define bsg_mem_1rw_sync_mask_write_byte_1hdsram_macro(words,bits,tag) \
+  `bsg_mem_1rw_sync_mask_write_byte_macro(words,bits)
+
+`define bsg_mem_1rw_sync_mask_write_byte_macro(words,bits) \
+if (els_p == words && data_width_p == bits)                     \
+  begin: wrap                                                   \
+    logic [data_width_p-1:0] w_mask_li;                         \
+    bsg_expand_bitmask                                          \
+     #(.in_width_p(write_mask_width_lp), .expand_p(8))          \
+     wmask_expand                                               \
+      (.i(write_mask_i)                                         \
+       ,.o(w_mask_li)                                           \
+       );                                                       \
+                                                                \
+    bsg_mem_1rw_sync_mask_write_bit                             \
+     #(.width_p(data_width_p), .els_p(els_p))                   \
+     bit_mem                                                    \
+      (.w_mask_i(w_mask_li), .*);                               \
+  end
+
+`define bsg_mem_1rw_sync_mask_write_byte_banked_macro(words,bits,wbank,dbank) \
+  if (harden_p && els_p == words && data_width_p == bits) begin: macro        \
+      bsg_mem_1rw_sync_mask_write_byte_banked #(                              \
+        .data_width_p(data_width_p)                                           \
+        ,.els_p(els_p)                                                        \
+        ,.latch_last_read_p(latch_last_read_p)                                \
+        ,.num_width_bank_p(wbank)                                             \
+        ,.num_depth_bank_p(dbank)                                             \
+      ) bmem (                                                                \
+        .clk_i(clk_i)                                                         \
+        ,.reset_i(reset_i)                                                    \
+        ,.v_i(v_i)                                                            \
+        ,.w_i(w_i)                                                            \
+        ,.addr_i(addr_i)                                                      \
+        ,.data_i(data_i)                                                      \
+        ,.write_mask_i(write_mask_i)                                          \
+        ,.data_o(data_o)                                                      \
+      );                                                                      \
+    end: macro
+
+`endif 

--- a/hard/tsmc_28/bsg_mem/bsg_mem_2r1w_sync_macros.vh
+++ b/hard/tsmc_28/bsg_mem/bsg_mem_2r1w_sync_macros.vh
@@ -1,0 +1,129 @@
+
+`ifndef BSG_MEM_2R1W_SYNC_MACROS_VH
+`define BSG_MEM_2R1W_SYNC_MACROS_VH
+
+`define bsg_mem_2r1w_sync_2rf_macro(words,bits,tag) \
+  if (harden_p && els_p == words && width_p == bits) \
+    begin: macro                                                \
+          tsmc28_1r1w_d``words``_w``bits``_``tag``_2rf mem0     \
+            (                                                   \
+              .AA       ( w_addr_i      )                       \
+             ,.D        ( w_data_i      )                       \
+             ,.WEB      ( ~w_v_i        )                       \
+             ,.CLKW     ( clk_i         )                       \
+                                                                \
+             ,.AB       ( r0_addr_i     )                       \
+             ,.REB      ( ~r0_v_i       )                       \
+             ,.CLKR     ( clk_i         )                       \
+             ,.Q        ( r0_data_o     )                       \
+            );                                                  \
+          tsmc28_1r1w_d``words``_w``bits``_``tag``_2rf mem1     \
+            (                                                   \
+              .AA       ( w_addr_i      )                       \
+             ,.D        ( w_data_i      )                       \
+             ,.WEB      ( ~w_v_i        )                       \
+             ,.CLKW     ( clk_i         )                       \
+                                                                \
+             ,.AB       ( r1_addr_i     )                       \
+             ,.REB      ( ~r1_v_i       )                       \
+             ,.CLKR     ( clk_i         )                       \
+             ,.Q        ( r1_data_o     )                       \
+            );                                                  \
+    end: macro
+
+`define bsg_mem_2r1w_sync_2sram_macro(words,bits,tag) \
+if (harden_p && els_p == words && width_p == bits)              \
+  begin: macro                                                  \
+          tsmc28_2rw_d``words``_w``bits``_``tag``_2sram mem0    \
+            (                                                   \
+              .AA       ( w_addr_i      )                       \
+             ,.DA       ( w_data_i      )                       \
+             ,.WEBA     ( ~w_v_i        )                       \
+             ,.CEBA     ( ~w_v_i        )                       \
+             ,.CLKA     ( clk_i         )                       \
+             ,.QA       (               )                       \
+                                                                \
+             ,.AB       ( r0_addr_i     )                       \
+             ,.DB       ( '1            )                       \
+             ,.WEBB     ( '1            )                       \
+             ,.CEBB     ( ~r0_v_i       )                       \
+             ,.CLKB     ( clk_i         )                       \
+             ,.QB       ( r0_data_o     )                       \
+                                                                \
+             /* According to TSMC, other settings are for debug only */ \
+             ,.WTSEL    ( 2'b01         )                       \
+             ,.RTSEL    ( 2'b01         )                       \
+             ,.VG       ( 1'b1          )                       \
+             ,.VS       ( 1'b1          )                       \
+            );                                                  \
+          tsmc28_2rw_d``words``_w``bits``_``tag``_2sram mem1    \
+            (                                                   \
+              .AA       ( w_addr_i      )                       \
+             ,.DA       ( w_data_i      )                       \
+             ,.WEBA     ( ~w_v_i        )                       \
+             ,.CEBA     ( ~w_v_i        )                       \
+             ,.CLKA     ( clk_i         )                       \
+             ,.QA       (               )                       \
+                                                                \
+             ,.AB       ( r1_addr_i     )                       \
+             ,.DB       ( '1            )                       \
+             ,.WEBB     ( '1            )                       \
+             ,.CEBB     ( ~r1_v_i       )                       \
+             ,.CLKB     ( clk_i         )                       \
+             ,.QB       ( r1_data_o     )                       \
+                                                                \
+             /* According to TSMC, other settings are for debug only */ \
+             ,.WTSEL    ( 2'b01         )                       \
+             ,.RTSEL    ( 2'b01         )                       \
+             ,.VG       ( 1'b1          )                       \
+             ,.VS       ( 1'b1          )                       \
+            );                                                  \
+  end
+
+`define bsg_mem_2r1w_sync_2hdsram_macro(words,bits,tag) \
+if (harden_p && els_p == words && width_p == bits)              \
+  begin: macro                                                  \
+          tsmc28_2rw_d``words``_w``bits``_``tag``_2hdsram mem0  \
+            (                                                   \
+              .AA       ( w_addr_i      )                       \
+             ,.DA       ( w_data_i      )                       \
+             ,.WEBA     ( ~w_v_i        )                       \
+             ,.CEBA     ( ~w_v_i        )                       \
+             ,.CLK      ( clk_i         )                       \
+             ,.QA       (               )                       \
+                                                                \
+             ,.AB       ( r0_addr_i     )                       \
+             ,.DB       ( '1            )                       \
+             ,.WEBB     ( '1            )                       \
+             ,.CEBB     ( ~r0_v_i       )                       \
+             ,.QB       ( r0_data_o     )                       \
+                                                                \
+             /* According to TSMC, other settings are for debug only */ \
+             ,.WTSEL    ( 2'b00         )                       \
+             ,.RTSEL    ( 2'b00         )                       \
+             ,.PTSEL    ( 2'b00         )                       \
+            );                                                  \
+          tsmc28_2rw_d``words``_w``bits``_``tag``_2hdsram mem1  \
+            (                                                   \
+              .AA       ( w_addr_i      )                       \
+             ,.DA       ( w_data_i      )                       \
+             ,.WEBA     ( ~w_v_i        )                       \
+             ,.CEBA     ( ~w_v_i        )                       \
+             ,.CLK      ( clk_i         )                       \
+             ,.QA       (               )                       \
+                                                                \
+             ,.AB       ( r1_addr_i     )                       \
+             ,.DB       ( '1            )                       \
+             ,.WEBB     ( '1            )                       \
+             ,.CEBB     ( ~r1_v_i       )                       \
+             ,.QB       ( r1_data_o     )                       \
+                                                                \
+             /* According to TSMC, other settings are for debug only */ \
+             ,.WTSEL    ( 2'b00         )                       \
+             ,.RTSEL    ( 2'b00         )                       \
+             ,.PTSEL    ( 2'b00         )                       \
+            );                                                  \
+  end
+
+`endif
+

--- a/hard/tsmc_28/bsg_mem/bsg_mem_2r1w_sync_macros.vh
+++ b/hard/tsmc_28/bsg_mem/bsg_mem_2r1w_sync_macros.vh
@@ -44,8 +44,8 @@ if (harden_p && els_p == words && width_p == bits)              \
              ,.QA       (               )                       \
                                                                 \
              ,.AB       ( r0_addr_i     )                       \
-             ,.DB       ( '1            )                       \
-             ,.WEBB     ( '1            )                       \
+             ,.DB       ( {bits{1'b1}   )                       \
+             ,.WEBB     ( 1'b1          )                       \
              ,.CEBB     ( ~r0_v_i       )                       \
              ,.CLKB     ( clk_i         )                       \
              ,.QB       ( r0_data_o     )                       \
@@ -66,8 +66,8 @@ if (harden_p && els_p == words && width_p == bits)              \
              ,.QA       (               )                       \
                                                                 \
              ,.AB       ( r1_addr_i     )                       \
-             ,.DB       ( '1            )                       \
-             ,.WEBB     ( '1            )                       \
+             ,.DB       ( {bits{1'b1}}  )                       \
+             ,.WEBB     ( 1'b1          )                       \
              ,.CEBB     ( ~r1_v_i       )                       \
              ,.CLKB     ( clk_i         )                       \
              ,.QB       ( r1_data_o     )                       \
@@ -93,8 +93,8 @@ if (harden_p && els_p == words && width_p == bits)              \
              ,.QA       (               )                       \
                                                                 \
              ,.AB       ( r0_addr_i     )                       \
-             ,.DB       ( '1            )                       \
-             ,.WEBB     ( '1            )                       \
+             ,.DB       ( {bits{1'b1}}  )                       \
+             ,.WEBB     ( 1'b1          )                       \
              ,.CEBB     ( ~r0_v_i       )                       \
              ,.QB       ( r0_data_o     )                       \
                                                                 \
@@ -113,8 +113,8 @@ if (harden_p && els_p == words && width_p == bits)              \
              ,.QA       (               )                       \
                                                                 \
              ,.AB       ( r1_addr_i     )                       \
-             ,.DB       ( '1            )                       \
-             ,.WEBB     ( '1            )                       \
+             ,.DB       ( {bits{1'b1}}  )                       \
+             ,.WEBB     ( 1'b1          )                       \
              ,.CEBB     ( ~r1_v_i       )                       \
              ,.QB       ( r1_data_o     )                       \
                                                                 \

--- a/hard/tsmc_28/bsg_mem/bsg_mem_2rw_sync_macros.vh
+++ b/hard/tsmc_28/bsg_mem/bsg_mem_2rw_sync_macros.vh
@@ -18,6 +18,7 @@
              ,.AB       ( b_addr_i      )                       \
              ,.DB       ( b_data_i      )                       \
              ,.QB       ( b_data_o      )                       \
+             /* According to TSMC, other settings are for debug only */ \
              ,.WTSEL    ( 2'b01         )                       \
              ,.RTSEL    ( 2'b01         )                       \
              ,.VG       ( 1'b1          )                       \
@@ -43,6 +44,7 @@
              ,.AB       ( b_addr_i      )                       \
              ,.DB       ( b_data_i      )                       \
              ,.QB       ( b_data_o      )                       \
+             /* According to TSMC, other settings are for debug only */ \
              ,.WTSEL    ( 2'b00         )                       \
              ,.RTSEL    ( 2'b00         )                       \
              ,.PTSEL    ( 2'b00         )                       \            

--- a/hard/tsmc_28/bsg_mem/bsg_mem_2rw_sync_macros.vh
+++ b/hard/tsmc_28/bsg_mem/bsg_mem_2rw_sync_macros.vh
@@ -1,0 +1,52 @@
+`ifndef BSG_MEM_2RW_SYNC_MACROS_VH
+`define BSG_MEM_2RW_SYNC_MACROS_VH
+
+`define bsg_mem_2rw_sync_2sram_macro(words,bits,tag)       \
+  if (harden_p && els_p == words && width_p == bits) \
+    begin: macro                                     \
+          tsmc28_2rw_d``words``_w``bits``_``tag``_2sram mem  \
+            (                                                   \
+              .CLKA     ( clk_i         )                       \
+             ,.CEBA     ( ~a_v_i        )                       \
+             ,.WEBA     ( ~a_w_i        )                       \
+             ,.AA       ( a_addr_i      )                       \
+             ,.DA       ( a_data_i      )                       \
+             ,.QA       ( a_data_o      )                       \
+             ,.CLKB     ( clk_i         )                       \
+             ,.CEBB     ( ~b_v_i        )                       \
+             ,.WEBB     ( ~b_w_i        )                       \
+             ,.AB       ( b_addr_i      )                       \
+             ,.DB       ( b_data_i      )                       \
+             ,.QB       ( b_data_o      )                       \
+             ,.WTSEL    ( 2'b01         )                       \
+             ,.RTSEL    ( 2'b01         )                       \
+             ,.VG       ( 1'b1          )                       \
+             ,.VS       ( 1'b1          )                       \             
+            );                                                  \
+    end
+
+
+`define bsg_mem_2rw_sync_2hdsram_macro(words,bits,tag)       \
+  if (harden_p && els_p == words && width_p == bits) \
+    begin: macro                                     \
+          tsmc28_2rw_d``words``_w``bits``_``tag``_2hdsram mem  \
+            (                                                   \
+              .CLKA     ( clk_i         )                       \
+             ,.CEBA     ( ~a_v_i        )                       \
+             ,.WEBA     ( ~a_w_i        )                       \
+             ,.AA       ( a_addr_i      )                       \
+             ,.DA       ( a_data_i      )                       \
+             ,.QA       ( a_data_o      )                       \
+             ,.CLKB     ( clk_i         )                       \
+             ,.CEBB     ( ~b_v_i        )                       \
+             ,.WEBB     ( ~b_w_i        )                       \
+             ,.AB       ( b_addr_i      )                       \
+             ,.DB       ( b_data_i      )                       \
+             ,.QB       ( b_data_o      )                       \
+             ,.WTSEL    ( 2'b00         )                       \
+             ,.RTSEL    ( 2'b00         )                       \
+             ,.PTSEL    ( 2'b00         )                       \            
+            );                                                  \
+    end
+
+`endif 

--- a/hard/tsmc_28/bsg_mem/bsg_mem_2rw_sync_macros.vh
+++ b/hard/tsmc_28/bsg_mem/bsg_mem_2rw_sync_macros.vh
@@ -32,13 +32,12 @@
     begin: macro                                     \
           tsmc28_2rw_d``words``_w``bits``_``tag``_2hdsram mem  \
             (                                                   \
-              .CLKA     ( clk_i         )                       \
+              .CLK      ( clk_i         )                       \
              ,.CEBA     ( ~a_v_i        )                       \
              ,.WEBA     ( ~a_w_i        )                       \
              ,.AA       ( a_addr_i      )                       \
              ,.DA       ( a_data_i      )                       \
              ,.QA       ( a_data_o      )                       \
-             ,.CLKB     ( clk_i         )                       \
              ,.CEBB     ( ~b_v_i        )                       \
              ,.WEBB     ( ~b_w_i        )                       \
              ,.AB       ( b_addr_i      )                       \

--- a/hard/tsmc_28/bsg_mem/bsg_mem_2rw_sync_macros.vh
+++ b/hard/tsmc_28/bsg_mem/bsg_mem_2rw_sync_macros.vh
@@ -22,7 +22,7 @@
              ,.WTSEL    ( 2'b01         )                       \
              ,.RTSEL    ( 2'b01         )                       \
              ,.VG       ( 1'b1          )                       \
-             ,.VS       ( 1'b1          )                       \             
+             ,.VS       ( 1'b1          )                       \
             );                                                  \
     end
 
@@ -46,7 +46,7 @@
              /* According to TSMC, other settings are for debug only */ \
              ,.WTSEL    ( 2'b00         )                       \
              ,.RTSEL    ( 2'b00         )                       \
-             ,.PTSEL    ( 2'b00         )                       \            
+             ,.PTSEL    ( 2'b00         )                       \
             );                                                  \
     end
 

--- a/hard/tsmc_28/bsg_mem/bsg_mem_2rw_sync_mask_write_bit_macros.vh
+++ b/hard/tsmc_28/bsg_mem/bsg_mem_2rw_sync_mask_write_bit_macros.vh
@@ -34,14 +34,13 @@
     begin: macro                                     \
           tsmc28_2rw_d``words``_w``bits``_``tag``_bit_2hdsram mem  \
             (                                                   \
-              .CLKA     ( clk_i         )                       \
+              .CLK      ( clk_i         )                       \
              ,.CEBA     ( ~a_v_i        )                       \
              ,.WEBA     ( ~a_w_i        )                       \
              ,.BWEBA    ( ~a_w_mask_i   )                       \
              ,.AA       ( a_addr_i      )                       \
              ,.DA       ( a_data_i      )                       \
              ,.QA       ( a_data_o      )                       \
-             ,.CLKB     ( clk_i         )                       \
              ,.CEBB     ( ~b_v_i        )                       \
              ,.WEBB     ( ~b_w_i        )                       \
              ,.BWEBB    ( ~b_w_mask_i   )                       \

--- a/hard/tsmc_28/bsg_mem/bsg_mem_2rw_sync_mask_write_bit_macros.vh
+++ b/hard/tsmc_28/bsg_mem/bsg_mem_2rw_sync_mask_write_bit_macros.vh
@@ -20,6 +20,7 @@
              ,.AB       ( b_addr_i      )                       \
              ,.DB       ( b_data_i      )                       \
              ,.QB       ( b_data_o      )                       \
+             /* According to TSMC, other settings are for debug only */ \
              ,.WTSEL    ( 2'b01         )                       \
              ,.RTSEL    ( 2'b01         )                       \
              ,.VG       ( 1'b1          )                       \
@@ -47,6 +48,7 @@
              ,.AB       ( b_addr_i      )                       \
              ,.DB       ( b_data_i      )                       \
              ,.QB       ( b_data_o      )                       \
+             /* According to TSMC, other settings are for debug only */ \
              ,.RTSEL    ( 2'b00         )                       \
              ,.WTSEL    ( 2'b00         )                       \
              ,.PTSEL    ( 2'b00         )                       \            

--- a/hard/tsmc_28/bsg_mem/bsg_mem_2rw_sync_mask_write_bit_macros.vh
+++ b/hard/tsmc_28/bsg_mem/bsg_mem_2rw_sync_mask_write_bit_macros.vh
@@ -1,0 +1,56 @@
+`ifndef BSG_MEM_2RW_SYNC_MASK_WRITE_BIT_MACROS_VH
+`define BSG_MEM_2RW_SYNC_MASK_WRITE_BIT_MACROS_VH
+
+`define bsg_mem_2rw_sync_mask_write_bit_2sram_macro(words,bits,tag)       \
+  if (harden_p && els_p == words && width_p == bits) \
+    begin: macro                                     \
+          tsmc28_2rw_d``words``_w``bits``_``tag``_bit_2sram mem  \
+            (                                                   \
+              .CLKA     ( clk_i         )                       \
+             ,.CEBA     ( ~a_v_i        )                       \
+             ,.WEBA     ( ~a_w_i        )                       \
+             ,.BWEBA    ( ~a_w_mask_i   )                       \
+             ,.AA       ( a_addr_i      )                       \
+             ,.DA       ( a_data_i      )                       \
+             ,.QA       ( a_data_o      )                       \
+             ,.CLKB     ( clk_i         )                       \
+             ,.CEBB     ( ~b_v_i        )                       \
+             ,.WEBB     ( ~b_w_i        )                       \
+             ,.BWEBB    ( ~b_w_mask_i   )                       \
+             ,.AB       ( b_addr_i      )                       \
+             ,.DB       ( b_data_i      )                       \
+             ,.QB       ( b_data_o      )                       \
+             ,.WTSEL    ( 2'b01         )                       \
+             ,.RTSEL    ( 2'b01         )                       \
+             ,.VG       ( 1'b1          )                       \
+             ,.VS       ( 1'b1          )                       \             
+            );                                                  \
+    end
+
+
+`define bsg_mem_2rw_sync_mask_write_bit_2hdsram_macro(words,bits,tag)       \
+  if (harden_p && els_p == words && width_p == bits) \
+    begin: macro                                     \
+          tsmc28_2rw_d``words``_w``bits``_``tag``_bit_2hdsram mem  \
+            (                                                   \
+              .CLKA     ( clk_i         )                       \
+             ,.CEBA     ( ~a_v_i        )                       \
+             ,.WEBA     ( ~a_w_i        )                       \
+             ,.BWEBA    ( ~a_w_mask_i   )                       \
+             ,.AA       ( a_addr_i      )                       \
+             ,.DA       ( a_data_i      )                       \
+             ,.QA       ( a_data_o      )                       \
+             ,.CLKB     ( clk_i         )                       \
+             ,.CEBB     ( ~b_v_i        )                       \
+             ,.WEBB     ( ~b_w_i        )                       \
+             ,.BWEBB    ( ~b_w_mask_i   )                       \
+             ,.AB       ( b_addr_i      )                       \
+             ,.DB       ( b_data_i      )                       \
+             ,.QB       ( b_data_o      )                       \
+             ,.RTSEL    ( 2'b00         )                       \
+             ,.WTSEL    ( 2'b00         )                       \
+             ,.PTSEL    ( 2'b00         )                       \            
+            );                                                  \
+    end
+
+`endif

--- a/hard/tsmc_28/bsg_mem/bsg_mem_2rw_sync_mask_write_bit_macros.vh
+++ b/hard/tsmc_28/bsg_mem/bsg_mem_2rw_sync_mask_write_bit_macros.vh
@@ -24,7 +24,7 @@
              ,.WTSEL    ( 2'b01         )                       \
              ,.RTSEL    ( 2'b01         )                       \
              ,.VG       ( 1'b1          )                       \
-             ,.VS       ( 1'b1          )                       \             
+             ,.VS       ( 1'b1          )                       \
             );                                                  \
     end
 
@@ -50,7 +50,7 @@
              /* According to TSMC, other settings are for debug only */ \
              ,.RTSEL    ( 2'b00         )                       \
              ,.WTSEL    ( 2'b00         )                       \
-             ,.PTSEL    ( 2'b00         )                       \            
+             ,.PTSEL    ( 2'b00         )                       \
             );                                                  \
     end
 

--- a/hard/tsmc_28/bsg_mem/bsg_mem_2rw_sync_mask_write_byte_macros.vh
+++ b/hard/tsmc_28/bsg_mem/bsg_mem_2rw_sync_mask_write_byte_macros.vh
@@ -1,14 +1,14 @@
 `ifndef BSG_MEM_2RW_SYNC_MASK_WRITE_BYTE_MACROS_VH
 `define BSG_MEM_2RW_SYNC_MASK_WRITE_BYTE_MACROS_VH
 
-`define bsg_mem_2rw_sync_mask_write_2rf_byte_macro(words,bits,tag) \
+`define bsg_mem_2rw_sync_mask_write_byte_2rf_macro(words,bits,tag) \
   `bsg_mem_2rw_sync_mask_write_byte_macro(words,bits)
-`define bsg_mem_2rw_sync_mask_write_2sram_byte_macro(words,bits,tag) \
+`define bsg_mem_2rw_sync_mask_write_byte_2sram_macro(words,bits,tag) \
   `bsg_mem_2rw_sync_mask_write_byte_macro(words,bits)
-`define bsg_mem_2rw_sync_mask_write_2hdsram_byte_macro(words,bits,tag) \
+`define bsg_mem_2rw_sync_mask_write_byte_2hdsram_macro(words,bits,tag) \
   `bsg_mem_2rw_sync_mask_write_byte_macro(words,bits)
 
-`define bsg_mem_2rw_sync_mask_write_2hdsram_byte_macro(words,bits) \
+`define bsg_mem_2rw_sync_mask_write_byte_macro(words,bits) \
 if (els_p == words && width_p == bits)                          \
   begin: wrap                                                   \
   logic [width_p-1:0] a_w_mask_li;                              \

--- a/hard/tsmc_28/bsg_mem/bsg_mem_2rw_sync_mask_write_byte_macros.vh
+++ b/hard/tsmc_28/bsg_mem/bsg_mem_2rw_sync_mask_write_byte_macros.vh
@@ -9,7 +9,7 @@
   `bsg_mem_2rw_sync_mask_write_byte_macro(words,bits)
 
 `define bsg_mem_2rw_sync_mask_write_byte_macro(words,bits) \
-if (els_p == words && width_p == bits)                          \
+if (harden_p && els_p == words && width_p == bits)              \
   begin: wrap                                                   \
   logic [width_p-1:0] a_w_mask_li;                              \
   bsg_expand_bitmask                                            \

--- a/hard/tsmc_28/bsg_mem/bsg_mem_2rw_sync_mask_write_byte_macros.vh
+++ b/hard/tsmc_28/bsg_mem/bsg_mem_2rw_sync_mask_write_byte_macros.vh
@@ -1,0 +1,36 @@
+`ifndef BSG_MEM_2RW_SYNC_MASK_WRITE_BYTE_MACROS_VH
+`define BSG_MEM_2RW_SYNC_MASK_WRITE_BYTE_MACROS_VH
+
+`define bsg_mem_2rw_sync_mask_write_2rf_byte_macro(words,bits,tag) \
+  `bsg_mem_2rw_sync_mask_write_byte_macro(words,bits)
+`define bsg_mem_2rw_sync_mask_write_2sram_byte_macro(words,bits,tag) \
+  `bsg_mem_2rw_sync_mask_write_byte_macro(words,bits)
+`define bsg_mem_2rw_sync_mask_write_2hdsram_byte_macro(words,bits,tag) \
+  `bsg_mem_2rw_sync_mask_write_byte_macro(words,bits)
+
+`define bsg_mem_2rw_sync_mask_write_2hdsram_byte_macro(words,bits) \
+if (els_p == words && width_p == bits)                          \
+  begin: wrap                                                   \
+  logic [width_p-1:0] a_w_mask_li;                              \
+  bsg_expand_bitmask                                            \
+   #(.in_width_p(write_mask_width_lp), .expand_p(8))            \
+   a_wmask_expand                                               \
+    (.i(a_w_mask_i)                                             \
+     ,.o(a_w_mask_li)                                           \
+     );                                                         \
+                                                                \
+  logic [width_p-1:0] b_w_mask_li;                              \
+  bsg_expand_bitmask                                            \
+   #(.in_width_p(write_mask_width_lp), .expand_p(8))            \
+   b_wmask_expand                                               \
+    (.i(b_w_mask_i)                                             \
+     ,.o(b_w_mask_li)                                           \
+     );                                                         \
+                                                                \
+  bsg_mem_2rw_sync_mask_write_bit                               \
+   #(.width_p(width_p), .els_p(els_p))                          \
+   bit_mem                                                      \
+    (.a_w_mask_i(a_w_mask_li), .b_w_mask_i(b_w_mask_i), .*);    \
+  end
+
+`endif 

--- a/hard/tsmc_28/bsg_mem/bsg_mem_3r1w_sync_macros.vh
+++ b/hard/tsmc_28/bsg_mem/bsg_mem_3r1w_sync_macros.vh
@@ -29,7 +29,7 @@
              ,.CLKR     ( clk_i         )                       \
              ,.Q        ( r1_data_o     )                       \
             );                                                  \
-          tsmc28_3r1w_d``words``_w``bits``_``tag``_2rf mem2     \
+          tsmc28_1r1w_d``words``_w``bits``_``tag``_2rf mem2     \
             (                                                   \
               .AA       ( w_addr_i      )                       \
              ,.D        ( w_data_i      )                       \

--- a/hard/tsmc_28/bsg_mem/bsg_mem_3r1w_sync_macros.vh
+++ b/hard/tsmc_28/bsg_mem/bsg_mem_3r1w_sync_macros.vh
@@ -1,0 +1,183 @@
+
+`ifndef BSG_MEM_3R1W_SYNC_MACROS_VH
+`define BSG_MEM_3R1W_SYNC_MACROS_VH
+
+`define bsg_mem_3r1w_sync_2rf_macro(words,bits,tag) \
+  if (harden_p && els_p == words && width_p == bits) \
+    begin: macro                                                \
+          tsmc28_1r1w_d``words``_w``bits``_``tag``_2rf mem0     \
+            (                                                   \
+              .AA       ( w_addr_i      )                       \
+             ,.D        ( w_data_i      )                       \
+             ,.WEB      ( ~w_v_i        )                       \
+             ,.CLKW     ( clk_i         )                       \
+                                                                \
+             ,.AB       ( r0_addr_i     )                       \
+             ,.REB      ( ~r0_v_i       )                       \
+             ,.CLKR     ( clk_i         )                       \
+             ,.Q        ( r0_data_o     )                       \
+            );                                                  \
+          tsmc28_1r1w_d``words``_w``bits``_``tag``_2rf mem1     \
+            (                                                   \
+              .AA       ( w_addr_i      )                       \
+             ,.D        ( w_data_i      )                       \
+             ,.WEB      ( ~w_v_i        )                       \
+             ,.CLKW     ( clk_i         )                       \
+                                                                \
+             ,.AB       ( r1_addr_i     )                       \
+             ,.REB      ( ~r1_v_i       )                       \
+             ,.CLKR     ( clk_i         )                       \
+             ,.Q        ( r1_data_o     )                       \
+            );                                                  \
+          tsmc28_3r1w_d``words``_w``bits``_``tag``_2rf mem2     \
+            (                                                   \
+              .AA       ( w_addr_i      )                       \
+             ,.D        ( w_data_i      )                       \
+             ,.WEB      ( ~w_v_i        )                       \
+             ,.CLKW     ( clk_i         )                       \
+                                                                \
+             ,.AB       ( r2_addr_i     )                       \
+             ,.REB      ( ~r2_v_i       )                       \
+             ,.CLKR     ( clk_i         )                       \
+             ,.Q        ( r2_data_o     )                       \
+            );                                                  \
+    end: macro
+
+`define bsg_mem_3r1w_sync_2sram_macro(words,bits,tag) \
+if (harden_p && els_p == words && width_p == bits)              \
+  begin: macro                                                  \
+          tsmc28_2rw_d``words``_w``bits``_``tag``_2sram mem0    \
+            (                                                   \
+              .AA       ( w_addr_i      )                       \
+             ,.DA       ( w_data_i      )                       \
+             ,.WEBA     ( ~w_v_i        )                       \
+             ,.CEBA     ( ~w_v_i        )                       \
+             ,.CLKA     ( clk_i         )                       \
+             ,.QA       (               )                       \
+                                                                \
+             ,.AB       ( r0_addr_i     )                       \
+             ,.DB       ( '1            )                       \
+             ,.WEBB     ( '1            )                       \
+             ,.CEBB     ( ~r0_v_i       )                       \
+             ,.CLKB     ( clk_i         )                       \
+             ,.QB       ( r0_data_o     )                       \
+                                                                \
+             /* According to TSMC, other settings are for debug only */ \
+             ,.WTSEL    ( 2'b01         )                       \
+             ,.RTSEL    ( 2'b01         )                       \
+             ,.VG       ( 1'b1          )                       \
+             ,.VS       ( 1'b1          )                       \
+            );                                                  \
+          tsmc28_2rw_d``words``_w``bits``_``tag``_2sram mem1    \
+            (                                                   \
+              .AA       ( w_addr_i      )                       \
+             ,.DA       ( w_data_i      )                       \
+             ,.WEBA     ( ~w_v_i        )                       \
+             ,.CEBA     ( ~w_v_i        )                       \
+             ,.CLKA     ( clk_i         )                       \
+             ,.QA       (               )                       \
+                                                                \
+             ,.AB       ( r1_addr_i     )                       \
+             ,.DB       ( '1            )                       \
+             ,.WEBB     ( '1            )                       \
+             ,.CEBB     ( ~r1_v_i       )                       \
+             ,.CLKB     ( clk_i         )                       \
+             ,.QB       ( r1_data_o     )                       \
+                                                                \
+             /* According to TSMC, other settings are for debug only */ \
+             ,.WTSEL    ( 2'b01         )                       \
+             ,.RTSEL    ( 2'b01         )                       \
+             ,.VG       ( 1'b1          )                       \
+             ,.VS       ( 1'b1          )                       \
+            );                                                  \
+          tsmc28_2rw_d``words``_w``bits``_``tag``_2sram mem2    \
+            (                                                   \
+              .AA       ( w_addr_i      )                       \
+             ,.DA       ( w_data_i      )                       \
+             ,.WEBA     ( ~w_v_i        )                       \
+             ,.CEBA     ( ~w_v_i        )                       \
+             ,.CLKA     ( clk_i         )                       \
+             ,.QA       (               )                       \
+                                                                \
+             ,.AB       ( r2_addr_i     )                       \
+             ,.DB       ( '1            )                       \
+             ,.WEBB     ( '1            )                       \
+             ,.CEBB     ( ~r2_v_i       )                       \
+             ,.CLKB     ( clk_i         )                       \
+             ,.QB       ( r2_data_o     )                       \
+                                                                \
+             /* According to TSMC, other settings are for debug only */ \
+             ,.WTSEL    ( 2'b01         )                       \
+             ,.RTSEL    ( 2'b01         )                       \
+             ,.VG       ( 1'b1          )                       \
+             ,.VS       ( 1'b1          )                       \
+            );                                                  \
+  end
+
+`define bsg_mem_3r1w_sync_2hdsram_macro(words,bits,tag) \
+if (harden_p && els_p == words && width_p == bits)              \
+  begin: macro                                                  \
+          tsmc28_2rw_d``words``_w``bits``_``tag``_2hdsram mem0  \
+            (                                                   \
+              .AA       ( w_addr_i      )                       \
+             ,.DA       ( w_data_i      )                       \
+             ,.WEBA     ( ~w_v_i        )                       \
+             ,.CEBA     ( ~w_v_i        )                       \
+             ,.CLK      ( clk_i         )                       \
+             ,.QA       (               )                       \
+                                                                \
+             ,.AB       ( r0_addr_i     )                       \
+             ,.DB       ( '1            )                       \
+             ,.WEBB     ( '1            )                       \
+             ,.CEBB     ( ~r0_v_i       )                       \
+             ,.QB       ( r0_data_o     )                       \
+                                                                \
+             /* According to TSMC, other settings are for debug only */ \
+             ,.WTSEL    ( 2'b00         )                       \
+             ,.RTSEL    ( 2'b00         )                       \
+             ,.PTSEL    ( 2'b00         )                       \
+            );                                                  \
+          tsmc28_2rw_d``words``_w``bits``_``tag``_2hdsram mem1  \
+            (                                                   \
+              .AA       ( w_addr_i      )                       \
+             ,.DA       ( w_data_i      )                       \
+             ,.WEBA     ( ~w_v_i        )                       \
+             ,.CEBA     ( ~w_v_i        )                       \
+             ,.CLK      ( clk_i         )                       \
+             ,.QA       (               )                       \
+                                                                \
+             ,.AB       ( r1_addr_i     )                       \
+             ,.DB       ( '1            )                       \
+             ,.WEBB     ( '1            )                       \
+             ,.CEBB     ( ~r1_v_i       )                       \
+             ,.QB       ( r1_data_o     )                       \
+                                                                \
+             /* According to TSMC, other settings are for debug only */ \
+             ,.WTSEL    ( 2'b00         )                       \
+             ,.RTSEL    ( 2'b00         )                       \
+             ,.PTSEL    ( 2'b00         )                       \
+            );                                                  \
+          tsmc28_2rw_d``words``_w``bits``_``tag``_2hdsram mem2  \
+            (                                                   \
+              .AA       ( w_addr_i      )                       \
+             ,.DA       ( w_data_i      )                       \
+             ,.WEBA     ( ~w_v_i        )                       \
+             ,.CEBA     ( ~w_v_i        )                       \
+             ,.CLK      ( clk_i         )                       \
+             ,.QA       (               )                       \
+                                                                \
+             ,.AB       ( r2_addr_i     )                       \
+             ,.DB       ( '1            )                       \
+             ,.WEBB     ( '1            )                       \
+             ,.CEBB     ( ~r2_v_i       )                       \
+             ,.QB       ( r2_data_o     )                       \
+                                                                \
+             /* According to TSMC, other settings are for debug only */ \
+             ,.WTSEL    ( 2'b00         )                       \
+             ,.RTSEL    ( 2'b00         )                       \
+             ,.PTSEL    ( 2'b00         )                       \
+            );                                                  \
+  end
+
+`endif
+

--- a/hard/tsmc_28/bsg_mem/bsg_mem_3r1w_sync_macros.vh
+++ b/hard/tsmc_28/bsg_mem/bsg_mem_3r1w_sync_macros.vh
@@ -56,8 +56,8 @@ if (harden_p && els_p == words && width_p == bits)              \
              ,.QA       (               )                       \
                                                                 \
              ,.AB       ( r0_addr_i     )                       \
-             ,.DB       ( '1            )                       \
-             ,.WEBB     ( '1            )                       \
+             ,.DB       ( {bits{1'b1}}  )                       \
+             ,.WEBB     ( 1'b1          )                       \
              ,.CEBB     ( ~r0_v_i       )                       \
              ,.CLKB     ( clk_i         )                       \
              ,.QB       ( r0_data_o     )                       \
@@ -78,8 +78,8 @@ if (harden_p && els_p == words && width_p == bits)              \
              ,.QA       (               )                       \
                                                                 \
              ,.AB       ( r1_addr_i     )                       \
-             ,.DB       ( '1            )                       \
-             ,.WEBB     ( '1            )                       \
+             ,.DB       ( {bits{1'b1}}  )                       \
+             ,.WEBB     ( 1'b1          )                       \
              ,.CEBB     ( ~r1_v_i       )                       \
              ,.CLKB     ( clk_i         )                       \
              ,.QB       ( r1_data_o     )                       \
@@ -100,8 +100,8 @@ if (harden_p && els_p == words && width_p == bits)              \
              ,.QA       (               )                       \
                                                                 \
              ,.AB       ( r2_addr_i     )                       \
-             ,.DB       ( '1            )                       \
-             ,.WEBB     ( '1            )                       \
+             ,.DB       ( {bits{1'b1}}  )                       \
+             ,.WEBB     ( 1'b1          )                       \
              ,.CEBB     ( ~r2_v_i       )                       \
              ,.CLKB     ( clk_i         )                       \
              ,.QB       ( r2_data_o     )                       \
@@ -127,8 +127,8 @@ if (harden_p && els_p == words && width_p == bits)              \
              ,.QA       (               )                       \
                                                                 \
              ,.AB       ( r0_addr_i     )                       \
-             ,.DB       ( '1            )                       \
-             ,.WEBB     ( '1            )                       \
+             ,.DB       ( {bits{1'b1}}  )                       \
+             ,.WEBB     ( 1'b1          )                       \
              ,.CEBB     ( ~r0_v_i       )                       \
              ,.QB       ( r0_data_o     )                       \
                                                                 \
@@ -147,8 +147,8 @@ if (harden_p && els_p == words && width_p == bits)              \
              ,.QA       (               )                       \
                                                                 \
              ,.AB       ( r1_addr_i     )                       \
-             ,.DB       ( '1            )                       \
-             ,.WEBB     ( '1            )                       \
+             ,.DB       ( {bits{1'b1}}  )                       \
+             ,.WEBB     ( 1'b1          )                       \
              ,.CEBB     ( ~r1_v_i       )                       \
              ,.QB       ( r1_data_o     )                       \
                                                                 \
@@ -167,8 +167,8 @@ if (harden_p && els_p == words && width_p == bits)              \
              ,.QA       (               )                       \
                                                                 \
              ,.AB       ( r2_addr_i     )                       \
-             ,.DB       ( '1            )                       \
-             ,.WEBB     ( '1            )                       \
+             ,.DB       ( {bits{1'b1}}  )                       \
+             ,.WEBB     ( 1'b1          )                       \
              ,.CEBB     ( ~r2_v_i       )                       \
              ,.QB       ( r2_data_o     )                       \
                                                                 \


### PR DESCRIPTION
Adds memory macros for TSMC28. Part of a decomposition of #492 