### PR TITLE
Adding clock gen for TSMC28

### DIFF
--- a/hard/tsmc_28/bsg_clk_gen/README.verification
+++ b/hard/tsmc_28/bsg_clk_gen/README.verification
@@ -1,0 +1,24 @@
+This clock generator is intended to be able to change the frequency as the chip operates without glitches or short pulses.
+
+* Verification using SDF and gate-level simulation
+
+After the system has gone through place-and-route, it's important to check the timing corners in the circuit. The default tester tests the worst-case transition, which
+occurs when transitioning from the fastest frequency to the closest frequency.
+
+In gate-level simulation, this can be view by looking at clk_gen_osc_inst/adt/sel_r_reg_0, and finding the part in the test where the clock goes from fastest to slowest.
+Measure the distance between the D input and the CK signal. Typically D will fall shortly before CK rises, indicating a setup time condition that needs to be verified.
+This time can be compared against the negedge setup time for the same gate in the .SDF file.
+
+The other potential race is in the mux4i of the adt. The select lines should transition in a way that the output does not glitch. Currently the select lines transition
+from 3 (D)->2 (C)->0(A) after the D is already zero, C is hardwired to 0, and then A has just transitioned to 0.
+
+In practice, if the chip exhibits this race in the real world, it can be avoid by transitioning to an intermediate frequency before going to the slowest frequency.
+
+* Verification using Spice
+
+True transistor-level extraction-based spice is the best way to verify the circuit, although it takes a long time.  The simulation-based model in the spice directory
+can be used to eyeball frequency ranges.
+
+
+
+

--- a/hard/tsmc_28/bsg_clk_gen/bsg_clk_gen_osc.v
+++ b/hard/tsmc_28/bsg_clk_gen/bsg_clk_gen_osc.v
@@ -1,0 +1,174 @@
+// bsg_clk_gen_osc
+//
+// new settings are delivered via bsg_tag_i
+//
+// the clock is designed to be atomically updated
+// between any of its values without glitching.
+//
+// the order of components is:
+//
+// ADT, CDT, FDT  --> feedback (and buffer to outside world)
+//
+// All three stages invert their outputs.
+//
+// All of the modules have delay circuits that clock their config
+// flops right after the signal has passed through. All of them are
+// configured to grab the new value after a negedge enters the beginning of
+// of the ADT, but of course since the signal is inverted at each stage
+// ADT and FDT do it on posege and CDT does it on negedge.
+//
+// We employ a MUXI4 that is part of the standard cell library
+// that we verify to be glitch-free using spice simulation (presumably because it is based on a
+// t-gate design). If the MUXI4 were made out of AND-OR circuits, care
+// would have to be taken to make sure that the transitions occur when
+// either all inputs are 0 or 1 to the MUXI4, depending on the implementation.
+// For example, if the mux is AOI, triggered on negedge edge of input clock would
+// be okay. Fortunately, we don't have to worry about this (and confirmed by spice.)
+//
+// We have verified this in TSMC 40 by running with sdf annotations.
+//
+
+// Gen 2 specific info (starting with 40nm)  MBT 5-26-2018
+//
+// This Gen 2 clock generator has been slight redesigned in order to address the races
+// in the gen 1 design that prevented automation.
+//
+// We use the bsg_tag_client_unsync implementation in order to reduce the load on
+// the internally generated clock. Additionally, we separate out the we_r trigger
+// signal so that it is explicitly set. This means that to set the frequency
+// on average, three packets will need to be sent. First, a packet will be sent
+// to set clock configuration bits. Then a packet will be sent to enable the we_r
+// signal. Finally a packet will be sent to clear the we_r signal.
+// This applies only for the oscillator programming.
+//
+// The trigger is synchronized inside the ADT; and then the synchronized signal
+// is buffered and passed on to the CDT and then to the FDT, mirroring the
+// flow of the clock signal through the units.
+//
+// The goal of this approach is to ensure that a new value is latched into the
+// oscillator's configuration registers atomically, and during the first negative
+// clock phase after a positive edge.
+//
+//
+// The downsampler uses the normal interface.
+//
+//
+// Gen 1 specific info (for reference)
+//
+// There is an implicit race between the bsg_tag's output fb_we_r (clocked on
+// positive edge of FDT output) and these config flops that cannot be addressed
+// in ICC because we cannot explicitly control timing between ICC-managed
+// clocks and our internal oscillator clocks.
+//
+// A final check must be made on the 5 flops inside the adt / cdt / fdt
+// to see that async reset drops and data inputs do not come too close
+// to the appropriate clock edge.  This could be verified via a script that
+// processes the SDF file, but for now we pull the test trace up in DVE and
+// manually check these points.  Typically, the ADT is the closest
+// call, where in MAX timing mode, the data changes about 481 ps before the
+// positive edge of the flop's clock. With a setup time on the order of
+// 261 ps, there is a slack of 220 ps. This path was originally a problem
+// and it fixed by sending the clock out to the BTC at the beginning of
+// the FDT as opposed to at the end. This gives more time for propagate
+// through the ICC-generate clock tree for the BTC.
+//
+//
+//
+//
+
+`timescale 1ps/1ps
+
+`include "bsg_defines.v"
+`include "bsg_clk_gen.vh"
+
+module bsg_clk_gen_osc
+   import bsg_tag_pkg::bsg_tag_s;
+ #(parameter num_adgs_p=1)
+  (
+   input bsg_tag_s bsg_tag_i
+   ,input bsg_tag_s bsg_tag_trigger_i
+
+   ,input async_reset_i
+   ,output clk_o
+   );
+
+   wire  fb_clk;
+   wire       async_reset_neg = ~async_reset_i;
+
+   `declare_bsg_clk_gen_osc_tag_payload_s(num_adgs_p)
+
+   bsg_clk_gen_osc_tag_payload_s tag_r_async;
+   wire       tag_trigger_r_async;
+   wire       adt_to_cdt_trigger_lo, cdt_to_fdt_trigger_lo;
+
+   // this is a raw interface; and wires will toggle
+   // as the bits shift in. the wires are also
+   // unsynchronized with respect to the target domain.
+
+   bsg_tag_client_unsync
+     #(.width_p($bits(bsg_clk_gen_osc_tag_payload_s))
+       ,.harden_p(1)
+       ) btc
+       (.bsg_tag_i(bsg_tag_i)
+        ,.data_async_r_o(tag_r_async)
+        );
+
+   bsg_tag_client_unsync
+     #(.width_p(1)
+       ,.harden_p(1)
+       ) btc_trigger
+       (.bsg_tag_i(bsg_tag_trigger_i)
+        ,.data_async_r_o(tag_trigger_r_async)
+        );
+
+   wire adt_lo, cdt_lo;
+
+   wire fb_clk_del;
+
+   // this adds some delay in the loop for RTL simulation
+   // should be ignored in synthesis
+   assign #4000 fb_clk_del = fb_clk;
+
+   bsg_rp_clk_gen_atomic_delay_tuner  adt_BSG_DONT_TOUCH
+     (.i(fb_clk_del)
+      ,.we_async_i (tag_trigger_r_async   )
+      ,.we_inited_i(bsg_tag_trigger_i.en  )
+      ,.async_reset_neg_i(async_reset_neg )
+      ,.sel_i(tag_r_async.adg[0]          )
+      ,.we_o(adt_to_cdt_trigger_lo        )
+      ,.o(adt_lo                          )
+      );
+
+   // instantatiate CDT (coarse delay tuner)
+   // this one inverts the output
+   // captures config state on negative edge of input clock
+
+   bsg_rp_clk_gen_coarse_delay_tuner cdt_BSG_DONT_TOUCH
+     (.i                 (adt_lo)
+      ,.we_i             (adt_to_cdt_trigger_lo)
+      ,.async_reset_neg_i(async_reset_neg      )
+      ,.sel_i            (tag_r_async.cdt      )
+      ,.we_o             (cdt_to_fdt_trigger_lo)
+      ,.o                (cdt_lo)
+      );
+
+   // instantiate FDT (fine delay tuner)
+   // captures config state on positive edge of (inverted) input clk
+   // non-inverting
+
+   bsg_rp_clk_gen_fine_delay_tuner fdt_BSG_DONT_TOUCH
+     (.i                 (cdt_lo)
+      ,.we_i             (cdt_to_fdt_trigger_lo)
+      ,.async_reset_neg_i(async_reset_neg)
+      ,.sel_i            (tag_r_async.fdt)
+      ,.o                (fb_clk)     // in the actual critical loop
+      ,.buf_o            (clk_o)     // outside this module
+      );
+
+   //always @(*)
+   //  $display("%m async_reset_neg=%b fb_clk=%b adg_int=%b fb_tag_r=%b fb_we_r=%b",
+   //           async_reset_neg,fb_clk,adg_int,fb_tag_r,fb_we_r);
+
+endmodule // bsg_clk_gen_osc
+
+

--- a/hard/tsmc_28/bsg_clk_gen/bsg_dly_line.v
+++ b/hard/tsmc_28/bsg_clk_gen/bsg_dly_line.v
@@ -1,0 +1,179 @@
+// bsg_delay_line
+//
+// new settings are delivered via bsg_tag_i
+//
+// the clock is designed to be atomically updated
+// between any of its values without glitching.
+//
+// the order of components is:
+//
+// ADT, CDT, FDT  --> feedback (and buffer to outside world)
+//
+// All three stages invert their outputs.
+//
+// All of the modules have delay circuits that clock their config
+// flops right after the signal has passed through. All of them are
+// configured to grab the new value after a negedge enters the beginning of
+// of the ADT, but of course since the signal is inverted at each stage
+// ADT and FDT do it on posege and CDT does it on negedge.
+//
+// We employ a MUXI4 that is part of the standard cell library
+// that we verify to be glitch-free using spice simulation (presumably because it is based on a
+// t-gate design). If the MUXI4 were made out of AND-OR circuits, care
+// would have to be taken to make sure that the transitions occur when
+// either all inputs are 0 or 1 to the MUXI4, depending on the implementation.
+// For example, if the mux is AOI, triggered on negedge edge of input clock would
+// be okay. Fortunately, we don't have to worry about this (and confirmed by spice.)
+//
+// We have verified this in TSMC 40 by running with sdf annotations.
+//
+
+// Gen 2 specific info (starting with 40nm)  MBT 5-26-2018
+//
+// This Gen 2 clock generator has been slight redesigned in order to address the races
+// in the gen 1 design that prevented automation.
+//
+// We use the bsg_tag_client_unsync implementation in order to reduce the load on
+// the internally generated clock. Additionally, we separate out the we_r trigger
+// signal so that it is explicitly set. This means that to set the frequency
+// on average, three packets will need to be sent. First, a packet will be sent
+// to set clock configuration bits. Then a packet will be sent to enable the we_r
+// signal. Finally a packet will be sent to clear the we_r signal.
+// This applies only for the oscillator programming.
+//
+// The trigger is synchronized inside the ADT; and then the synchronized signal
+// is buffered and passed on to the CDT and then to the FDT, mirroring the
+// flow of the clock signal through the units.
+//
+// The goal of this approach is to ensure that a new value is latched into the
+// oscillator's configuration registers atomically, and during the first negative
+// clock phase after a positive edge.
+//
+//
+// The downsampler uses the normal interface.
+//
+//
+// Gen 1 specific info (for reference)
+//
+// There is an implicit race between the bsg_tag's output fb_we_r (clocked on
+// positive edge of FDT output) and these config flops that cannot be addressed
+// in ICC because we cannot explicitly control timing between ICC-managed
+// clocks and our internal oscillator clocks.
+//
+// A final check must be made on the 5 flops inside the adt / cdt / fdt
+// to see that async reset drops and data inputs do not come too close
+// to the appropriate clock edge.  This could be verified via a script that
+// processes the SDF file, but for now we pull the test trace up in DVE and
+// manually check these points.  Typically, the ADT is the closest
+// call, where in MAX timing mode, the data changes about 481 ps before the
+// positive edge of the flop's clock. With a setup time on the order of
+// 261 ps, there is a slack of 220 ps. This path was originally a problem
+// and it fixed by sending the clock out to the BTC at the beginning of
+// the FDT as opposed to at the end. This gives more time for propagate
+// through the ICC-generate clock tree for the BTC.
+//
+//
+//
+//
+
+`timescale 1ps/1ps
+
+`include "bsg_clk_gen.vh"
+
+module bsg_dly_line
+   import bsg_tag_pkg::bsg_tag_s;
+ #(parameter num_adgs_p=1)
+  (
+   input bsg_tag_s bsg_tag_i
+   ,input bsg_tag_s bsg_tag_trigger_i
+
+   ,input async_reset_i
+   ,input clk_i
+   ,output clk_o
+   );
+
+   wire  fb_clk;
+   wire       async_reset_neg = ~async_reset_i;
+
+   `declare_bsg_clk_gen_osc_tag_payload_s(num_adgs_p)
+
+   bsg_clk_gen_osc_tag_payload_s tag_r_async;
+   wire       tag_trigger_r_async;
+   wire       adt_to_cdt_trigger_lo, cdt_to_fdt_trigger_lo;
+
+   // this is a raw interface; and wires will toggle
+   // as the bits shift in. the wires are also
+   // unsynchronized with respect to the target domain.
+
+   bsg_tag_client_unsync
+     #(.width_p($bits(bsg_clk_gen_osc_tag_payload_s))
+       ,.harden_p(1)
+       ) btc
+       (.bsg_tag_i(bsg_tag_i)
+        ,.data_async_r_o(tag_r_async)
+        );
+
+   bsg_tag_client_unsync
+     #(.width_p(1)
+       ,.harden_p(1)
+       ) btc_trigger
+       (.bsg_tag_i(bsg_tag_trigger_i)
+        ,.data_async_r_o(tag_trigger_r_async)
+        );
+
+   wire adt_lo, cdt_lo;
+
+   wire fb_clk_del;
+
+   // this adds some delay in the loop for RTL simulation
+   // should be ignored in synthesis
+   assign #4000 fb_clk_del = fb_clk;
+
+  wire clk_inv;
+  assign clk_inv = ~clk_i;
+
+   bsg_rp_clk_gen_atomic_delay_tuner  adt
+     (.i(clk_inv)
+      ,.we_async_i (tag_trigger_r_async   )
+      ,.we_inited_i(bsg_tag_trigger_i.en  )
+      ,.async_reset_neg_i(async_reset_neg )
+      ,.sel_i(tag_r_async.adg[0]          )
+      ,.we_o(adt_to_cdt_trigger_lo        )
+      ,.o(adt_lo                          )
+      );
+
+   // instantatiate CDT (coarse delay tuner)
+   // this one inverts the output
+   // captures config state on negative edge of input clock
+
+   bsg_rp_clk_gen_coarse_delay_tuner cdt
+     (.i                 (adt_lo)
+      ,.we_i             (adt_to_cdt_trigger_lo)
+      ,.async_reset_neg_i(async_reset_neg      )
+      ,.sel_i            (tag_r_async.cdt      )
+      ,.we_o             (cdt_to_fdt_trigger_lo)
+      ,.o                (cdt_lo)
+      );
+
+   // instantiate FDT (fine delay tuner)
+   // captures config state on positive edge of (inverted) input clk
+   // non-inverting
+
+   bsg_rp_clk_gen_fine_delay_tuner fdt
+     (.i                 (cdt_lo)
+      ,.we_i             (cdt_to_fdt_trigger_lo)
+      ,.async_reset_neg_i(async_reset_neg)
+      ,.sel_i            (tag_r_async.fdt)
+      ,.o                (fb_clk)     // in the actual critical loop
+      ,.buf_o            (clk_o)     // outside this module
+      );
+
+   //always @(*)
+   //  $display("%m async_reset_neg=%b fb_clk=%b adg_int=%b fb_tag_r=%b fb_we_r=%b",
+   //           async_reset_neg,fb_clk,adg_int,fb_tag_r,fb_we_r);
+
+endmodule // bsg_clk_gen_osc
+
+`BSG_ABSTRACT_MODULE(bsg_dly_line)
+
+

--- a/hard/tsmc_28/bsg_clk_gen/bsg_dly_line.v
+++ b/hard/tsmc_28/bsg_clk_gen/bsg_dly_line.v
@@ -132,7 +132,7 @@ module bsg_dly_line
   wire clk_inv;
   assign clk_inv = ~clk_i;
 
-   bsg_rp_clk_gen_atomic_delay_tuner  adt
+   bsg_rp_clk_gen_atomic_delay_tuner  adt_BSG_DONT_TOUCH
      (.i(clk_inv)
       ,.we_async_i (tag_trigger_r_async   )
       ,.we_inited_i(bsg_tag_trigger_i.en  )
@@ -146,7 +146,7 @@ module bsg_dly_line
    // this one inverts the output
    // captures config state on negative edge of input clock
 
-   bsg_rp_clk_gen_coarse_delay_tuner cdt
+   bsg_rp_clk_gen_coarse_delay_tuner cdt_BSG_DONT_TOUCH
      (.i                 (adt_lo)
       ,.we_i             (adt_to_cdt_trigger_lo)
       ,.async_reset_neg_i(async_reset_neg      )
@@ -159,7 +159,7 @@ module bsg_dly_line
    // captures config state on positive edge of (inverted) input clk
    // non-inverting
 
-   bsg_rp_clk_gen_fine_delay_tuner fdt
+   bsg_rp_clk_gen_fine_delay_tuner fdt_BSG_DONT_TOUCH
      (.i                 (cdt_lo)
       ,.we_i             (cdt_to_fdt_trigger_lo)
       ,.async_reset_neg_i(async_reset_neg)
@@ -172,7 +172,7 @@ module bsg_dly_line
    //  $display("%m async_reset_neg=%b fb_clk=%b adg_int=%b fb_tag_r=%b fb_we_r=%b",
    //           async_reset_neg,fb_clk,adg_int,fb_tag_r,fb_we_r);
 
-endmodule // bsg_clk_gen_osc
+endmodule // bsg_dly_line
 
 `BSG_ABSTRACT_MODULE(bsg_dly_line)
 

--- a/hard/tsmc_28/bsg_clk_gen/bsg_rp_clk_gen_atomic_delay_tuner.v
+++ b/hard/tsmc_28/bsg_clk_gen/bsg_rp_clk_gen_atomic_delay_tuner.v
@@ -4,7 +4,7 @@
 //
 // module bsg_clk_gen_coarse_delay_element #(parameter `BSG_INV_PARAM(start_tap_p))
 //
-// DWP 10/6/2021: Ported from TSMC40 to TSMC28 by reusing cells and appending 7T40P140 for the specific cell lib
+// DWP 10/6/2021: Ported from TSMC40 to TSMC28 by reusing cells and appending 7T30P140ULVT for the specific cell lib
 
 module bsg_rp_clk_gen_atomic_delay_tuner
   (input i
@@ -28,32 +28,30 @@ module bsg_rp_clk_gen_atomic_delay_tuner
    // synopsys rp_group (bsg_clk_gen_adt)
    // synopsys rp_fill (13 2 LX)
 
-   CKND2BWP7T40P140 I1  (.I(signal[0]), .ZN(signal[1]) );
-   CKND2BWP7T40P140 I2  (.I(signal[1]), .ZN(signal[2]) );
-   CKND4BWP7T40P140 I2a (.I(signal[1]), .ZN()          );
+   CKND2BWP7T30P140ULVT I1  (.I(signal[0]), .ZN(signal[1]) );
+   CKND2BWP7T30P140ULVT I2  (.I(signal[1]), .ZN(signal[2]) );
+   CKND2BWP7T30P140ULVT I2a (.I(signal[1]), .ZN()          );
 
-   CKND2BWP7T40P140 I3  (.I(signal[2]), .ZN(signal[3]) );
-   CKND2BWP7T40P140 I4  (.I(signal[3]), .ZN(signal[4]) );
-   CKND4BWP7T40P140 I4a (.I(signal[3]), .ZN()          );
-   CKND2BWP7T40P140 I4b (.I(signal[3]), .ZN()          ); // this is an extra gate because
+   CKND2BWP7T30P140ULVT I3  (.I(signal[2]), .ZN(signal[3]) );
+   CKND2BWP7T30P140ULVT I4  (.I(signal[3]), .ZN(signal[4]) );
+   CKND4BWP7T30P140ULVT I4a (.I(signal[3]), .ZN()          );
+   CKND2BWP7T30P140ULVT I4b (.I(signal[3]), .ZN()          );
                                                         // we are not attaching to the mux
                                                         // cap tries to match that of mux input
-   CKND2BWP7T40P140 I5  (.I(signal[4]), .ZN(signal[5]) );
-   CKND2BWP7T40P140 I6  (.I(signal[5]), .ZN(signal[6]) );
-   CKND4BWP7T40P140 I6a (.I(signal[5]), .ZN()          );
+   CKND2BWP7T30P140ULVT I5  (.I(signal[4]), .ZN(signal[5]) );
+   CKND4BWP7T30P140ULVT I6  (.I(signal[5]), .ZN(signal[6]) );
+   CKND4BWP7T30P140ULVT I6a (.I(signal[5]), .ZN()          );
 
-   CKND2BWP7T40P140 I7  (.I(signal[6]), .ZN(signal[7]) );
-   CKND2BWP7T40P140 I8  (.I(signal[7]), .ZN(signal[8]) );
-
-   CKND4BWP7T40P140 I8a (.I(signal[7]), .ZN()          );
-   CKND3BWP7T40P140 I8b (.I(signal[7]), .ZN()          ); // fudge factor capacitance
+   CKND2BWP7T30P140ULVT I7  (.I(signal[6]), .ZN(signal[7]) );
+   CKND2BWP7T30P140ULVT I8  (.I(signal[7]), .ZN(signal[8]) );
+   CKND4BWP7T30P140ULVT I8a (.I(signal[7]), .ZN()          );
+   CKND3BWP7T30P140ULVT I8b (.I(signal[7]), .ZN()          );
 
    // synopsys rp_fill (0 1 RX)
 
    wire       zero_bit;
 
-
-   MUX4ND4BWP7T40P140 M1 ( .I0(signal[8])
+   MUX4ND4BWP7T30P140ULVT M1 ( .I0(signal[8])
                         ,.I1(signal[6])
                         ,.I2(zero_bit)
                         ,.I3(signal[0])
@@ -69,27 +67,27 @@ module bsg_rp_clk_gen_atomic_delay_tuner
    // synopsys rp_fill (0 0 RX)
 
    // this gate picks input 01 when async reset is low, initializing the oscillator
-   IND2D2BWP7T40P140 NB (.A1(sel_r[0]), .B1(async_reset_neg_i), .ZN(sel_r[1]));
-   TIELBWP7T40P140   ZB (.ZN(zero_bit));
+   IND2D2BWP7T30P140ULVT NB (.A1(sel_r[0]), .B1(async_reset_neg_i), .ZN(sel_r[1]));
+   TIELBWP7T30P140ULVT   ZB (.ZN(zero_bit));
 
-   DFCND4BWP7T40P140 sel_r_reg_0 (.D(mux_lo[0]), .CP(o)      ,.CDN(async_reset_neg_i), .Q(sel_r[0]), .QN());
-   //LHCND4BWP7T40P140 sel_r_latch_0 (.D(mux_lo[0]), .E(o)      ,.CDN(async_reset_neg_i), .Q(sel_r[0]), .QN());
+   DFCND4BWP7T30P140ULVT sel_r_reg_0 (.D(mux_lo[0]), .CP(o)      ,.CDN(async_reset_neg_i), .Q(sel_r[0]), .QN());
+   //LHCND4BWP7T30P140ULVT sel_r_latch_0 (.D(mux_lo[0]), .E(o)      ,.CDN(async_reset_neg_i), .Q(sel_r[0]), .QN());
 
    // inputs are reversed because select is inverted
    // we_i&we_inited_i=1 -> new value  (I0)
    // we_i&we_inited-i=0 -> use value in register (I1)
-   MUX2D1BWP7T40P140 MX1          ( .I0(sel_i), .I1(sel_r[0]), .S(we_i_sync_sync_nand), .Z(mux_lo[0]));
+   MUX2D1BWP7T30P140ULVT MX1          ( .I0(sel_i), .I1(sel_r[0]), .S(we_i_sync_sync_nand), .Z(mux_lo[0]));
 
    // nand 10ps versus 22ps
-   ND2D1BWP7T40P140 bsg_we_nand   (.A1(we_i_sync_sync), .A2(we_inited_i), .ZN(we_i_sync_sync_nand));
+   ND2D1BWP7T30P140ULVT bsg_we_nand   (.A1(we_i_sync_sync), .A2(we_inited_i), .ZN(we_i_sync_sync_nand));
    // synchronizer flops; negative edge triggered
-   //DFND1BWP7T40P140 bsg_SYNC_2_r  (.D(we_i_sync), .CPN(o), .Q(we_i_sync_sync), .QN());
-   //DFND1BWP7T40P140 bsg_SYNC_1_r  (.D(we_async_i),     .CPN(o), .Q(we_i_sync),      .QN());
-   DFNCND1BWP7T40P140 bsg_SYNC_2_r  (.D(we_i_sync),  .CPN(o), .CDN(async_reset_neg_i), .Q(we_i_sync_sync), .QN());
-   DFNCND1BWP7T40P140 bsg_SYNC_1_r  (.D(we_async_i), .CPN(o), .CDN(async_reset_neg_i), .Q(we_i_sync),      .QN());
+   //DFND1BWP7T30P140ULVT bsg_SYNC_2_r  (.D(we_i_sync), .CPN(o), .Q(we_i_sync_sync), .QN());
+   //DFND1BWP7T30P140ULVT bsg_SYNC_1_r  (.D(we_async_i),     .CPN(o), .Q(we_i_sync),      .QN());
+   DFNCND1BWP7T30P140ULVT bsg_SYNC_2_r  (.D(we_i_sync),  .CPN(o), .CDN(async_reset_neg_i), .Q(we_i_sync_sync), .QN());
+   DFNCND1BWP7T30P140ULVT bsg_SYNC_1_r  (.D(we_async_i), .CPN(o), .CDN(async_reset_neg_i), .Q(we_i_sync),      .QN());
    // drive we signal to next CDT; minimize capacitive load on critical we_i path
-   INVD0BWP7T40P140 we_o_pre      (.I(we_i_sync_sync_nand), .ZN(we_o_pre_buf));
-   BUFFD4BWP7T40P140 we_o_buf     (.I(we_o_pre_buf),. Z(we_o));
+   INVD0BWP7T30P140ULVT we_o_pre      (.I(we_i_sync_sync_nand), .ZN(we_o_pre_buf));
+   BUFFD4BWP7T30P140ULVT we_o_buf     (.I(we_o_pre_buf),. Z(we_o));
 
    // synopsys rp_endgroup (bsg_clk_gen_adt)
 

--- a/hard/tsmc_28/bsg_clk_gen/bsg_rp_clk_gen_atomic_delay_tuner.v
+++ b/hard/tsmc_28/bsg_clk_gen/bsg_rp_clk_gen_atomic_delay_tuner.v
@@ -75,8 +75,6 @@ module bsg_rp_clk_gen_atomic_delay_tuner
    DFCND4BWP7T40P140 sel_r_reg_0 (.D(mux_lo[0]), .CP(o)      ,.CDN(async_reset_neg_i), .Q(sel_r[0]), .QN());
    //LHCND4BWP7T40P140 sel_r_latch_0 (.D(mux_lo[0]), .E(o)      ,.CDN(async_reset_neg_i), .Q(sel_r[0]), .QN());
 
-   // 40nm: non-inverting mux 32.5ps + load S->Z
-   // 40nm: inverting     mux 43ps + load  S->ZN
    // inputs are reversed because select is inverted
    // we_i&we_inited_i=1 -> new value  (I0)
    // we_i&we_inited-i=0 -> use value in register (I1)

--- a/hard/tsmc_28/bsg_clk_gen/bsg_rp_clk_gen_atomic_delay_tuner.v
+++ b/hard/tsmc_28/bsg_clk_gen/bsg_rp_clk_gen_atomic_delay_tuner.v
@@ -1,0 +1,99 @@
+// bsg_rp_clk_gen_coarse_delay_element
+//
+// o       contains controllably delayed signal
+//
+// module bsg_clk_gen_coarse_delay_element #(parameter `BSG_INV_PARAM(start_tap_p))
+//
+// DWP 10/6/2021: Ported to TSMC28 by reusing cells and appending 30P140 for the specific cell lib
+
+module bsg_rp_clk_gen_atomic_delay_tuner
+  (input i
+
+   , input  sel_i
+   , input  we_async_i
+   , input  we_inited_i  // basically says we_async_i should have successfully passed through
+                         // the generated clock's synchronizers; i.e. the generated clock is
+                         // running and the bsg_tag_slave and client have been initialized
+   , input async_reset_neg_i
+   , output we_o
+   , output o
+   );
+
+   wire [1:0] sel_r;
+   wire [8:0] signal;
+   wire       we_o_pre_buf;
+
+   assign signal[0] = i;
+
+   // synopsys rp_group (bsg_clk_gen_adt)
+   // synopsys rp_fill (13 2 LX)
+
+   CKND2BWP7T40P140 I1  (.I(signal[0]), .ZN(signal[1]) );
+   CKND2BWP7T40P140 I2  (.I(signal[1]), .ZN(signal[2]) );
+   CKND4BWP7T40P140 I2a (.I(signal[1]), .ZN()          );
+
+   CKND2BWP7T40P140 I3  (.I(signal[2]), .ZN(signal[3]) );
+   CKND2BWP7T40P140 I4  (.I(signal[3]), .ZN(signal[4]) );
+   CKND4BWP7T40P140 I4a (.I(signal[3]), .ZN()          );
+   CKND2BWP7T40P140 I4b (.I(signal[3]), .ZN()          ); // this is an extra gate because
+                                                        // we are not attaching to the mux
+                                                        // cap tries to match that of mux input
+   CKND2BWP7T40P140 I5  (.I(signal[4]), .ZN(signal[5]) );
+   CKND2BWP7T40P140 I6  (.I(signal[5]), .ZN(signal[6]) );
+   CKND4BWP7T40P140 I6a (.I(signal[5]), .ZN()          );
+
+   CKND2BWP7T40P140 I7  (.I(signal[6]), .ZN(signal[7]) );
+   CKND2BWP7T40P140 I8  (.I(signal[7]), .ZN(signal[8]) );
+
+   CKND4BWP7T40P140 I8a (.I(signal[7]), .ZN()          );
+   CKND3BWP7T40P140 I8b (.I(signal[7]), .ZN()          ); // fudge factor capacitance
+
+   // synopsys rp_fill (0 1 RX)
+
+   wire       zero_bit;
+
+
+   MUX4ND4BWP7T40P140 M1 ( .I0(signal[8])
+                        ,.I1(signal[6])
+                        ,.I2(zero_bit)
+                        ,.I3(signal[0])
+
+                        ,.S0(sel_r[0])
+                        ,.S1(sel_r[1])
+                        ,.ZN(o   )
+                         );
+
+   wire [1:0] mux_lo;
+   wire       we_i_sync, we_i_sync_sync, we_i_sync_sync_nand;
+
+   // synopsys rp_fill (0 0 RX)
+
+   // this gate picks input 01 when async reset is low, initializing the oscillator
+   IND2D2BWP7T40P140 NB (.A1(sel_r[0]), .B1(async_reset_neg_i), .ZN(sel_r[1]));
+   TIELBWP7T40P140   ZB (.ZN(zero_bit));
+
+   DFCND4BWP7T40P140 sel_r_reg_0 (.D(mux_lo[0]), .CP(o)      ,.CDN(async_reset_neg_i), .Q(sel_r[0]), .QN());
+   //LHCND4BWP7T40P140 sel_r_latch_0 (.D(mux_lo[0]), .E(o)      ,.CDN(async_reset_neg_i), .Q(sel_r[0]), .QN());
+
+   // 40nm: non-inverting mux 32.5ps + load S->Z
+   // 40nm: inverting     mux 43ps + load  S->ZN
+   // inputs are reversed because select is inverted
+   // we_i&we_inited_i=1 -> new value  (I0)
+   // we_i&we_inited-i=0 -> use value in register (I1)
+   MUX2D1BWP7T40P140 MX1          ( .I0(sel_i), .I1(sel_r[0]), .S(we_i_sync_sync_nand), .Z(mux_lo[0]));
+
+   // nand 10ps versus 22ps
+   ND2D1BWP7T40P140 bsg_we_nand   (.A1(we_i_sync_sync), .A2(we_inited_i), .ZN(we_i_sync_sync_nand));
+   // synchronizer flops; negative edge triggered
+   //DFND1BWP7T40P140 bsg_SYNC_2_r  (.D(we_i_sync), .CPN(o), .Q(we_i_sync_sync), .QN());
+   //DFND1BWP7T40P140 bsg_SYNC_1_r  (.D(we_async_i),     .CPN(o), .Q(we_i_sync),      .QN());
+   DFNCND1BWP7T40P140 bsg_SYNC_2_r  (.D(we_i_sync),  .CPN(o), .CDN(async_reset_neg_i), .Q(we_i_sync_sync), .QN());
+   DFNCND1BWP7T40P140 bsg_SYNC_1_r  (.D(we_async_i), .CPN(o), .CDN(async_reset_neg_i), .Q(we_i_sync),      .QN());
+   // drive we signal to next CDT; minimize capacitive load on critical we_i path
+   INVD0BWP7T40P140 we_o_pre      (.I(we_i_sync_sync_nand), .ZN(we_o_pre_buf));
+   BUFFD4BWP7T40P140 we_o_buf     (.I(we_o_pre_buf),. Z(we_o));
+
+   // synopsys rp_endgroup (bsg_clk_gen_adt)
+
+endmodule
+

--- a/hard/tsmc_28/bsg_clk_gen/bsg_rp_clk_gen_atomic_delay_tuner.v
+++ b/hard/tsmc_28/bsg_clk_gen/bsg_rp_clk_gen_atomic_delay_tuner.v
@@ -4,7 +4,7 @@
 //
 // module bsg_clk_gen_coarse_delay_element #(parameter `BSG_INV_PARAM(start_tap_p))
 //
-// DWP 10/6/2021: Ported to TSMC28 by reusing cells and appending 30P140 for the specific cell lib
+// DWP 10/6/2021: Ported from TSMC40 to TSMC28 by reusing cells and appending 7T40P140 for the specific cell lib
 
 module bsg_rp_clk_gen_atomic_delay_tuner
   (input i

--- a/hard/tsmc_28/bsg_clk_gen/bsg_rp_clk_gen_coarse_delay_tuner.v
+++ b/hard/tsmc_28/bsg_clk_gen/bsg_rp_clk_gen_coarse_delay_tuner.v
@@ -12,7 +12,7 @@
 //
 // module bsg_clk_gen_coarse_delay_element #(parameter `BSG_INV_PARAM(start_tap_p))
 //
-// DWP 10/6/2021: Ported from TSMC40 to TSMC28 by reusing cells and appending 7T40P140 for the specific cell lib
+// DWP 10/6/2021: Ported from TSMC40 to TSMC28 by reusing cells and appending 7T30P140ULVT for the specific cell lib
 
 module bsg_rp_clk_gen_coarse_delay_tuner
   (input i
@@ -32,24 +32,24 @@ module bsg_rp_clk_gen_coarse_delay_tuner
    // synopsys rp_group (bsg_clk_gen_cdt)
    // synopsys rp_fill (0 0 RX)
 
-   CKND2BWP7T40P140 I1  (.I(signal[0]), .ZN(signal[1]) );
-   CKND2BWP7T40P140 I2  (.I(signal[1]), .ZN(signal[2]) );
-   CKND4BWP7T40P140 I2a (.I(signal[1]), .ZN()          );
+   CKND2BWP7T30P140ULVT  I1  (.I(signal[0]), .ZN(signal[1]) );
+   CKND2BWP7T30P140ULVT  I2  (.I(signal[1]), .ZN(signal[2]) );
+   CKND4BWP7T30P140ULVT I2a (.I(signal[1]), .ZN()          );
 
-   CKND2BWP7T40P140 I3  (.I(signal[2]), .ZN(signal[3]) );
-   CKND2BWP7T40P140 I4  (.I(signal[3]), .ZN(signal[4]) );
-   CKND4BWP7T40P140 I4a (.I(signal[3]), .ZN()          );
+   CKND2BWP7T30P140ULVT  I3  (.I(signal[2]), .ZN(signal[3]) );
+   CKND2BWP7T30P140ULVT  I4  (.I(signal[3]), .ZN(signal[4]) );
+   CKND8BWP7T30P140ULVT I4a (.I(signal[3]), .ZN()          );
 
-   CKND2BWP7T40P140 I5  (.I(signal[4]), .ZN(signal[5]) );
-   CKND2BWP7T40P140 I6  (.I(signal[5]), .ZN(signal[6]) );
-   CKND4BWP7T40P140 I6a (.I(signal[5]), .ZN()          );
+   CKND2BWP7T30P140ULVT  I5  (.I(signal[4]), .ZN(signal[5]) );
+   CKND2BWP7T30P140ULVT  I6  (.I(signal[5]), .ZN(signal[6]) );
+   CKND4BWP7T30P140ULVT I6a (.I(signal[5]), .ZN()          );
 
-   CKND2BWP7T40P140 I7  (.I(signal[6]), .ZN(signal[7]) );
-   CKND2BWP7T40P140 I8  (.I(signal[7]), .ZN(signal[8]) );
+   CKND2BWP7T30P140ULVT  I7  (.I(signal[6]), .ZN(signal[7]) );
+   CKND2BWP7T30P140ULVT  I8  (.I(signal[7]), .ZN(signal[8]) );
 
    // synopsys rp_fill (0 1 RX)
 
-   MUX4ND4BWP7T40P140 M1 ( .I0(signal[6])       // start_tap_p + 6
+   MUX4ND4BWP7T30P140ULVT M1 ( .I0(signal[6])       // start_tap_p + 6
                         ,.I1(signal[4])       // start_tap_p + 4
                         ,.I2(signal[2])       // start_tap_p + 2
                         ,.I3(signal[0])       // start_tap_p + 0
@@ -63,16 +63,16 @@ module bsg_rp_clk_gen_coarse_delay_tuner
 
    // synopsys rp_fill (0 2 RX)
 
-   DFNCND4BWP7T40P140 sel_r_reg_0 (.D(mux_lo[0]), .CPN(o), .CDN(async_reset_neg_i), .Q(sel_r[0]), .QN());
-   MUX2D1BWP7T40P140 MX1 (.I0(sel_r[0]),.I1(sel_i[0]),.S(we_i), .Z(mux_lo[0]));
+   DFNCND4BWP7T30P140ULVT sel_r_reg_0 (.D(mux_lo[0]), .CPN(o), .CDN(async_reset_neg_i), .Q(sel_r[0]), .QN());
+   MUX2D1BWP7T30P140ULVT MX1 (.I0(sel_r[0]),.I1(sel_i[0]),.S(we_i), .Z(mux_lo[0]));
 
    // synopsys rp_fill (0 3 RX)
 
-   DFNCND4BWP7T40P140 sel_r_reg_1 (.D(mux_lo[1]), .CPN(o), .CDN(async_reset_neg_i), .Q(sel_r[1]), .QN());
-   MUX2D1BWP7T40P140 MX2 (.I0(sel_r[1]),.I1(sel_i[1]),.S(we_i), .Z(mux_lo[1]));
+   DFNCND4BWP7T30P140ULVT sel_r_reg_1 (.D(mux_lo[1]), .CPN(o), .CDN(async_reset_neg_i), .Q(sel_r[1]), .QN());
+   MUX2D1BWP7T30P140ULVT MX2 (.I0(sel_r[1]),.I1(sel_i[1]),.S(we_i), .Z(mux_lo[1]));
 
    // synopsys rp_fill (0 4 RX)
-   BUFFD4BWP7T40P140 we_o_buf (.I(we_i), .Z(we_o));
+   BUFFD4BWP7T30P140ULVT we_o_buf (.I(we_i), .Z(we_o));
 
    // synopsys rp_endgroup (bsg_clk_gen_cdt)
 

--- a/hard/tsmc_28/bsg_clk_gen/bsg_rp_clk_gen_coarse_delay_tuner.v
+++ b/hard/tsmc_28/bsg_clk_gen/bsg_rp_clk_gen_coarse_delay_tuner.v
@@ -12,7 +12,7 @@
 //
 // module bsg_clk_gen_coarse_delay_element #(parameter `BSG_INV_PARAM(start_tap_p))
 //
-// DWP 10/6/2021: Ported to TSMC28 by reusing cells and appending 7T40P140 for the specific cell lib
+// DWP 10/6/2021: Ported from TSMC40 to TSMC28 by reusing cells and appending 7T40P140 for the specific cell lib
 
 module bsg_rp_clk_gen_coarse_delay_tuner
   (input i

--- a/hard/tsmc_28/bsg_clk_gen/bsg_rp_clk_gen_coarse_delay_tuner.v
+++ b/hard/tsmc_28/bsg_clk_gen/bsg_rp_clk_gen_coarse_delay_tuner.v
@@ -12,7 +12,7 @@
 //
 // module bsg_clk_gen_coarse_delay_element #(parameter `BSG_INV_PARAM(start_tap_p))
 //
-// DWP 10/6/2021: Ported to TSMC28 by reusing cells and appending 30P140 for the specific cell lib
+// DWP 10/6/2021: Ported to TSMC28 by reusing cells and appending 7T40P140 for the specific cell lib
 
 module bsg_rp_clk_gen_coarse_delay_tuner
   (input i

--- a/hard/tsmc_28/bsg_clk_gen/bsg_rp_clk_gen_coarse_delay_tuner.v
+++ b/hard/tsmc_28/bsg_clk_gen/bsg_rp_clk_gen_coarse_delay_tuner.v
@@ -1,0 +1,80 @@
+// bsg_rp_clk_gen_coarse_delay_element
+//
+// (o       is inverting on even start_tap_p
+//  worst_o is non-inverting)
+//
+// o       contains controllably delayed signal
+// worst_o contains worst-case   delayed signal (for delay matching)
+//
+//
+// we use sed to substitute parameters because the netlist reader
+// does not like them, and we need the netlist reader for rp_groups
+//
+// module bsg_clk_gen_coarse_delay_element #(parameter `BSG_INV_PARAM(start_tap_p))
+//
+// DWP 10/6/2021: Ported to TSMC28 by reusing cells and appending 30P140 for the specific cell lib
+
+module bsg_rp_clk_gen_coarse_delay_tuner
+  (input i
+
+   , input  [1:0] sel_i
+   , input  we_i
+   , input async_reset_neg_i
+   , output       o
+   , output we_o
+   );
+
+   wire [1:0] sel_r;
+   wire [8:0] signal;
+
+   assign signal[0] = i;
+
+   // synopsys rp_group (bsg_clk_gen_cdt)
+   // synopsys rp_fill (0 0 RX)
+
+   CKND2BWP7T40P140 I1  (.I(signal[0]), .ZN(signal[1]) );
+   CKND2BWP7T40P140 I2  (.I(signal[1]), .ZN(signal[2]) );
+   CKND4BWP7T40P140 I2a (.I(signal[1]), .ZN()          );
+
+   CKND2BWP7T40P140 I3  (.I(signal[2]), .ZN(signal[3]) );
+   CKND2BWP7T40P140 I4  (.I(signal[3]), .ZN(signal[4]) );
+   CKND4BWP7T40P140 I4a (.I(signal[3]), .ZN()          );
+
+   CKND2BWP7T40P140 I5  (.I(signal[4]), .ZN(signal[5]) );
+   CKND2BWP7T40P140 I6  (.I(signal[5]), .ZN(signal[6]) );
+   CKND4BWP7T40P140 I6a (.I(signal[5]), .ZN()          );
+
+   CKND2BWP7T40P140 I7  (.I(signal[6]), .ZN(signal[7]) );
+   CKND2BWP7T40P140 I8  (.I(signal[7]), .ZN(signal[8]) );
+
+   // synopsys rp_fill (0 1 RX)
+
+   MUX4ND4BWP7T40P140 M1 ( .I0(signal[6])       // start_tap_p + 6
+                        ,.I1(signal[4])       // start_tap_p + 4
+                        ,.I2(signal[2])       // start_tap_p + 2
+                        ,.I3(signal[0])       // start_tap_p + 0
+
+                        ,.S0(sel_r[0])
+                        ,.S1(sel_r[1])
+                        ,.ZN (o   )
+                         );
+
+   wire [1:0] mux_lo;
+
+   // synopsys rp_fill (0 2 RX)
+
+   DFNCND4BWP7T40P140 sel_r_reg_0 (.D(mux_lo[0]), .CPN(o), .CDN(async_reset_neg_i), .Q(sel_r[0]), .QN());
+   MUX2D1BWP7T40P140 MX1 (.I0(sel_r[0]),.I1(sel_i[0]),.S(we_i), .Z(mux_lo[0]));
+
+   // synopsys rp_fill (0 3 RX)
+
+   DFNCND4BWP7T40P140 sel_r_reg_1 (.D(mux_lo[1]), .CPN(o), .CDN(async_reset_neg_i), .Q(sel_r[1]), .QN());
+   MUX2D1BWP7T40P140 MX2 (.I0(sel_r[1]),.I1(sel_i[1]),.S(we_i), .Z(mux_lo[1]));
+
+   // synopsys rp_fill (0 4 RX)
+   BUFFD4BWP7T40P140 we_o_buf (.I(we_i), .Z(we_o));
+
+   // synopsys rp_endgroup (bsg_clk_gen_cdt)
+
+endmodule
+

--- a/hard/tsmc_28/bsg_clk_gen/bsg_rp_clk_gen_fine_delay_tuner.v
+++ b/hard/tsmc_28/bsg_clk_gen/bsg_rp_clk_gen_fine_delay_tuner.v
@@ -4,7 +4,7 @@
 //
 // o is delayed signal, non-inverted
 //
-// DWP 10/6/2021: Ported to TSMC28 by reusing cells and appending 30P140 for the specific cell lib
+// DWP 10/6/2021: Ported to TSMC28 by reusing cells and appending 7T40P140 for the specific cell lib
 
 module bsg_rp_clk_gen_fine_delay_tuner
   (input i

--- a/hard/tsmc_28/bsg_clk_gen/bsg_rp_clk_gen_fine_delay_tuner.v
+++ b/hard/tsmc_28/bsg_clk_gen/bsg_rp_clk_gen_fine_delay_tuner.v
@@ -4,7 +4,7 @@
 //
 // o is delayed signal, non-inverted
 //
-// DWP 10/6/2021: Ported from TSMC40 to TSMC28 by reusing cells and appending 7T40P140 for the specific cell lib
+// DWP 10/6/2021: Ported from TSMC40 to TSMC28 by reusing cells and appending 7T30P140ULVT for the specific cell lib
 
 module bsg_rp_clk_gen_fine_delay_tuner
   (input i
@@ -30,44 +30,44 @@ module bsg_rp_clk_gen_fine_delay_tuner
    // synopsys rp_fill (0 0 UX)
 
    // synopsys rp_orient ({N FS} I2_1)
-   CKND3BWP7T40P140 I2_1 (.I(ft[1]),.ZN());
+   CKND3BWP7T30P140ULVT I2_1 (.I(ft[1]),.ZN());
    // synopsys rp_orient ({N FS} I3_1)
-   CKND3BWP7T40P140 I3_1 (.I(ft[2]),.ZN());
+   CKND3BWP7T30P140ULVT I3_1 (.I(ft[2]),.ZN());
    // synopsys rp_orient ({N FS} I3_2)
-   CKND4BWP7T40P140 I3_2 (.I(ft[2]),.ZN());
+   CKND4BWP7T30P140ULVT I3_2 (.I(ft[2]),.ZN());
    // synopsys rp_orient ({N FS} I4_1)
-   CKND3BWP7T40P140 I4_1 (.I(ft[3]),.ZN());
+   CKND3BWP7T30P140ULVT I4_1 (.I(ft[3]),.ZN());
    // synopsys rp_orient ({N FS} I4_2)
-   CKND4BWP7T40P140 I4_2 (.I(ft[3]),.ZN());
+   CKND4BWP7T30P140ULVT I4_2 (.I(ft[3]),.ZN());
    // synopsys rp_orient ({N FS} I4_3)
-   CKND4BWP7T40P140 I4_3 (.I(ft[3]),.ZN());
+   CKND4BWP7T30P140ULVT I4_3 (.I(ft[3]),.ZN());
 
    // same driver with different caps and thus different transition times
    // synopsys rp_fill (1 0 UX)
-   CKND4BWP7T40P140 I0 (.I(i), .ZN(i_inv));     // decouple load of FDT from previous stage; also makes this inverting
-   CKND2BWP7T40P140 I1 (.I(i_inv), .ZN(ft[0]));
-   CKND2BWP7T40P140 I2 (.I(i_inv), .ZN(ft[1]));
-   CKND2BWP7T40P140 I3 (.I(i_inv), .ZN(ft[2]));
-   CKND2BWP7T40P140 I4 (.I(i_inv), .ZN(ft[3]));
+   CKND4BWP7T30P140ULVT I0 (.I(i), .ZN(i_inv));     // decouple load of FDT from previous stage; also makes this inverting
+   CKND2BWP7T30P140ULVT I1 (.I(i_inv), .ZN(ft[0]));
+   CKND2BWP7T30P140ULVT I2 (.I(i_inv), .ZN(ft[1]));
+   CKND2BWP7T30P140ULVT I3 (.I(i_inv), .ZN(ft[2]));
+   CKND2BWP7T30P140ULVT I4 (.I(i_inv), .ZN(ft[3]));
 
    // flops catch on positive edge of inverted clock
 
    // synopsys rp_fill (2 0 UX)
-   MUX2D1BWP7T40P140   MX1 (.I0(sel_r [0]),.I1  (sel_i[0]), .S(we_i)    ,.Z(mux_lo[0]         ));
-   DFCND4BWP7T40P140 DFFR1 (.D(mux_lo[0]),.CP(o), .Q (sel_r[0]), .QN(), .CDN(async_reset_neg_i));
+   MUX2D1BWP7T30P140ULVT   MX1 (.I0(sel_r [0]),.I1  (sel_i[0]), .S(we_i)    ,.Z(mux_lo[0]         ));
+   DFCND4BWP7T30P140ULVT DFFR1 (.D(mux_lo[0]),.CP(o), .Q (sel_r[0]), .QN(), .CDN(async_reset_neg_i));
 
-   MUX4ND4BWP7T40P140 M2 (.I0(ft[3]), .I1(ft[2]), .I2(ft[1]), .I3(ft[0])
+   MUX4ND4BWP7T30P140ULVT M2 (.I0(ft[3]), .I1(ft[2]), .I2(ft[1]), .I3(ft[0])
               ,.S0(sel_r[0]), .S1(sel_r[1])
               ,.ZN(o)
               );
 
    // capture on positive edge
-   DFCND4BWP7T40P140 DFFR2 (.D(mux_lo[1]),.CP(o), .Q (sel_r[1]), .QN(), .CDN(async_reset_neg_i));
-   MUX2D1BWP7T40P140   MX2 (.I0(sel_r [1]),.I1  (sel_i[1]), .S(we_i)    ,.Z(mux_lo[1]         ));
+   DFCND4BWP7T30P140ULVT DFFR2 (.D(mux_lo[1]),.CP(o), .Q (sel_r[1]), .QN(), .CDN(async_reset_neg_i));
+   MUX2D1BWP7T30P140ULVT   MX2 (.I0(sel_r [1]),.I1  (sel_i[1]), .S(we_i)    ,.Z(mux_lo[1]         ));
 
    // synopsys rp_fill (3 2 UX)
 
-   CKBD8BWP7T40P140 ICLK (.I(o),        .Z(buf_o) );
+   CKBD8BWP7T30P140ULVT ICLK (.I(o),        .Z(buf_o) );
 
    // synopsys rp_endgroup(bsg_clk_gen_fdt)
 

--- a/hard/tsmc_28/bsg_clk_gen/bsg_rp_clk_gen_fine_delay_tuner.v
+++ b/hard/tsmc_28/bsg_clk_gen/bsg_rp_clk_gen_fine_delay_tuner.v
@@ -4,7 +4,7 @@
 //
 // o is delayed signal, non-inverted
 //
-// DWP 10/6/2021: Ported to TSMC28 by reusing cells and appending 7T40P140 for the specific cell lib
+// DWP 10/6/2021: Ported from TSMC40 to TSMC28 by reusing cells and appending 7T40P140 for the specific cell lib
 
 module bsg_rp_clk_gen_fine_delay_tuner
   (input i

--- a/hard/tsmc_28/bsg_clk_gen/bsg_rp_clk_gen_fine_delay_tuner.v
+++ b/hard/tsmc_28/bsg_clk_gen/bsg_rp_clk_gen_fine_delay_tuner.v
@@ -1,0 +1,75 @@
+
+// bsg_rp_clk_gen_fine_delay_tuner
+// fine-tuned sub-gate granularity of delay tuning
+//
+// o is delayed signal, non-inverted
+//
+// DWP 10/6/2021: Ported to TSMC28 by reusing cells and appending 30P140 for the specific cell lib
+
+module bsg_rp_clk_gen_fine_delay_tuner
+  (input i
+   , input we_i
+   , input async_reset_neg_i
+   , input [1:0] sel_i
+   , output o
+   , output buf_o
+   );
+
+   wire [1:0] sel_r;
+   wire [1:0] mux_lo;
+
+   // if wen, capture the select line shortly after a transition
+   // from 1 to 0 of the input i
+
+   // synopsys rp_group (bsg_clk_gen_fdt)
+   // synopsys rp_fill (0 0 UX)
+
+   wire [3:0] ft;
+   wire       i_inv;
+
+   // synopsys rp_fill (0 0 UX)
+
+   // synopsys rp_orient ({N FS} I2_1)
+   CKND3BWP7T40P140 I2_1 (.I(ft[1]),.ZN());
+   // synopsys rp_orient ({N FS} I3_1)
+   CKND3BWP7T40P140 I3_1 (.I(ft[2]),.ZN());
+   // synopsys rp_orient ({N FS} I3_2)
+   CKND4BWP7T40P140 I3_2 (.I(ft[2]),.ZN());
+   // synopsys rp_orient ({N FS} I4_1)
+   CKND3BWP7T40P140 I4_1 (.I(ft[3]),.ZN());
+   // synopsys rp_orient ({N FS} I4_2)
+   CKND4BWP7T40P140 I4_2 (.I(ft[3]),.ZN());
+   // synopsys rp_orient ({N FS} I4_3)
+   CKND4BWP7T40P140 I4_3 (.I(ft[3]),.ZN());
+
+   // same driver with different caps and thus different transition times
+   // synopsys rp_fill (1 0 UX)
+   CKND4BWP7T40P140 I0 (.I(i), .ZN(i_inv));     // decouple load of FDT from previous stage; also makes this inverting
+   CKND2BWP7T40P140 I1 (.I(i_inv), .ZN(ft[0]));
+   CKND2BWP7T40P140 I2 (.I(i_inv), .ZN(ft[1]));
+   CKND2BWP7T40P140 I3 (.I(i_inv), .ZN(ft[2]));
+   CKND2BWP7T40P140 I4 (.I(i_inv), .ZN(ft[3]));
+
+   // flops catch on positive edge of inverted clock
+
+   // synopsys rp_fill (2 0 UX)
+   MUX2D1BWP7T40P140   MX1 (.I0(sel_r [0]),.I1  (sel_i[0]), .S(we_i)    ,.Z(mux_lo[0]         ));
+   DFCND4BWP7T40P140 DFFR1 (.D(mux_lo[0]),.CP(o), .Q (sel_r[0]), .QN(), .CDN(async_reset_neg_i));
+
+   MUX4ND4BWP7T40P140 M2 (.I0(ft[3]), .I1(ft[2]), .I2(ft[1]), .I3(ft[0])
+              ,.S0(sel_r[0]), .S1(sel_r[1])
+              ,.ZN(o)
+              );
+
+   // capture on positive edge
+   DFCND4BWP7T40P140 DFFR2 (.D(mux_lo[1]),.CP(o), .Q (sel_r[1]), .QN(), .CDN(async_reset_neg_i));
+   MUX2D1BWP7T40P140   MX2 (.I0(sel_r [1]),.I1  (sel_i[1]), .S(we_i)    ,.Z(mux_lo[1]         ));
+
+   // synopsys rp_fill (3 2 UX)
+
+   CKBD8BWP7T40P140 ICLK (.I(o),        .Z(buf_o) );
+
+   // synopsys rp_endgroup(bsg_clk_gen_fdt)
+
+endmodule
+


### PR DESCRIPTION
Adds the clock gen. Part of decomposition of #492. This hasn't been fully validated, but has gone through APR with SDP groups