### PR TITLE
Removing defines from bsg_cache_non_blocking_pkg and bsg_dmc_pkg

### DIFF
--- a/bsg_cache/bsg_cache_non_blocking.v
+++ b/bsg_cache/bsg_cache_non_blocking.v
@@ -10,7 +10,7 @@
  */
 
 
-`include "bsg_defines.v"
+`include "bsg_cache_non_blocking.vh"
 
 module bsg_cache_non_blocking 
   import bsg_cache_non_blocking_pkg::*;

--- a/bsg_cache/bsg_cache_non_blocking.vh
+++ b/bsg_cache/bsg_cache_non_blocking.vh
@@ -1,0 +1,166 @@
+`ifndef BSG_CACHE_NON_BLOCKING_VH
+`define BSG_CACHE_NON_BLOCKING_VH
+
+  `include "bsg_defines.v"
+
+  // bsg_cache_pkt_s
+  //
+  `define declare_bsg_cache_non_blocking_pkt_s(id_width_mp,addr_width_mp,data_width_mp) \
+    typedef struct packed {                                     \
+      logic [id_width_mp-1:0] id;                               \
+      bsg_cache_non_blocking_opcode_e opcode;                   \
+      logic [addr_width_mp-1:0] addr;                           \
+      logic [data_width_mp-1:0] data;                           \
+      logic [(data_width_mp>>3)-1:0] mask;                      \
+    } bsg_cache_non_blocking_pkt_s
+
+
+  `define bsg_cache_non_blocking_pkt_width(id_width_mp,addr_width_mp,data_width_mp) \
+    ($bits(bsg_cache_non_blocking_opcode_e)+id_width_mp+addr_width_mp+data_width_mp+(data_width_mp>>3))
+
+
+  // DMA command
+  //
+  `define declare_bsg_cache_non_blocking_dma_cmd_s(ways_mp,sets_mp,tag_width_mp) \
+    typedef struct packed {                         \
+      logic [`BSG_SAFE_CLOG2(ways_mp)-1:0] way_id;  \
+      logic [`BSG_SAFE_CLOG2(sets_mp)-1:0] index;   \
+      logic refill;                                 \
+      logic evict;                                  \
+      logic [tag_width_mp-1:0] refill_tag;          \
+      logic [tag_width_mp-1:0] evict_tag;           \
+    } bsg_cache_non_blocking_dma_cmd_s
+
+
+  `define bsg_cache_non_blocking_dma_cmd_width(ways_mp,sets_mp,tag_width_mp) \
+    (`BSG_SAFE_CLOG2(ways_mp)+`BSG_SAFE_CLOG2(sets_mp)+((1+tag_width_mp)*2))
+
+
+  // DMA packet
+  //
+  `define declare_bsg_cache_non_blocking_dma_pkt_s(addr_width_mp) \
+    typedef struct packed {               \
+      logic write_not_read;               \
+      logic [addr_width_mp-1:0] addr;     \
+    } bsg_cache_non_blocking_dma_pkt_s
+
+
+  `define bsg_cache_non_blocking_dma_pkt_width(addr_width_mp)    \
+    (1+addr_width_mp)
+
+
+  // data_mem pkt s
+  //
+  `define declare_bsg_cache_non_blocking_data_mem_pkt_s(ways_mp,sets_mp,block_size_in_words_mp,data_width_mp) \
+    typedef struct packed {                                                                \
+      logic write_not_read;                                                                \
+      logic sigext_op;                                                                     \
+      logic mask_op;                                                                       \
+      logic [1:0] size_op;                                                                 \
+      logic [`BSG_SAFE_CLOG2(data_width_mp>>3)-1:0] byte_sel;                               \
+      logic [`BSG_SAFE_CLOG2(ways_mp)-1:0] way_id;                                          \
+      logic [`BSG_SAFE_CLOG2(sets_mp)+`BSG_SAFE_CLOG2(block_size_in_words_mp)-1:0] addr;    \
+      logic [data_width_mp-1:0] data;                                                       \
+      logic [(data_width_mp>>3)-1:0] mask;                                                  \
+    } bsg_cache_non_blocking_data_mem_pkt_s
+
+  `define bsg_cache_non_blocking_data_mem_pkt_width(ways_mp,sets_mp,block_size_in_words_mp,data_width_mp) \
+    (1+1+1+2+`BSG_SAFE_CLOG2(data_width_mp>>3)+`BSG_SAFE_CLOG2(ways_mp)+        \
+      `BSG_SAFE_CLOG2(sets_mp)+`BSG_SAFE_CLOG2(block_size_in_words_mp)+data_width_mp+(data_width_mp>>3))
+
+
+  // tag info s
+  //
+  `define declare_bsg_cache_non_blocking_tag_info_s(tag_width_mp) \
+    typedef struct packed {                   \
+      logic valid;                            \
+      logic lock;                             \
+      logic [tag_width_mp-1:0] tag;           \
+    } bsg_cache_non_blocking_tag_info_s
+
+
+  `define bsg_cache_non_blocking_tag_info_width(tag_width_mp) \
+    (tag_width_mp+2)
+
+  
+  // tag_mem_pkt
+  //
+  `define declare_bsg_cache_non_blocking_tag_mem_pkt_s(ways_mp,sets_mp,data_width_mp,tag_width_mp) \
+    typedef struct packed {                               \
+      logic [`BSG_SAFE_CLOG2(ways_mp)-1:0] way_id;        \
+      logic [`BSG_SAFE_CLOG2(sets_mp)-1:0] index;         \
+      logic [data_width_mp-1:0] data;                     \
+      logic [tag_width_mp-1:0] tag;                       \
+      bsg_cache_non_blocking_tag_op_e opcode;             \
+    } bsg_cache_non_blocking_tag_mem_pkt_s
+
+
+  `define bsg_cache_non_blocking_tag_mem_pkt_width(ways_mp,sets_mp,data_width_mp,tag_width_mp) \
+    (`BSG_SAFE_CLOG2(ways_mp)+`BSG_SAFE_CLOG2(sets_mp)+data_width_mp+tag_width_mp+$bits(bsg_cache_non_blocking_tag_op_e)) 
+
+
+  // stat info s
+  //
+  `define declare_bsg_cache_non_blocking_stat_info_s(ways_mp)    \
+    typedef struct packed {                         \
+      logic [ways_mp-1:0] dirty;                    \
+      logic [ways_mp-2:0] lru_bits;                 \
+    } bsg_cache_non_blocking_stat_info_s
+
+
+  `define bsg_cache_non_blocking_stat_info_width(ways_mp) \
+    (ways_mp+ways_mp-1)
+
+
+  // stat_mem pkt
+  //
+  `define declare_bsg_cache_non_blocking_stat_mem_pkt_s(ways_mp,sets_mp) \
+    typedef struct packed {                               \
+      bsg_cache_non_blocking_stat_op_e opcode;            \
+      logic [`BSG_SAFE_CLOG2(ways_mp)-1:0] way_id;         \
+      logic [`BSG_SAFE_CLOG2(sets_mp)-1:0] index;          \
+    } bsg_cache_non_blocking_stat_mem_pkt_s
+ 
+  `define bsg_cache_non_blocking_stat_mem_pkt_width(ways_mp,sets_mp) \
+    ($bits(bsg_cache_non_blocking_stat_op_e)+`BSG_SAFE_CLOG2(ways_mp)+`BSG_SAFE_CLOG2(sets_mp)) 
+
+
+  // miss FIFO entry
+  //
+  `define declare_bsg_cache_non_blocking_miss_fifo_entry_s(id_width_mp,addr_width_mp,data_width_mp) \
+    typedef struct packed {                   \
+      logic write_not_read;                   \
+      logic block_load;                       \
+      logic [1:0] size_op;                    \
+      logic sigext_op;                        \
+      logic mask_op;                          \
+      logic [id_width_mp-1:0] id;             \
+      logic [addr_width_mp-1:0] addr;         \
+      logic [data_width_mp-1:0] data;         \
+      logic [(data_width_mp>>3)-1:0] mask;    \
+    } bsg_cache_non_blocking_miss_fifo_entry_s;  
+
+  `define bsg_cache_non_blocking_miss_fifo_entry_width(id_width_mp,addr_width_mp,data_width_mp) \
+    (1+1+2+1+1+id_width_mp+addr_width_mp+data_width_mp+(data_width_mp>>3)) 
+
+
+  // MHU dff
+  //
+  `define declare_bsg_cache_non_blocking_mhu_dff_s(id_width_mp,addr_width_mp,tag_width_mp,ways_mp) \
+    typedef struct packed {                                                                 \
+      bsg_cache_non_blocking_decode_s decode;                                               \
+      logic [ways_mp-1:0] valid;                                                           \
+      logic [ways_mp-1:0] lock;                                                            \
+      logic [ways_mp-1:0][tag_width_mp-1:0] tag;                                           \
+      logic [`BSG_SAFE_CLOG2(ways_mp)-1:0] tag_hit_way;                                  \
+      logic tag_hit_found;                                                                \
+      logic [id_width_mp-1:0] id;                                                          \
+      logic [addr_width_mp-1:0] addr;                                                      \
+    } bsg_cache_non_blocking_mhu_dff_s
+
+
+  `define bsg_cache_non_blocking_mhu_dff_width(id_width_mp,addr_width_mp,tag_width_mp,ways_mp) \
+    ($bits(bsg_cache_non_blocking_decode_s)+ways_mp+ways_mp+(ways_mp*tag_width_mp)+`BSG_SAFE_CLOG2(ways_mp)+1+id_width_mp+addr_width_mp)
+
+`endif
+

--- a/bsg_cache/bsg_cache_non_blocking_data_mem.v
+++ b/bsg_cache/bsg_cache_non_blocking_data_mem.v
@@ -8,7 +8,7 @@
  */
 
 
-`include "bsg_defines.v"
+`include "bsg_cache_non_blocking.vh"
 
 module bsg_cache_non_blocking_data_mem
   import bsg_cache_non_blocking_pkg::*;

--- a/bsg_cache/bsg_cache_non_blocking_decode.v
+++ b/bsg_cache/bsg_cache_non_blocking_decode.v
@@ -6,7 +6,7 @@
  */
 
 
-`include "bsg_defines.v"
+`include "bsg_cache_non_blocking.vh"
 
 module bsg_cache_non_blocking_decode
   import bsg_cache_non_blocking_pkg::*;

--- a/bsg_cache/bsg_cache_non_blocking_dma.v
+++ b/bsg_cache/bsg_cache_non_blocking_dma.v
@@ -8,7 +8,7 @@
  */
 
 
-`include "bsg_defines.v"
+`include "bsg_cache_non_blocking.vh"
 
 module bsg_cache_non_blocking_dma
   import bsg_cache_non_blocking_pkg::*;

--- a/bsg_cache/bsg_cache_non_blocking_mhu.v
+++ b/bsg_cache/bsg_cache_non_blocking_mhu.v
@@ -8,7 +8,7 @@
  */
 
 
-`include "bsg_defines.v"
+`include "bsg_cache_non_blocking.vh"
 
 module bsg_cache_non_blocking_mhu
   import bsg_cache_non_blocking_pkg::*;

--- a/bsg_cache/bsg_cache_non_blocking_miss_fifo.v
+++ b/bsg_cache/bsg_cache_non_blocking_miss_fifo.v
@@ -8,7 +8,7 @@
  */
 
 
-`include "bsg_defines.v"
+`include "bsg_cache_non_blocking.vh"
 
 module bsg_cache_non_blocking_miss_fifo
   import bsg_cache_non_blocking_pkg::*;

--- a/bsg_cache/bsg_cache_non_blocking_pkg.v
+++ b/bsg_cache/bsg_cache_non_blocking_pkg.v
@@ -45,22 +45,6 @@ package bsg_cache_non_blocking_pkg;
   } bsg_cache_non_blocking_opcode_e;
 
 
-  // bsg_cache_pkt_s
-  //
-  `define declare_bsg_cache_non_blocking_pkt_s(id_width_mp,addr_width_mp,data_width_mp) \
-    typedef struct packed {                                     \
-      logic [id_width_mp-1:0] id;                               \
-      bsg_cache_non_blocking_opcode_e opcode;                   \
-      logic [addr_width_mp-1:0] addr;                           \
-      logic [data_width_mp-1:0] data;                           \
-      logic [(data_width_mp>>3)-1:0] mask;                      \
-    } bsg_cache_non_blocking_pkt_s
-
-
-  `define bsg_cache_non_blocking_pkt_width(id_width_mp,addr_width_mp,data_width_mp) \
-    ($bits(bsg_cache_non_blocking_opcode_e)+id_width_mp+addr_width_mp+data_width_mp+(data_width_mp>>3))
-
-
   // cache pkt decode
   //
   typedef struct packed {
@@ -91,70 +75,6 @@ package bsg_cache_non_blocking_pkg;
   } bsg_cache_non_blocking_decode_s;
 
 
-  // DMA command
-  //
-  `define declare_bsg_cache_non_blocking_dma_cmd_s(ways_mp,sets_mp,tag_width_mp) \
-    typedef struct packed {                         \
-      logic [`BSG_SAFE_CLOG2(ways_mp)-1:0] way_id;  \
-      logic [`BSG_SAFE_CLOG2(sets_mp)-1:0] index;   \
-      logic refill;                                 \
-      logic evict;                                  \
-      logic [tag_width_mp-1:0] refill_tag;          \
-      logic [tag_width_mp-1:0] evict_tag;           \
-    } bsg_cache_non_blocking_dma_cmd_s
-
-
-  `define bsg_cache_non_blocking_dma_cmd_width(ways_mp,sets_mp,tag_width_mp) \
-    (`BSG_SAFE_CLOG2(ways_mp)+`BSG_SAFE_CLOG2(sets_mp)+((1+tag_width_mp)*2))
-
-
-  // DMA packet
-  //
-  `define declare_bsg_cache_non_blocking_dma_pkt_s(addr_width_mp) \
-    typedef struct packed {               \
-      logic write_not_read;               \
-      logic [addr_width_mp-1:0] addr;     \
-    } bsg_cache_non_blocking_dma_pkt_s
-
-
-  `define bsg_cache_non_blocking_dma_pkt_width(addr_width_mp)    \
-    (1+addr_width_mp)
-
-
-  // data_mem pkt s
-  //
-  `define declare_bsg_cache_non_blocking_data_mem_pkt_s(ways_mp,sets_mp,block_size_in_words_mp,data_width_mp) \
-    typedef struct packed {                                                                \
-      logic write_not_read;                                                                \
-      logic sigext_op;                                                                     \
-      logic mask_op;                                                                       \
-      logic [1:0] size_op;                                                                 \
-      logic [`BSG_SAFE_CLOG2(data_width_mp>>3)-1:0] byte_sel;                               \
-      logic [`BSG_SAFE_CLOG2(ways_mp)-1:0] way_id;                                          \
-      logic [`BSG_SAFE_CLOG2(sets_mp)+`BSG_SAFE_CLOG2(block_size_in_words_mp)-1:0] addr;    \
-      logic [data_width_mp-1:0] data;                                                       \
-      logic [(data_width_mp>>3)-1:0] mask;                                                  \
-    } bsg_cache_non_blocking_data_mem_pkt_s
-
-  `define bsg_cache_non_blocking_data_mem_pkt_width(ways_mp,sets_mp,block_size_in_words_mp,data_width_mp) \
-    (1+1+1+2+`BSG_SAFE_CLOG2(data_width_mp>>3)+`BSG_SAFE_CLOG2(ways_mp)+        \
-      `BSG_SAFE_CLOG2(sets_mp)+`BSG_SAFE_CLOG2(block_size_in_words_mp)+data_width_mp+(data_width_mp>>3))
-
-
-  // tag info s
-  //
-  `define declare_bsg_cache_non_blocking_tag_info_s(tag_width_mp) \
-    typedef struct packed {                   \
-      logic valid;                            \
-      logic lock;                             \
-      logic [tag_width_mp-1:0] tag;           \
-    } bsg_cache_non_blocking_tag_info_s
-
-
-  `define bsg_cache_non_blocking_tag_info_width(tag_width_mp) \
-    (tag_width_mp+2)
-
-  
   // tag info op
   //
   typedef enum logic [2:0] {
@@ -166,35 +86,6 @@ package bsg_cache_non_blocking_pkg;
     ,e_tag_lock                   // lock <= 1;
     ,e_tag_unlock                 // lock <= 0;
   } bsg_cache_non_blocking_tag_op_e;
-
-
-  // tag_mem_pkt
-  //
-  `define declare_bsg_cache_non_blocking_tag_mem_pkt_s(ways_mp,sets_mp,data_width_mp,tag_width_mp) \
-    typedef struct packed {                               \
-      logic [`BSG_SAFE_CLOG2(ways_mp)-1:0] way_id;        \
-      logic [`BSG_SAFE_CLOG2(sets_mp)-1:0] index;         \
-      logic [data_width_mp-1:0] data;                     \
-      logic [tag_width_mp-1:0] tag;                       \
-      bsg_cache_non_blocking_tag_op_e opcode;             \
-    } bsg_cache_non_blocking_tag_mem_pkt_s
-
-
-  `define bsg_cache_non_blocking_tag_mem_pkt_width(ways_mp,sets_mp,data_width_mp,tag_width_mp) \
-    (`BSG_SAFE_CLOG2(ways_mp)+`BSG_SAFE_CLOG2(sets_mp)+data_width_mp+tag_width_mp+$bits(bsg_cache_non_blocking_tag_op_e)) 
-
-
-  // stat info s
-  //
-  `define declare_bsg_cache_non_blocking_stat_info_s(ways_mp)    \
-    typedef struct packed {                         \
-      logic [ways_mp-1:0] dirty;                    \
-      logic [ways_mp-2:0] lru_bits;                 \
-    } bsg_cache_non_blocking_stat_info_s
-
-
-  `define bsg_cache_non_blocking_stat_info_width(ways_mp) \
-    (ways_mp+ways_mp-1)
 
 
   // stat op
@@ -209,19 +100,6 @@ package bsg_cache_non_blocking_pkg;
   } bsg_cache_non_blocking_stat_op_e;
 
 
-  // stat_mem pkt
-  //
-  `define declare_bsg_cache_non_blocking_stat_mem_pkt_s(ways_mp,sets_mp) \
-    typedef struct packed {                               \
-      bsg_cache_non_blocking_stat_op_e opcode;            \
-      logic [`BSG_SAFE_CLOG2(ways_mp)-1:0] way_id;         \
-      logic [`BSG_SAFE_CLOG2(sets_mp)-1:0] index;          \
-    } bsg_cache_non_blocking_stat_mem_pkt_s
- 
-  `define bsg_cache_non_blocking_stat_mem_pkt_width(ways_mp,sets_mp) \
-    ($bits(bsg_cache_non_blocking_stat_op_e)+`BSG_SAFE_CLOG2(ways_mp)+`BSG_SAFE_CLOG2(sets_mp)) 
-
-
   // miss FIFO yumi op 
   //
   typedef enum logic [1:0] {
@@ -229,44 +107,6 @@ package bsg_cache_non_blocking_pkg;
     ,e_miss_fifo_skip
     ,e_miss_fifo_invalidate
   } bsg_cache_non_blocking_miss_fifo_op_e;
-
-
-  // miss FIFO entry
-  //
-  `define declare_bsg_cache_non_blocking_miss_fifo_entry_s(id_width_mp,addr_width_mp,data_width_mp) \
-    typedef struct packed {                   \
-      logic write_not_read;                   \
-      logic block_load;                       \
-      logic [1:0] size_op;                    \
-      logic sigext_op;                        \
-      logic mask_op;                          \
-      logic [id_width_mp-1:0] id;             \
-      logic [addr_width_mp-1:0] addr;         \
-      logic [data_width_mp-1:0] data;         \
-      logic [(data_width_mp>>3)-1:0] mask;    \
-    } bsg_cache_non_blocking_miss_fifo_entry_s;  
-
-  `define bsg_cache_non_blocking_miss_fifo_entry_width(id_width_mp,addr_width_mp,data_width_mp) \
-    (1+1+2+1+1+id_width_mp+addr_width_mp+data_width_mp+(data_width_mp>>3)) 
-
-
-  // MHU dff
-  //
-  `define declare_bsg_cache_non_blocking_mhu_dff_s(id_width_mp,addr_width_mp,tag_width_mp,ways_mp) \
-    typedef struct packed {                                                                 \
-      bsg_cache_non_blocking_decode_s decode;                                               \
-      logic [ways_mp-1:0] valid;                                                           \
-      logic [ways_mp-1:0] lock;                                                            \
-      logic [ways_mp-1:0][tag_width_mp-1:0] tag;                                           \
-      logic [`BSG_SAFE_CLOG2(ways_mp)-1:0] tag_hit_way;                                  \
-      logic tag_hit_found;                                                                \
-      logic [id_width_mp-1:0] id;                                                          \
-      logic [addr_width_mp-1:0] addr;                                                      \
-    } bsg_cache_non_blocking_mhu_dff_s
-
-
-  `define bsg_cache_non_blocking_mhu_dff_width(id_width_mp,addr_width_mp,tag_width_mp,ways_mp) \
-    ($bits(bsg_cache_non_blocking_decode_s)+ways_mp+ways_mp+(ways_mp*tag_width_mp)+`BSG_SAFE_CLOG2(ways_mp)+1+id_width_mp+addr_width_mp)
 
 
   // MHU FSM states

--- a/bsg_cache/bsg_cache_non_blocking_stat_mem.v
+++ b/bsg_cache/bsg_cache_non_blocking_stat_mem.v
@@ -8,7 +8,7 @@
  */
 
 
-`include "bsg_defines.v"
+`include "bsg_cache_non_blocking.vh"
 
 module bsg_cache_non_blocking_stat_mem
   import bsg_cache_non_blocking_pkg::*;

--- a/bsg_cache/bsg_cache_non_blocking_tag_mem.v
+++ b/bsg_cache/bsg_cache_non_blocking_tag_mem.v
@@ -7,7 +7,7 @@
 
 
 
-`include "bsg_defines.v"
+`include "bsg_cache_non_blocking.vh"
 
 module bsg_cache_non_blocking_tag_mem 
   import bsg_cache_non_blocking_pkg::*;

--- a/bsg_cache/bsg_cache_non_blocking_tl_stage.v
+++ b/bsg_cache/bsg_cache_non_blocking_tl_stage.v
@@ -8,7 +8,7 @@
  */
 
 
-`include "bsg_defines.v"
+`include "bsg_cache_non_blocking.vh"
 
 module bsg_cache_non_blocking_tl_stage
   import bsg_cache_non_blocking_pkg::*;

--- a/bsg_cache/bsg_cache_to_dram_ctrl.v
+++ b/bsg_cache/bsg_cache_to_dram_ctrl.v
@@ -7,6 +7,7 @@
 
 `include "bsg_defines.v"
 `include "bsg_cache.vh"
+`include "bsg_dmc.vh"
 
 module bsg_cache_to_dram_ctrl
   import bsg_cache_pkg::*;

--- a/bsg_dmc/bsg_dmc.v
+++ b/bsg_dmc/bsg_dmc.v
@@ -1,4 +1,4 @@
-`include "bsg_defines.v"
+`include "bsg_dmc.vh"
 
 module bsg_dmc
   import bsg_tag_pkg::*;

--- a/bsg_dmc/bsg_dmc.vh
+++ b/bsg_dmc/bsg_dmc.vh
@@ -1,0 +1,14 @@
+
+`ifndef BSG_DMC_VH
+`define BSG_DMC_VH
+
+  `include "bsg_defines.v"
+
+  `define declare_app_cmd_afifo_entry_s(addr_width_mp) \
+    typedef struct packed {           \
+      app_cmd_e cmd;                  \
+      logic [addr_width_mp-1:0] addr; \
+    } app_cmd_afifo_entry_s;
+
+`endif
+

--- a/bsg_dmc/bsg_dmc_controller.v
+++ b/bsg_dmc/bsg_dmc_controller.v
@@ -1,4 +1,4 @@
-`include "bsg_defines.v"
+`include "bsg_dmc.vh"
 
 module bsg_dmc_controller
   import bsg_dmc_pkg::*;

--- a/bsg_dmc/bsg_dmc_pkg.v
+++ b/bsg_dmc/bsg_dmc_pkg.v
@@ -1,4 +1,3 @@
-`include "bsg_defines.v"
 
 package bsg_dmc_pkg;
   typedef struct packed {
@@ -28,12 +27,6 @@ package bsg_dmc_pkg;
     ,RD = 3'b001 // read
     ,WR = 3'b000 // write
   } app_cmd_e;
-
-  `define declare_app_cmd_afifo_entry_s(addr_width_mp) \
-    typedef struct packed {           \
-      app_cmd_e cmd;                  \
-      logic [addr_width_mp-1:0] addr; \
-    } app_cmd_afifo_entry_s;
 
   typedef enum logic [3:0]
     {LMR      = 4'b0000

--- a/bsg_noc/bsg_mesh_router_decoder_dor.v
+++ b/bsg_noc/bsg_mesh_router_decoder_dor.v
@@ -6,6 +6,8 @@
  *    depopulated ruche router.
  */
 
+`include "bsg_defines.v"
+
 module bsg_mesh_router_decoder_dor
   import bsg_noc_pkg::*;
   import bsg_mesh_router_pkg::*;

--- a/testing/bsg_cache/common/bsg_nonsynth_non_blocking_dma_model.v
+++ b/testing/bsg_cache/common/bsg_nonsynth_non_blocking_dma_model.v
@@ -6,6 +6,7 @@
  *
  */
 
+`include "bsg_cache_non_blocking.vh"
 
 module bsg_nonsynth_non_blocking_dma_model
   import bsg_cache_non_blocking_pkg::*;

--- a/testing/bsg_cache/dmc/testbench.v
+++ b/testing/bsg_cache/dmc/testbench.v
@@ -1,4 +1,6 @@
 
+`include "bsg_dmc.vh"
+
 module testbench
   import bsg_dmc_pkg::*;
   import bsg_cache_pkg::*;

--- a/testing/bsg_cache/regression_non_blocking/basic_checker.v
+++ b/testing/bsg_cache/regression_non_blocking/basic_checker.v
@@ -1,3 +1,6 @@
+
+`include "bsg_cache_non_blocking.vh"
+
 module basic_checker 
   import bsg_cache_non_blocking_pkg::*;
   #(parameter `BSG_INV_PARAM(data_width_p)

--- a/testing/bsg_cache/regression_non_blocking/block_ld_checker.v
+++ b/testing/bsg_cache/regression_non_blocking/block_ld_checker.v
@@ -1,3 +1,6 @@
+
+`include "bsg_cache_non_blocking.vh"
+
 module block_ld_checker
   import bsg_cache_non_blocking_pkg::*;
   #(parameter `BSG_INV_PARAM(data_width_p)

--- a/testing/bsg_cache/regression_non_blocking/cov_mhu.v
+++ b/testing/bsg_cache/regression_non_blocking/cov_mhu.v
@@ -1,3 +1,6 @@
+
+`include "bsg_cache_non_blocking.vh"
+
 module cov_mhu
   import bsg_cache_non_blocking_pkg::*;
   (

--- a/testing/bsg_cache/regression_non_blocking/cov_miss_fifo.v
+++ b/testing/bsg_cache/regression_non_blocking/cov_miss_fifo.v
@@ -1,3 +1,6 @@
+
+`include "bsg_cache_non_blocking.vh"
+
 module cov_miss_fifo
   import bsg_cache_non_blocking_pkg::*;
   (

--- a/testing/bsg_cache/regression_non_blocking/cov_tl_stage.v
+++ b/testing/bsg_cache/regression_non_blocking/cov_tl_stage.v
@@ -1,3 +1,6 @@
+
+`include "bsg_cache_non_blocking.vh"
+
 module cov_tl_stage
   import bsg_cache_non_blocking_pkg::*;
   (

--- a/testing/bsg_cache/regression_non_blocking/tag_checker.v
+++ b/testing/bsg_cache/regression_non_blocking/tag_checker.v
@@ -1,3 +1,6 @@
+
+`include "bsg_cache_non_blocking.vh"
+
 module tag_checker 
   import bsg_cache_non_blocking_pkg::*;
   #(parameter `BSG_INV_PARAM(id_width_p)

--- a/testing/bsg_cache/regression_non_blocking/testbench.v
+++ b/testing/bsg_cache/regression_non_blocking/testbench.v
@@ -2,6 +2,7 @@
  *  testbench.v
  */
 
+`include "bsg_cache_non_blocking.vh"
 
 module testbench();
   import bsg_cache_non_blocking_pkg::*;

--- a/testing/bsg_dmc/testbench.v
+++ b/testing/bsg_dmc/testbench.v
@@ -1,6 +1,8 @@
 `define WRITE 3'b000
 `define READ  3'b001
 
+`include "bsg_dmc.vh"
+
 module testbench
   import bsg_tag_pkg::*;
   import bsg_dmc_pkg::*;


### PR DESCRIPTION
In order for some tools to handle basejump code, each file needs to be able to parse as its own compilation unit. This means we can't rely on definitions from packages being available at import time.  This PR separates out bsg_cache_non_blocking_pkg and bsg_dmc_pkg defines into their own include files. Users should both import the package and include the defines