### PR TITLE
[DEFERRED] Tsmc28 clkmux

### DIFF
--- a/bsg_misc/bsg_clkmux.v
+++ b/bsg_misc/bsg_clkmux.v
@@ -1,10 +1,12 @@
 `include "bsg_defines.v"
-module bsg_clkmux #(`BSG_INV_PARAM(els_p)
+module bsg_clkmux #(`BSG_INV_PARAM(width_p)
+                 , `BSG_INV_PARAM(els_p)
                  , harden_p = 0
+                 , script_p = 0
                  , lg_els_lp=`BSG_SAFE_CLOG2(els_p)
                  )
    (
-    input [els_p-1:0] data_i
+    input [els_p-1:0][width_p-1:0] data_i
     ,input [lg_els_lp-1:0] sel_i
     ,output data_o
     );

--- a/bsg_misc/bsg_clkmux.v
+++ b/bsg_misc/bsg_clkmux.v
@@ -1,0 +1,23 @@
+`include "bsg_defines.v"
+module bsg_clkmux #(`BSG_INV_PARAM(els_p)
+                 , harden_p = 0
+                 , lg_els_lp=`BSG_SAFE_CLOG2(els_p)
+                 )
+   (
+    input [els_p-1:0] data_i
+    ,input [lg_els_lp-1:0] sel_i
+    ,output data_o
+    );
+
+   if (els_p == 1)
+     begin
+      assign data_o = data_i;
+      wire unused = sel_i;
+     end
+   else
+     assign data_o = data_i[sel_i];
+
+endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_clkmux)
+

--- a/hard/tsmc_28/bsg_misc/bsg_clkmux.v
+++ b/hard/tsmc_28/bsg_misc/bsg_clkmux.v
@@ -1,0 +1,69 @@
+`include "bsg_defines.v"
+module bsg_clkmux #(els_p = 2
+                 , width_p = 1
+                 , harden_p = 1
+                 , strength_p = 0
+                 , lg_els_lp=`BSG_SAFE_CLOG2(els_p)
+                 )
+   (
+    input [els_p-1:0][width_p-1:0] data_i
+    ,input [lg_els_lp-1:0] sel_i
+    ,output [width_p-1:0] data_o
+    );
+
+  localparam total_els_lp = width_p*els_p;
+  localparam pot_els_lp = 2**$clog2(total_els_lp);
+
+   if (total_els_lp == 2 && strength_p == 0)
+     begin : s0
+       CLMUX2D0BWP7T40P140 c
+        (.I0(data_i[0], .I1(data_i[1]), .S(sel_i), .Z(data_o));
+     end
+   else if (total_els_lp == 2 && strength_p == 1)
+     begin : s1
+       CLMUX2D1BWP7T40P140 c 
+        (.I0(data_i[0], .I1(data_i[1]), .S(sel_i), .Z(data_o));
+     end
+   else if (total_els_lp == 2 && strength_p == 2)
+     begin : s1
+       CLMUX2D2BWP7T40P140 c
+        (.I0(data_i[0], .I1(data_i[1]), .S(sel_i), .Z(data_o));
+     end
+   else if (total_els_lp == 2 && strength_p == 4)
+     begin : s1
+       CLMUX2D4BWP7T40P140 c
+        (.I0(data_i[0], .I1(data_i[1]), .S(sel_i), .Z(data_o));
+     end
+   else if (total_els_lp == 2 && strength_p == 8)
+     begin : s1
+       CLMUX2D8BWP7T40P140 c
+        (.I0(data_i[0], .I1(data_i[1]), .S(sel_i), .Z(data_o));
+     end
+   else
+     begin
+       localparam new_els_lp = new_els_lp;
+       localparam lg_new_els_lp = `BSG_SAFE_CLOG2(new_els_lp);
+       wire [pot_els_lp-1:0] data_li = {{(pot_els_lp-total_els_lp){1'b0}}, data_i};
+       logic [new_els_lp-1:0] c0_lo;
+       bsg_clkmux #(.els_p(new_els_lp), .harden_p(harden_p), .strength_p(strength_p)) c0
+        (.data_i(data_li[0+:new_els_lp])
+         ,.sel_i(sel_i[0+:lg_new_els_lp])
+         ,.data_o(c0_lo)
+         );
+       logic [new_els_lp-1:0] c1_lo;
+       bsg_clkmux #(.els_p(new_els_lp), .harden_p(harden_p), .strength_p(strength_p)) c1
+        (.data_i(data_li[new_els_lp+:new_els_lp])
+         ,.sel_i(sel_i[0+:lg_new_els_lp])
+         ,.data_o(c1_lo)
+         );
+       bsg_clkmux #(.width_p(new_width_lp), .harden_p(harden_p), .strength_p(strength_p)) c2
+        (.data_i({c1_lo, c0_lo})
+         ,.sel_i(sel_i[lg_new_els_lp])
+         ,.data_o(data_o)
+         );
+     end
+
+endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_clkmux)
+


### PR DESCRIPTION
Adds a hardened clock mux for tsmc28. This is useful for operations on clocks e.g. clock monitoring. Similarly, adds this cell to soft bsg_misc. The tree is unverified so needs to be tested before merging