### PR TITLE
[DMC][BUG] fix write and read to refresh timing violation

### DIFF
--- a/bsg_dmc/bsg_dmc_controller.v
+++ b/bsg_dmc/bsg_dmc_controller.v
@@ -440,14 +440,16 @@ module bsg_dmc_controller
 	         default: shoot = 1'b1;
                endcase
         WRITE: case(n_cmd)
-                 PRE:     shoot = (cmd_tick >= dmc_p_i.twr) & (cmd_act_tick >= dmc_p_i.tras);
+				// if write is followed by refresh, it means we are writing with auto precharge. But we still have to wait for twr after write and tras after activate. So timing condition below applies for either n_cmd = precharge or refresh
+                 PRE, REF:     shoot = (cmd_tick >= dmc_p_i.twr) & (cmd_act_tick >= dmc_p_i.tras);
                  WRITE:   shoot = (cmd_tick >= dfi_burst_length_lp-1) & (&tx_sipo_valid_lo);
                  READ:    shoot = cmd_tick >= dmc_p_i.twtr;
                  ACT:     shoot = (cmd_act_tick >= dmc_p_i.trc) & (cmd_tick >= dmc_p_i.twr + dmc_p_i.trp);
 	         default: shoot = 1'b1;
                endcase
         READ:  case(n_cmd)
-                 PRE:     shoot = (cmd_tick >= dmc_p_i.trtp) & (cmd_act_tick >= dmc_p_i.tras);
+				// if read is followed by refresh, it means we are reading with auto precharge. But we still have to wait for trtp after read and tras after activate. So timing condition below applies for either n_cmd = precharge or refresh
+                 PRE, REF:     shoot = (cmd_tick >= dmc_p_i.trtp) & (cmd_act_tick >= dmc_p_i.tras);
                  WRITE:   shoot = (cmd_tick >= dmc_p_i.tcas+dfi_burst_length_lp-1) & (&tx_sipo_valid_lo);
                  READ:    shoot = cmd_tick >= dfi_burst_length_lp-1;
                  ACT:     shoot = (cmd_act_tick >= dmc_p_i.trc) & (cmd_tick >= dmc_p_i.trtp + dmc_p_i.trp);


### PR DESCRIPTION
When it is time to refresh and there are no open banks after the operation just before a refresh, the last R/W operation can be directly followed by refresh . (Since there are no open banks, precharge all before refresh won't be done).
Adding wait conditions for write and read to refresh transitions to meet spec defined timing parameters.

More info [here](https://docs.google.com/presentation/d/1rwTdsuUihzIzrpGuZCu-2L2tawGwX760oHxns-mWEMc/edit?usp=sharing).