### PR TITLE
Update bsg_defines.v

### DIFF
--- a/bsg_misc/bsg_defines.v
+++ b/bsg_misc/bsg_defines.v
@@ -35,7 +35,8 @@
 // if later we find that all tools are compatible, we can remove the use of this from BaseJump STL
 
 `ifdef XCELIUM // Bare default parameters are incompatible as of 20.09.012
-`define BSG_INV_PARAM(param) param = "inv"
+               // = "inv" causes type inference mismatch as of 20.09.012
+`define BSG_INV_PARAM(param) param = -1
 `elsif YOSYS // Bare default parameters are incompatible as of 0.9
 `define BSG_INV_PARAM(param) param = "inv"
 `else // VIVADO, DC, VERILATOR, GENUS


### PR DESCRIPTION
Bug discovered in Xcelium 20, -1 doesn't cause elaboration time issues like it does in Vivado