### PR TITLE
fix data width assignment of stubbed links in wh concentrators

### DIFF
--- a/bsg_noc/bsg_wormhole_concentrator_in.v
+++ b/bsg_noc/bsg_wormhole_concentrator_in.v
@@ -60,7 +60,7 @@ module bsg_wormhole_concentrator_in
   for (i = 0; i < num_in_p; i++)
     begin : stub
       assign links_o_cast[i].v    = 1'b0;
-      assign links_o_cast[i].data = 1'b0;
+      assign links_o_cast[i].data = '0;
     end
     
   assign concentrated_link_o_cast.ready_and_rev = 1'b0;

--- a/bsg_noc/bsg_wormhole_concentrator_out.v
+++ b/bsg_noc/bsg_wormhole_concentrator_out.v
@@ -63,7 +63,7 @@ module bsg_wormhole_concentrator_out
     end
 
   assign concentrated_link_o_cast.v    = 1'b0;
-  assign concentrated_link_o_cast.data = 1'b0;
+  assign concentrated_link_o_cast.data = '0;
 
   /********** From concentrated side to unconcentrated side **********/
   


### PR DESCRIPTION
This PR fixes the width of constants used to stub the data wires of stubbed links in the wormhole concentrators. Functionality of modules is unchanged.