### PR TITLE
expose hold_on_valid_p param in wh router and concentrators

### DIFF
--- a/bsg_noc/bsg_wormhole_concentrator.v
+++ b/bsg_noc/bsg_wormhole_concentrator.v
@@ -29,6 +29,12 @@ module bsg_wormhole_concentrator
     ,parameter num_in_p            = 1
     ,parameter debug_lp            = 0
     ,parameter link_width_lp       = `bsg_ready_and_link_sif_width(flit_width_p)
+    // Hold on valid sets the arbitration policy such that once an output tag is selected, it
+    // remains selected until it is acked, then the round-robin scheduler continues cycling
+    // from the selected tag. This is consistent with BaseJump STL handshake assumptions.
+    // Notably, this parameter is required to work with bsg_parallel_in_serial_out_passthrough.
+    // This policy has a slight throughput degradation but effectively arbitrates based on age,
+    // so minimizes worst case latency.
     ,parameter hold_on_valid_p     = 0
    )
 

--- a/bsg_noc/bsg_wormhole_concentrator.v
+++ b/bsg_noc/bsg_wormhole_concentrator.v
@@ -26,9 +26,10 @@ module bsg_wormhole_concentrator
     ,parameter `BSG_INV_PARAM(len_width_p)
     ,parameter `BSG_INV_PARAM(cid_width_p)
     ,parameter `BSG_INV_PARAM(cord_width_p)
-   ,parameter num_in_p            = 1
-   ,parameter debug_lp            = 0
-   ,parameter link_width_lp       = `bsg_ready_and_link_sif_width(flit_width_p)
+    ,parameter num_in_p            = 1
+    ,parameter debug_lp            = 0
+    ,parameter link_width_lp       = `bsg_ready_and_link_sif_width(flit_width_p)
+    ,parameter hold_on_valid_p     = 0
    )
 
   (input clk_i
@@ -75,6 +76,7 @@ module bsg_wormhole_concentrator
      ,.num_in_p(num_in_p)
      ,.cord_width_p(cord_width_p)
      ,.debug_lp(debug_lp)
+     ,.hold_on_valid_p(hold_on_valid_p)
      )
    concentrator_in
     (.clk_i(clk_i)
@@ -94,6 +96,7 @@ module bsg_wormhole_concentrator
      ,.num_in_p(num_in_p)
      ,.cord_width_p(cord_width_p)
      ,.debug_lp(debug_lp)
+     ,.hold_on_valid_p(hold_on_valid_p)
      )
    concentrator_out
     (.clk_i(clk_i)

--- a/bsg_noc/bsg_wormhole_concentrator_in.v
+++ b/bsg_noc/bsg_wormhole_concentrator_in.v
@@ -26,8 +26,9 @@ module bsg_wormhole_concentrator_in
     ,parameter `BSG_INV_PARAM(len_width_p)
     ,parameter `BSG_INV_PARAM(cid_width_p)
     ,parameter `BSG_INV_PARAM(cord_width_p)
-   ,parameter num_in_p            = 1
-   ,parameter debug_lp            = 0
+    ,parameter num_in_p            = 1
+    ,parameter debug_lp            = 0
+    ,parameter hold_on_valid_p     = 0
    )
 
   (input clk_i
@@ -112,7 +113,8 @@ module bsg_wormhole_concentrator_in
 
   wire [num_in_p-1:0] data_sel_lo;
 
-  bsg_wormhole_router_output_control #(.input_dirs_p(num_in_p)) woc
+  bsg_wormhole_router_output_control
+  #(.input_dirs_p(num_in_p), .hold_on_valid_p(hold_on_valid_p)) woc
     (.clk_i
     ,.reset_i
     ,.reqs_i    (reqs         )

--- a/bsg_noc/bsg_wormhole_concentrator_out.v
+++ b/bsg_noc/bsg_wormhole_concentrator_out.v
@@ -26,8 +26,9 @@ module bsg_wormhole_concentrator_out
     ,parameter `BSG_INV_PARAM(len_width_p)
     ,parameter `BSG_INV_PARAM(cid_width_p)
     ,parameter `BSG_INV_PARAM(cord_width_p)
-   ,parameter num_in_p            = 1
-   ,parameter debug_lp            = 0
+    ,parameter num_in_p            = 1
+    ,parameter debug_lp            = 0
+    ,parameter hold_on_valid_p     = 0
    )
 
   (input clk_i
@@ -117,7 +118,8 @@ module bsg_wormhole_concentrator_out
   for (i = 0; i < num_in_p; i=i+1)
     begin: out_ch
 
-      bsg_wormhole_router_output_control #(.input_dirs_p(1)) concentrated_woc
+      bsg_wormhole_router_output_control
+      #(.input_dirs_p(1), .hold_on_valid_p(hold_on_valid_p)) concentrated_woc
         (.clk_i
         ,.reset_i
         ,.reqs_i    (concentrated_reqs[i] )

--- a/bsg_noc/bsg_wormhole_router.v
+++ b/bsg_noc/bsg_wormhole_router.v
@@ -18,8 +18,12 @@ module bsg_wormhole_router
    ,parameter reverse_order_p       = 0
    ,parameter `BSG_INV_PARAM(len_width_p)
    ,parameter debug_lp              = 0
-   // hold router_output_control input selection until consumed
-   // See bsg_wormhole_router_output_control and bsg_round_robin_arb.v for details
+   // Hold on valid sets the arbitration policy such that once an output tag is selected, it
+   // remains selected until it is acked, then the round-robin scheduler continues cycling
+   // from the selected tag. This is consistent with BaseJump STL handshake assumptions.
+   // Notably, this parameter is required to work with bsg_parallel_in_serial_out_passthrough.
+   // This policy has a slight throughput degradation but effectively arbitrates based on age,
+   // so minimizes worst case latency.
    ,parameter hold_on_valid_p       = 0
    )
 

--- a/bsg_noc/bsg_wormhole_router.v
+++ b/bsg_noc/bsg_wormhole_router.v
@@ -18,6 +18,9 @@ module bsg_wormhole_router
    ,parameter reverse_order_p       = 0
    ,parameter `BSG_INV_PARAM(len_width_p)
    ,parameter debug_lp              = 0
+   // hold router_output_control input selection until consumed
+   // See bsg_wormhole_router_output_control and bsg_round_robin_arb.v for details
+   ,parameter hold_on_valid_p       = 0
    )
 
   (input clk_i
@@ -206,7 +209,8 @@ module bsg_wormhole_router
       bsg_array_concentrate_static #(.width_p(flit_width_p), .pattern_els_p(routing_matrix_p[1][i])) conc4
       (.i(fifo_data_lo),.o(fifo_data_sparse_lo));
 
-      bsg_wormhole_router_output_control #(.input_dirs_p(input_dirs_sparse_lp)) woc
+      bsg_wormhole_router_output_control
+      #(.input_dirs_p(input_dirs_sparse_lp), .hold_on_valid_p(hold_on_valid_p)) woc
       (.clk_i
       ,.reset_i
       ,.reqs_i    (reqs_li   )

--- a/bsg_noc/bsg_wormhole_router_output_control.v
+++ b/bsg_noc/bsg_wormhole_router_output_control.v
@@ -1,7 +1,16 @@
 `include "bsg_defines.v"
 
 module bsg_wormhole_router_output_control
-  #(parameter `BSG_INV_PARAM(input_dirs_p))
+  #(parameter `BSG_INV_PARAM(input_dirs_p)
+    // Hold on valid sets the arbitration policy such that once
+    // a output tag is selected, it remains selected until it is
+    // acked. This is consistent with BaseJump STL handshake
+    // assumptions. Notably, this parameter is required to work
+    // with bsg_parallel_in_serial_out_passthrough. This policy
+    // has a slight throughput degradation but effectively
+    // arbitrates based on age, so minimizes worst case latency.
+    , parameter hold_on_valid_p = 0
+    )
    (input clk_i
     , input reset_i
 
@@ -31,7 +40,8 @@ module bsg_wormhole_router_output_control
    wire                     free_to_schedule = !scheduled_with_release;
 
    bsg_round_robin_arb
-     #(.inputs_p(input_dirs_p)) brr
+     #(.inputs_p(input_dirs_p), .hold_on_valid_p(hold_on_valid_p))
+   brr
    (.clk_i
     ,.reset_i
     ,.grants_en_i  (free_to_schedule)      // ports are all free

--- a/bsg_noc/bsg_wormhole_router_output_control.v
+++ b/bsg_noc/bsg_wormhole_router_output_control.v
@@ -2,13 +2,12 @@
 
 module bsg_wormhole_router_output_control
   #(parameter `BSG_INV_PARAM(input_dirs_p)
-    // Hold on valid sets the arbitration policy such that once
-    // a output tag is selected, it remains selected until it is
-    // acked. This is consistent with BaseJump STL handshake
-    // assumptions. Notably, this parameter is required to work
-    // with bsg_parallel_in_serial_out_passthrough. This policy
-    // has a slight throughput degradation but effectively
-    // arbitrates based on age, so minimizes worst case latency.
+    // Hold on valid sets the arbitration policy such that once an output tag is selected, it
+    // remains selected until it is acked, then the round-robin scheduler continues cycling
+    // from the selected tag. This is consistent with BaseJump STL handshake assumptions.
+    // Notably, this parameter is required to work with bsg_parallel_in_serial_out_passthrough.
+    // This policy has a slight throughput degradation but effectively arbitrates based on age,
+    // so minimizes worst case latency.
     , parameter hold_on_valid_p = 0
     )
    (input clk_i


### PR DESCRIPTION
This PR simply exposes the hold_on_valid_p parameter from bsg_round_robin_arb.v in bsg_wormhole_router_output_control, bsg_wormhole_router, and bsg_wormhole_concentrator*.

This parameter is useful in situations where an output channel may not be consumed in a single cycle, for example when a flit must be processed by a PISO.