### PR TITLE
Updates to clock gen osc and delay line

### DIFF
--- a/bsg_clk_gen/bsg_clk_gen_osc.v
+++ b/bsg_clk_gen/bsg_clk_gen_osc.v
@@ -1,6 +1,8 @@
 `include "bsg_defines.v"
 
+`ifndef BSG_NO_TIMESCALE
 `timescale 1ps/1ps
+`endif
 
 // This module is a behavioral model of the clock generator ring
 // oscillator. A TSMC 250nm hardened implementation of this module
@@ -23,6 +25,18 @@ module bsg_clk_gen_osc
    ,input bsg_tag_s bsg_tag_trigger_i
    ,output logic clk_o
    );
+
+`ifdef BSG_OSC_BASE_DELAY
+   localparam osc_base_delay_lp = `BSG_OSC_BASE_DELAY;
+`else
+   localparam osc_base_delay_lp = 1000;
+`endif
+
+`ifdef BSG_OSC_GRANULARITY
+   localparam osc_granularity_lp = `BSG_OSC_GRANULARITY;
+`else
+   localparam osc_granularity_lp = 100;
+`endif
 
    `declare_bsg_clk_gen_osc_tag_payload_s(num_adgs_p)
 
@@ -58,14 +72,13 @@ module bsg_clk_gen_osc
 
    always
      begin
-        #1000
+         #(osc_base_delay_lp);
         if (ctrl_rrr !== 'X)
           # (
-             ((1 << $bits(ctrl_rrr)) - ctrl_rrr)*100
+             ((1 << $bits(ctrl_rrr)) - ctrl_rrr)*osc_granularity_lp
             )
         clk_o <= ~(clk_o | async_reset_i);
 
      end
-
 
 endmodule

--- a/bsg_clk_gen/bsg_clk_gen_osc.v
+++ b/bsg_clk_gen/bsg_clk_gen_osc.v
@@ -72,7 +72,7 @@ module bsg_clk_gen_osc
 
    always
      begin
-         #(osc_base_delay_lp);
+        #(osc_base_delay_lp);
         if (ctrl_rrr !== 'X)
           # (
              ((1 << $bits(ctrl_rrr)) - ctrl_rrr)*osc_granularity_lp

--- a/bsg_clk_gen/bsg_dly_line.v
+++ b/bsg_clk_gen/bsg_dly_line.v
@@ -44,32 +44,29 @@ module bsg_dly_line
    bsg_clk_gen_osc_tag_payload_s fb_tag_r;
    wire  fb_we_r;
 
-   // note: delay line has to be already working in order
+   // note: oscillator has to be already working in order
    // for configuration state to pass through here
 
-   bsg_tag_client_unsync
-     #(.width_p($bits(bsg_clk_gen_osc_tag_payload_s))
-       ,.harden_p(1)
-       ) btc
-       (.bsg_tag_i(bsg_tag_i)
-        ,.data_async_r_o(fb_tag_r)
-        );
-
-   bsg_tag_client_unsync
-     #(.width_p(1)
-       ,.harden_p(1)
-       ) btc_trigger
-       (.bsg_tag_i(bsg_tag_trigger_i)
-        ,.data_async_r_o(fb_we_r)
-        );
+   bsg_tag_client #(.width_p($bits(bsg_clk_gen_osc_tag_payload_s))
+                    ,.harden_p(1)
+                    ) btc
+     (.bsg_tag_i     (bsg_tag_i)
+      ,.recv_clk_i   (clk_o)
+      ,.recv_new_r_o (fb_we_r)  // default is already in OSC flops
+      ,.recv_data_r_o(fb_tag_r)
+      );
 
    wire [1:0] cdt = fb_tag_r.cdt;
    wire [1:0] fdt = fb_tag_r.fdt;
    wire [num_adgs_p-1:0] adg_ctrl = fb_tag_r.adg;
 
    logic [4+num_adgs_p-1:0] ctrl_rrr;
-   always @(posedge fb_we_r)
-     ctrl_rrr <= {adg_ctrl, cdt, fdt};
+   always @(clk_o or async_reset_i)
+     if (async_reset_i)
+       ctrl_rrr <= '0;
+     else
+       if (fb_we_r)
+         ctrl_rrr <= {adg_ctrl, cdt, fdt};
 
    always
      begin

--- a/bsg_clk_gen/bsg_dly_line.v
+++ b/bsg_clk_gen/bsg_dly_line.v
@@ -1,6 +1,8 @@
 `include "bsg_defines.v"
 
+`ifndef BSG_NO_TIMESCALE
 `timescale 1ps/1ps
+`endif
 
 // This module is a behavioral model of the delay line.
 // A TSMC 40nm hardened implementation of this module
@@ -25,41 +27,56 @@ module bsg_dly_line
    ,output logic clk_o
    );
 
+`ifdef BSG_OSC_BASE_DELAY
+   localparam osc_base_delay_lp = `BSG_OSC_BASE_DELAY;
+`else
+   localparam osc_base_delay_lp = 1000;
+`endif
+
+`ifdef BSG_OSC_GRANULARITY
+   localparam osc_granularity_lp = `BSG_OSC_GRANULARITY;
+`else
+   localparam osc_granularity_lp = 100;
+`endif
+
    `declare_bsg_clk_gen_osc_tag_payload_s(num_adgs_p)
 
    bsg_clk_gen_osc_tag_payload_s fb_tag_r;
    wire  fb_we_r;
 
-   // note: oscillator has to be already working in order
+   // note: delay line has to be already working in order
    // for configuration state to pass through here
 
-   bsg_tag_client #(.width_p($bits(bsg_clk_gen_osc_tag_payload_s))
-                    ,.harden_p(1)
-                    ) btc
-     (.bsg_tag_i     (bsg_tag_i)
-      ,.recv_clk_i   (clk_o)
-      ,.recv_new_r_o (fb_we_r)  // default is already in OSC flops
-      ,.recv_data_r_o(fb_tag_r)
-      );
+   bsg_tag_client_unsync
+     #(.width_p($bits(bsg_clk_gen_osc_tag_payload_s))
+       ,.harden_p(1)
+       ) btc
+       (.bsg_tag_i(bsg_tag_i)
+        ,.data_async_r_o(fb_tag_r)
+        );
+
+   bsg_tag_client_unsync
+     #(.width_p(1)
+       ,.harden_p(1)
+       ) btc_trigger
+       (.bsg_tag_i(bsg_tag_trigger_i)
+        ,.data_async_r_o(fb_we_r)
+        );
 
    wire [1:0] cdt = fb_tag_r.cdt;
    wire [1:0] fdt = fb_tag_r.fdt;
    wire [num_adgs_p-1:0] adg_ctrl = fb_tag_r.adg;
 
    logic [4+num_adgs_p-1:0] ctrl_rrr;
-   always @(clk_o or async_reset_i)
-     if (async_reset_i)
-       ctrl_rrr <= '0;
-     else
-       if (fb_we_r)
-         ctrl_rrr <= {adg_ctrl, cdt, fdt};
+   always @(posedge fb_we_r)
+     ctrl_rrr <= {adg_ctrl, cdt, fdt};
 
    always
      begin
-        #1000
+        #(osc_base_delay_lp);
         if (ctrl_rrr !== 'X)
           # (
-             ((1 << $bits(ctrl_rrr)) - ctrl_rrr)*100
+             ((1 << $bits(ctrl_rrr)) - ctrl_rrr)*osc_granularity_lp
             )
         clk_o <= (clk_i | async_reset_i);
 

--- a/bsg_test/bsg_nonsynth_clock_gen.v
+++ b/bsg_test/bsg_nonsynth_clock_gen.v
@@ -2,7 +2,9 @@
 // this helps with x prop mode in VCS
 `include "bsg_defines.v"
 
-`timescale 1ps/1ps
+`ifndef BSG_NO_TIMESCALE
+ `timescale 1ps/1ps
+`endif
 
 module bsg_nonsynth_clock_gen
   #(parameter `BSG_INV_PARAM(cycle_time_p))


### PR DESCRIPTION
This PR adds the capability to tune our nonsynth oscillators (clock gen and delay line), for different process nodes using BSG_OSC_BASE_DELAY and BSG_OSC_GRANULARITY. By setting these parameters, we can get a fairly good approximation of the delays after APR. This is especially useful / necessary for the DMC which relies on relative delays between the oscillators and interface.

It also adds the BSG_NO_TIMESCALE macro which removes timescale from all modules. This is useful for simulating with libraries which have a defined timescale, since there are very messy semantics for overriding timescale in SystemVerilog.