### PR TITLE
Update wormhole router and concentrator testbench

### DIFF
--- a/testing/bsg_noc/bsg_wormhole_concentrator/Makefile
+++ b/testing/bsg_noc/bsg_wormhole_concentrator/Makefile
@@ -9,12 +9,12 @@ export BASEJUMP_STL_DIR = ../../..
 include $(BSG_CADENV_DIR)/cadenv.mk
 
 run:
-	$(VCS_BIN)/vcs -full64 -sverilog -timescale=1ps/1ps -f ./filelist -debug_pp -R -top bsg_wormhole_concentrator_tester +vcs+vcdpluson
+	$(VCS_BIN)/vcs -full64 -sverilog -timescale=1ps/1ps -f ./filelist -debug_pp -R -top bsg_wormhole_concentrator_tester +vcs+vcdpluson -assert svaext
     
 view:
 	$(VCS_BIN)/dve -full64 -vpd vcdplus.vpd &
 
-junk = csrc DVEfiles simv.daidir *.old *.vpd simv *.key
+junk = csrc DVEfiles simv.daidir *.old *.vpd simv *.key vc_hdrs.h
 
 clean:
 	rm -rf $(junk)

--- a/testing/bsg_noc/bsg_wormhole_concentrator/bsg_wormhole_concentrator_tester.v
+++ b/testing/bsg_noc/bsg_wormhole_concentrator/bsg_wormhole_concentrator_tester.v
@@ -44,6 +44,11 @@ module bsg_wormhole_concentrator_tester
                                              : StrictXY|XY_Allow_S|XY_Allow_N
   
   ,parameter cord_width_p = cord_markers_pos_p[dims_p]
+  
+  // Hold on valid sets the arbitration policy such that once an output tag is selected, it
+  // remains selected until it is acked, then the round-robin scheduler continues cycling
+  // from the selected tag.
+  ,parameter hold_on_valid_p = 0
   )
   
   ();
@@ -126,6 +131,7 @@ module bsg_wormhole_concentrator_tester
    ,.cord_width_p(cord_markers_pos_p[dims_p])
    ,.len_width_p(len_width_p)
    ,.cid_width_p(cid_width_p)
+   ,.hold_on_valid_p(hold_on_valid_p)
    ) master_concentrator
   (.clk_i(clk)
   ,.reset_i(reset)
@@ -190,6 +196,7 @@ module bsg_wormhole_concentrator_tester
    ,.cord_width_p(cord_markers_pos_p[dims_p])
    ,.len_width_p(len_width_p)
    ,.cid_width_p(cid_width_p)
+   ,.hold_on_valid_p(hold_on_valid_p)
    ) client_concentrator
   (.clk_i(clk)
   ,.reset_i(reset)
@@ -343,8 +350,11 @@ module bsg_wormhole_concentrator_tester
         #500;
         
         // node enable
-        @(posedge node_clk); #1;
-        node_en = '1;
+        for (j = num_in_p-1; j >= 0; j--)
+          begin
+            @(posedge node_clk); #1;
+            node_en[j] = 1'b1;
+          end
 	    $display("node en HI");
         
         #10000;

--- a/testing/bsg_noc/bsg_wormhole_router/Makefile
+++ b/testing/bsg_noc/bsg_wormhole_router/Makefile
@@ -9,12 +9,12 @@ export BASEJUMP_STL_DIR = ../../..
 include $(BSG_CADENV_DIR)/cadenv.mk
 
 run:
-	$(VCS_BIN)/vcs -full64 -sverilog -timescale=1ps/1ps -f ./filelist -debug_pp -R -top bsg_wormhole_router_tester +vcs+vcdpluson
+	$(VCS_BIN)/vcs -full64 -sverilog -timescale=1ps/1ps -f ./filelist -debug_pp -R -top bsg_wormhole_router_tester +vcs+vcdpluson -assert svaext
     
 view:
 	$(VCS_BIN)/dve -full64 -vpd vcdplus.vpd &
 
-junk = csrc DVEfiles simv.daidir *.old *.vpd simv *.key
+junk = csrc DVEfiles simv.daidir *.old *.vpd simv *.key vc_hdrs.h
 
 clean:
 	rm -rf $(junk)

--- a/testing/bsg_noc/bsg_wormhole_router/bsg_wormhole_router_tester.v
+++ b/testing/bsg_noc/bsg_wormhole_router/bsg_wormhole_router_tester.v
@@ -54,6 +54,11 @@ module bsg_wormhole_router_tester
                                              : StrictXY|XY_Allow_S|XY_Allow_N
   
   ,parameter cord_width_p = cord_markers_pos_p[dims_p]
+  
+  // Hold on valid sets the arbitration policy such that once an output tag is selected, it
+  // remains selected until it is acked, then the round-robin scheduler continues cycling
+  // from the selected tag.
+  ,parameter hold_on_valid_p = 0
   )
   
   ();
@@ -121,6 +126,7 @@ module bsg_wormhole_router_tester
        ,.routing_matrix_p(routing_matrix_p)
        ,.reverse_order_p(reverse_order_p)
        ,.len_width_p(len_width_p)
+       ,.hold_on_valid_p(hold_on_valid_p)
        ) wr_fwd
        (.clk_i(clk)
 	,.reset_i(reset)
@@ -136,6 +142,7 @@ module bsg_wormhole_router_tester
        ,.routing_matrix_p(routing_matrix_p)
        ,.reverse_order_p(reverse_order_p)
        ,.len_width_p(len_width_p)
+       ,.hold_on_valid_p(hold_on_valid_p)
        ) wr_rev
        (.clk_i(clk)
 	,.reset_i(reset)
@@ -316,8 +323,11 @@ module bsg_wormhole_router_tester
         #500;
         
         // mc enable
-        @(posedge mc_clk); #1;
-        mc_en = '1;
+        for (j = dirs_p-1; j >= 0; j--)
+          begin
+            @(posedge mc_clk); #1;
+            mc_en[j] = 1'b1;
+          end
      $display("mc en HI");
         
         #10000;


### PR DESCRIPTION
This PR updates testbenches for wormhole router and concentrator. Now it supports hold_on_valid_p verification.