### PR TITLE
Make passthrough SIPO truly passthrough

### DIFF
--- a/bsg_dataflow/bsg_serial_in_parallel_out_passthrough.v
+++ b/bsg_dataflow/bsg_serial_in_parallel_out_passthrough.v
@@ -57,7 +57,7 @@ module bsg_serial_in_parallel_out_passthrough
   for (genvar i = 0; i < els_p-1; i++)
     begin: rof
       wire my_turn = v_i & count_r[i];
-      bsg_dff_en #(.width_p(width_p)) dff
+      bsg_dff_en_bypass #(.width_p(width_p)) dff
       (.clk_i
        ,.data_i
        ,.en_i   (my_turn)


### PR DESCRIPTION
The passthrough SIPO right now has weird behavior. It builds up incrementally and then comes through all at once. This was done to save hardware but breaks certain usecases which want to examine the intermediate results.

For instance, passing in ABCD would have C and D both available starting at cycle 4.

Instead, if we bypass each entry, the SIPO becomes truly passthrough. Then the output sequence will be ABCD as expected.

