### PR TITLE
fix latch warnings and seq logic assign in nonsynth_axi_mem

### DIFF
--- a/bsg_test/bsg_nonsynth_axi_mem.v
+++ b/bsg_test/bsg_nonsynth_axi_mem.v
@@ -74,6 +74,9 @@ module bsg_nonsynth_axi_mem
     axi_bresp_o = '0;
     axi_bvalid_o = 1'b0;
 
+    awaddr_n = awaddr_r;
+    awid_n = awid_r;
+
     case (wr_state_r)
       WR_RESET: begin
         axi_awready_o = 1'b0;
@@ -219,7 +222,7 @@ module bsg_nonsynth_axi_mem
       if ((wr_state_r == WR_WAIT_DATA) & axi_wvalid_i) begin
         for (integer i = 0; i < axi_strb_width_lp; i++) begin
           if (axi_wstrb_i[i]) begin
-            ram[wr_ram_idx][i*8+:8] = axi_wdata_i[i*8+:8];
+            ram[wr_ram_idx][i*8+:8] <= axi_wdata_i[i*8+:8];
           end
         end
       end


### PR DESCRIPTION
This PR fixes two latch warnings and a blocking assign in sequential logic present in the bsg_nonsynth_axi_mem module, discovered during zynq-parrot compilation with Verilator.