### PR TITLE
Unharden synth memories

### DIFF
--- a/bsg_mem/bsg_mem_1r1w.v
+++ b/bsg_mem/bsg_mem_1r1w.v
@@ -31,7 +31,6 @@ module bsg_mem_1r1w #(parameter `BSG_INV_PARAM(width_p)
      #(.width_p(width_p)
        ,.els_p(els_p)
        ,.read_write_same_addr_p(read_write_same_addr_p)
-       ,.harden_p(harden_p)
        ) synth
        (.*);
 

--- a/bsg_mem/bsg_mem_1r1w_sync.v
+++ b/bsg_mem/bsg_mem_1r1w_sync.v
@@ -54,7 +54,6 @@ module bsg_mem_1r1w_sync #(parameter `BSG_INV_PARAM(width_p)
      #(.width_p(width_p)
        ,.els_p(els_p)
        ,.read_write_same_addr_p(read_write_same_addr_p)
-       ,.harden_p(harden_p)
        ) synth
        (.clk_i( clk_lo )
        ,.reset_i

--- a/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit.v
+++ b/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit.v
@@ -52,7 +52,6 @@ module bsg_mem_1r1w_sync_mask_write_bit #(parameter `BSG_INV_PARAM(width_p)
      #(.width_p(width_p)
        ,.els_p (els_p  )
        ,.read_write_same_addr_p(read_write_same_addr_p)
-       ,.harden_p(harden_p)
        ,.disable_collision_warning_p(disable_collision_warning_p)
        ) synth
        (.clk_i(clk_lo)

--- a/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit_synth.v
+++ b/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit_synth.v
@@ -14,7 +14,6 @@ module bsg_mem_1r1w_sync_mask_write_bit_synth #(parameter `BSG_INV_PARAM(width_p
 						, parameter `BSG_INV_PARAM(els_p)
 						, parameter read_write_same_addr_p=0
 						, parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
-						, parameter harden_p=0
                                                 , parameter disable_collision_warning_p=1
                                         )
    (input   clk_i

--- a/bsg_mem/bsg_mem_1r1w_sync_synth.v
+++ b/bsg_mem/bsg_mem_1r1w_sync_synth.v
@@ -18,7 +18,6 @@ module bsg_mem_1r1w_sync_synth #(parameter `BSG_INV_PARAM(width_p)
 				 , parameter `BSG_INV_PARAM(els_p)
 				 , parameter read_write_same_addr_p=0
 				 , parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
-				 , parameter harden_p=0
 				 )
    (input   clk_i
     , input reset_i

--- a/bsg_mem/bsg_mem_1r1w_synth.v
+++ b/bsg_mem/bsg_mem_1r1w_synth.v
@@ -13,8 +13,7 @@
 module bsg_mem_1r1w_synth #(parameter `BSG_INV_PARAM(width_p)
 			    ,parameter `BSG_INV_PARAM(els_p)
 			    ,parameter read_write_same_addr_p=0
-			    ,parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
-			    ,parameter harden_p=0)
+			    ,parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p))
 (
   input w_clk_i
   ,input w_reset_i

--- a/bsg_mem/bsg_mem_1rw_sync_banked.v
+++ b/bsg_mem/bsg_mem_1rw_sync_banked.v
@@ -38,6 +38,7 @@ module bsg_mem_1rw_sync_banked
     , parameter bank_addr_width_lp=`BSG_SAFE_CLOG2(bank_depth_lp)
     , parameter depth_bank_idx_width_lp=`BSG_SAFE_CLOG2(num_depth_bank_p)
     , parameter bank_width_lp=(width_p/num_width_bank_p)
+    , parameter harden_p=0
   )
   (
     input clk_i
@@ -60,6 +61,7 @@ module bsg_mem_1rw_sync_banked
         .width_p(bank_width_lp)
         ,.els_p(bank_depth_lp)
         ,.latch_last_read_p(latch_last_read_p)
+        ,.harden_p(harden_p)
       ) bank (
         .clk_i(clk_i)
         ,.reset_i(reset_i)

--- a/bsg_mem/bsg_mem_2r1w_sync.v
+++ b/bsg_mem/bsg_mem_2r1w_sync.v
@@ -56,7 +56,6 @@ module bsg_mem_2r1w_sync #(parameter `BSG_INV_PARAM(width_p)
      #(.width_p(width_p)
        ,.els_p(els_p)
        ,.read_write_same_addr_p(read_write_same_addr_p)
-       ,.harden_p(harden_p)
        ) synth
     (.clk_i( clk_lo )
     ,.reset_i

--- a/bsg_mem/bsg_mem_2r1w_sync_synth.v
+++ b/bsg_mem/bsg_mem_2r1w_sync_synth.v
@@ -18,7 +18,6 @@ module bsg_mem_2r1w_sync_synth #(parameter `BSG_INV_PARAM(width_p)
 				 , parameter `BSG_INV_PARAM(els_p)
 				 , parameter read_write_same_addr_p=0
 				 , parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
-				 , parameter harden_p=0
 				 )
    (input   clk_i
     , input reset_i

--- a/bsg_mem/bsg_mem_3r1w_sync.v
+++ b/bsg_mem/bsg_mem_3r1w_sync.v
@@ -61,7 +61,6 @@ module bsg_mem_3r1w_sync #(parameter `BSG_INV_PARAM(width_p)
      #(.width_p(width_p)
        ,.els_p(els_p)
        ,.read_write_same_addr_p(read_write_same_addr_p)
-       ,.harden_p(harden_p)
        ) synth
     (.clk_i( clk_lo )
     ,.reset_i

--- a/bsg_mem/bsg_mem_3r1w_sync_synth.v
+++ b/bsg_mem/bsg_mem_3r1w_sync_synth.v
@@ -19,7 +19,6 @@ module bsg_mem_3r1w_sync_synth #(parameter `BSG_INV_PARAM(width_p)
 				 , parameter `BSG_INV_PARAM(els_p)
 				 , parameter read_write_same_addr_p=0
 				 , parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
-				 , parameter harden_p=0
 				 )
    (input   clk_i
     , input reset_i

--- a/hard/common/bsg_mem/bsg_mem_generator.py
+++ b/hard/common/bsg_mem/bsg_mem_generator.py
@@ -51,7 +51,6 @@ bsg_mem_1r1w_sync_template = """
         .width_p(width_p)
         ,.els_p(els_p)
         ,.read_write_same_addr_p(read_write_same_addr_p)
-        ,.harden_p(harden_p)
       ) synth (.*);
     end
 
@@ -114,7 +113,6 @@ bsg_mem_1r1w_sync_mask_write_bit_template = """
         .width_p(width_p)
         ,.els_p(els_p)
         ,.read_write_same_addr_p(read_write_same_addr_p)
-        ,.harden_p(harden_p)
       ) synth (.*);
     end
 
@@ -178,7 +176,6 @@ bsg_mem_1r1w_sync_mask_write_byte_template = """
         .width_p(width_p)
         ,.els_p(els_p)
         ,.read_write_same_addr_p(read_write_same_addr_p)
-        ,.harden_p(harden_p)
       ) synth (.*);
     end
 
@@ -232,7 +229,6 @@ module bsg_mem_1rw_sync #(parameter `BSG_INV_PARAM(width_p)
         .width_p(width_p)
         ,.els_p(els_p)
         ,.latch_last_read_p(latch_last_read_p)
-        ,.harden_p(harden_p)
       ) synth (.*);
     end
 
@@ -285,7 +281,6 @@ module bsg_mem_1rw_sync_mask_write_bit #(parameter `BSG_INV_PARAM(width_p)
         .width_p(width_p)
         ,.els_p(els_p)
         ,.latch_last_read_p(latch_last_read_p)
-        ,.harden_p(harden_p)
       ) synth (.*);
     end
 
@@ -339,7 +334,6 @@ module bsg_mem_1rw_sync_mask_write_byte #(parameter `BSG_INV_PARAM(data_width_p)
         .data_width_p(data_width_p)
         ,.els_p(els_p)
         ,.latch_last_read_p(latch_last_read_p)
-        ,.harden_p(harden_p)
       ) synth (.*);
     end
 
@@ -398,7 +392,6 @@ bsg_mem_2r1w_sync_template = """
         .width_p(width_p)
         ,.els_p(els_p)
         ,.read_write_same_addr_p(read_write_same_addr_p)
-        ,.harden_p(harden_p)
       ) synth (.*);
     end
 
@@ -463,7 +456,6 @@ bsg_mem_2rw_sync_template = """
         .width_p(width_p)
         ,.els_p(els_p)
         ,.read_write_same_addr_p(read_write_same_addr_p)
-        ,.harden_p(harden_p)
       ) synth (.*);
     end
 
@@ -530,7 +522,6 @@ bsg_mem_2rw_sync_mask_write_bit_template = """
         .width_p(width_p)
         ,.els_p(els_p)
         ,.read_write_same_addr_p(read_write_same_addr_p)
-        ,.harden_p(harden_p)
       ) synth (.*);
     end
 
@@ -598,7 +589,6 @@ bsg_mem_2rw_sync_mask_write_byte_template = """
         .width_p(width_p)
         ,.els_p(els_p)
         ,.read_write_same_addr_p(read_write_same_addr_p)
-        ,.harden_p(harden_p)
       ) synth (.*);
     end
 
@@ -664,7 +654,6 @@ bsg_mem_3r1w_sync_template = """
         .width_p(width_p)
         ,.els_p(els_p)
         ,.read_write_same_addr_p(read_write_same_addr_p)
-        ,.harden_p(harden_p)
       ) synth (.*);
     end
 


### PR DESCRIPTION
Some of our synth memories have parameters for harden_p, some do not. It doesn't really make sense to have in an explicitly synth block, so this PR removes the parameter. None of our code instantiates synth memories directly so no additional updates should be needed. It also updates bsg_mem_generator to reflect this