### PR TITLE
[WIP] Ultrascale plus byte mask block ram

### DIFF
--- a/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_synth.v
+++ b/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_synth.v
@@ -39,7 +39,7 @@ module bsg_mem_1rw_sync_mask_write_byte_synth
   begin: bk
     // this code causes inefficient block ram mapping with Xilinx Ultrascale FPGAs 
     // in Vivado, substitute this file with hard/ultrascale_plus/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v
-    `BSG_VIVADO_SYNTH_FAILS
+    //`BSG_VIVADO_SYNTH_FAILS
 
     bsg_mem_1rw_sync #( .width_p      (8)
                         ,.els_p        (els_p)

--- a/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_synth.v
+++ b/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_synth.v
@@ -37,10 +37,6 @@ module bsg_mem_1rw_sync_mask_write_byte_synth
 
   for(i=0; i<write_mask_width_lp; i=i+1)
   begin: bk
-    // this code causes inefficient block ram mapping with Xilinx Ultrascale FPGAs 
-    // in Vivado, substitute this file with hard/ultrascale_plus/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v
-    //`BSG_VIVADO_SYNTH_FAILS
-
     bsg_mem_1rw_sync #( .width_p      (8)
                         ,.els_p        (els_p)
                         ,.addr_width_lp(addr_width_lp)

--- a/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_synth.v
+++ b/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_synth.v
@@ -37,6 +37,10 @@ module bsg_mem_1rw_sync_mask_write_byte_synth
 
   for(i=0; i<write_mask_width_lp; i=i+1)
   begin: bk
+    // this code causes inefficient block ram mapping with Xilinx Ultrascale FPGAs 
+    // in Vivado, substitute this file with hard/ultrascale_plus/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v
+    `BSG_VIVADO_SYNTH_FAILS
+
     bsg_mem_1rw_sync #( .width_p      (8)
                         ,.els_p        (els_p)
                         ,.addr_width_lp(addr_width_lp)

--- a/hard/ultrascale_plus/bsg_mem/bsg_mem_1r1w_sync_mask_write_byte.v
+++ b/hard/ultrascale_plus/bsg_mem/bsg_mem_1r1w_sync_mask_write_byte.v
@@ -12,6 +12,29 @@
 * https://docs.xilinx.com/v/u/2019.1-English/ug901-vivado-synthesis
 *
 * reads are synchronous
+*
+*
+* By default, the tool selects which type of RAM to infer based upon heuristics
+* that give the best results for most designs. Possible RAM mappings are:
+*
+* ┌───────────┬──────────┬──────┬─────┬─────┬─────┬──────────────────────────────┐
+* │ RAM Type  │Primitives│ Size │PortA│PortB│wb_en│           Mapping            │
+* ├───────────┼──────────┼──────┼─────┼─────┼─────┼──────────────────────────────┤
+* │Distributed│  LUTRAM  │ N/A  │ N/A │ N/A │ N/A │Memory with small depth       │
+* ├───────────┼──────────┼──────┼─────┼─────┼─────┼──────────────────────────────┤
+* │           │ RAMB18E2 │ 18Kb │  W  │  R  │  Y  │Width narrower than 2 bytes   │
+* │ Block RAM ├──────────┼──────┼─────┼─────┼─────┼──────────────────────────────┤
+* │           │ RAMB36E2 │ 36Kb │  W  │  R  │  Y  │Width narrower than 4 bytes   │
+* ├───────────┼──────────┼──────┼─────┼─────┼─────┼──────────────────────────────┤
+* │ Ultra RAM │ URAM288  │288Kb │  W  │  R  │  Y  │Width wider than 4 bytes      │
+* └───────────┴──────────┴──────┴─────┴─────┴─────┴──────────────────────────────┘
+*
+* To force the RAM into a specific type, use the RAM_STYLE attribute to tell
+* Vivado synthesis to infer the target primitives:
+*
+* (* ram_style = "x" *) logic [data_size-1:0] mem [2**addr_size-1:0];
+* Where x = [block, distributed, registers, ultra]
+*
 */
 
 `include "bsg_defines.v"

--- a/hard/ultrascale_plus/bsg_mem/bsg_mem_1r1w_sync_mask_write_byte.v
+++ b/hard/ultrascale_plus/bsg_mem/bsg_mem_1r1w_sync_mask_write_byte.v
@@ -5,7 +5,8 @@
 * Write mode: No-change | Read mode: No-change
 * Note:
 * There are 2 basic BRAM library primitives, RAMB18E2 and RAMB36E2 in Vivado
-* Both of them support byte write enable
+* There is 1 URAM library primitive, URAM288 in Vivado
+* All of them support byte write enable
 *
 * Refer to Vivado Design Suite User Guide: Synthesis (UG901), Byte Write Enable (Block RAM)
 * https://docs.xilinx.com/v/u/2019.1-English/ug901-vivado-synthesis
@@ -55,9 +56,9 @@ module bsg_mem_1r1w_sync_mask_write_byte #(parameter `BSG_INV_PARAM(width_p)
   else
   begin: nz
 
-  /* WARNING: This implementation will use BRAM/URAM inference.
+  /* WARNING: Vivado will automatically choose between BRAM and URAM.
    *
-   * We also can support URAM inference
+   * We also can support URAM-only inference
    * (https://github.com/bespoke-silicon-group/basejump_stl/pull/564/files)
    * if we provide a hardened switch file which can choose between
    * BRAM and URAM inference based on depth and width parameterizations.

--- a/hard/ultrascale_plus/bsg_mem/bsg_mem_1r1w_sync_mask_write_byte.v
+++ b/hard/ultrascale_plus/bsg_mem/bsg_mem_1r1w_sync_mask_write_byte.v
@@ -1,0 +1,84 @@
+/*
+* bsg_mem_1r1w_sync_mask_write_byte.v
+*
+* 2-ports byte write mask block ram for xilinx ultrascale or ultrascale plus FPGA
+* Write mode: No-change | Read mode: No-change
+* Note:
+* There are 2 basic BRAM library primitives, RAMB18E2 and RAMB36E2 in Vivado
+* Both of them support byte write enable
+*
+* Refer to Vivado Design Suite User Guide: Synthesis (UG901), Byte Write Enable (Block RAM)
+* https://docs.xilinx.com/v/u/2019.1-English/ug901-vivado-synthesis
+*
+* reads are synchronous
+*/
+
+`include "bsg_defines.v"
+
+module bsg_mem_1r1w_sync_mask_write_byte #(parameter `BSG_INV_PARAM(width_p)
+                                         , parameter `BSG_INV_PARAM(els_p)
+                                         // semantics of "1" are write occurs, then read
+                                         // the other semantics cannot be simulated on a hardened, non-simultaneous
+                                         // 1r1w SRAM without changing timing.
+                                         // fixme: change to write_then_read_same_addr_p
+                                         , parameter read_write_same_addr_p=0
+                                         , parameter latch_last_read_p=0 
+                                         , parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
+                                         , parameter harden_p=0
+                                         , parameter disable_collision_warning_p=0
+                                         , parameter write_mask_width_lp = width_p>>3
+                                         , parameter enable_clock_gating_p=0
+                                         )
+   (input   clk_i
+    , input reset_i
+
+    , input                     w_v_i
+    // for each bit set in the mask, a byte is written
+   ,input [`BSG_SAFE_MINUS(write_mask_width_lp, 1):0] w_mask_i
+    , input [addr_width_lp-1:0] w_addr_i
+    , input [`BSG_SAFE_MINUS(width_p, 1):0]       w_data_i
+
+    , input                      r_v_i
+    , input [addr_width_lp-1:0]  r_addr_i
+
+    , output logic [`BSG_SAFE_MINUS(width_p, 1):0] r_data_o
+    );
+
+
+  wire unused = reset_i;
+
+  if (width_p == 0)
+  begin: z
+    wire unused0 = &{clk_i, w_v_i, w_mask_i, w_addr_i, w_data_i, r_v_i, r_addr_i};
+    assign r_data_o = '0;
+  end
+  else
+  begin: nz
+
+  /* WARNING: This implementation will use BRAM/URAM inference.
+   *
+   * We also can support URAM inference
+   * (https://github.com/bespoke-silicon-group/basejump_stl/pull/564/files)
+   * if we provide a hardened switch file which can choose between
+   * BRAM and URAM inference based on depth and width parameterizations.
+   */
+
+    logic [width_p-1:0] mem [els_p-1:0];
+
+    for(genvar i = 0; i < write_mask_width_lp; i++)
+      begin: write
+        always_ff @(posedge clk_i)
+            if(w_v_i)
+                if(w_mask_i[i])
+                    mem[w_addr_i][i*8+:8] <= w_data_i[i*8+:8];
+      end
+
+    always_ff @(posedge clk_i)
+        if(r_v_i)
+            r_data_o <= mem[r_addr_i];
+
+  end
+
+endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_mem_1r1w_sync_mask_write_byte)

--- a/hard/ultrascale_plus/bsg_mem/bsg_mem_1r1w_sync_mask_write_byte.v
+++ b/hard/ultrascale_plus/bsg_mem/bsg_mem_1r1w_sync_mask_write_byte.v
@@ -65,6 +65,12 @@ module bsg_mem_1r1w_sync_mask_write_byte #(parameter `BSG_INV_PARAM(width_p)
 
     logic [width_p-1:0] mem [els_p-1:0];
 
+  /* In order to synthesize into a byte masked BRAM/URAM, follow instruction in
+   * Xilinx doc "UG901", Section "Byte Write Enable (Block RAM)"
+   *
+   * Note: must follow the example code line-to-line, Vivado is very inflexible on this
+   */
+
     for(genvar i = 0; i < write_mask_width_lp; i++)
       begin: write
         always_ff @(posedge clk_i)

--- a/hard/ultrascale_plus/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v
+++ b/hard/ultrascale_plus/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v
@@ -54,10 +54,8 @@ module bsg_mem_1rw_sync_mask_write_byte #(parameter `BSG_INV_PARAM(els_p)
       end
 
     always_ff @(posedge clk_i)
-      begin: read
         if(v_i & ~w_i)
             data_o <= mem[addr_i];
-      end
 
   end
 

--- a/hard/ultrascale_plus/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v
+++ b/hard/ultrascale_plus/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v
@@ -46,6 +46,14 @@ module bsg_mem_1rw_sync_mask_write_byte #(parameter `BSG_INV_PARAM(els_p)
   else
   begin: nz
 
+  /* WARNING: This implementation will use BRAM inference.
+   *
+   * We also can support URAM inference
+   * (https://github.com/bespoke-silicon-group/basejump_stl/pull/564/files)
+   * if we provide a hardened switch file which can choose between
+   * BRAM and URAM inference based on depth and width parameterizations.
+   */
+
     logic [data_width_p-1:0] mem [els_p-1:0];
 
     for(genvar i = 0; i < write_mask_width_lp; i++)

--- a/hard/ultrascale_plus/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v
+++ b/hard/ultrascale_plus/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v
@@ -36,9 +36,11 @@ module bsg_mem_1rw_sync_mask_write_byte #(parameter `BSG_INV_PARAM(els_p)
    ,output logic [`BSG_SAFE_MINUS(data_width_p, 1):0] data_o
   );
 
+  wire unused = reset_i;
+
   if (data_width_p == 0)
   begin: z
-    wire unused0 = &{clk_i, reset_i, v_i, w_i, addr_i, data_i, write_mask_i};
+    wire unused0 = &{clk_i, v_i, w_i, addr_i, data_i, write_mask_i};
     assign data_o = '0;
   end
   else

--- a/hard/ultrascale_plus/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v
+++ b/hard/ultrascale_plus/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v
@@ -5,7 +5,8 @@
 * Write mode: No-change | Read mode: No-change
 * Note:
 * There are 2 basic BRAM library primitives, RAMB18E2 and RAMB36E2 in Vivado
-* Both of them support byte write enable
+* There is 1 URAM library primitive, URAM288 in Vivado
+* All of them support byte write enable
 *
 * Refer to Vivado Design Suite User Guide: Synthesis (UG901), Byte Write Enable (Block RAM)
 * https://docs.xilinx.com/v/u/2019.1-English/ug901-vivado-synthesis
@@ -46,9 +47,9 @@ module bsg_mem_1rw_sync_mask_write_byte #(parameter `BSG_INV_PARAM(els_p)
   else
   begin: nz
 
-  /* WARNING: This implementation will use BRAM/URAM inference.
+  /* WARNING: Vivado will automatically choose between BRAM and URAM.
    *
-   * We also can support URAM inference
+   * We also can support URAM-only inference
    * (https://github.com/bespoke-silicon-group/basejump_stl/pull/564/files)
    * if we provide a hardened switch file which can choose between
    * BRAM and URAM inference based on depth and width parameterizations.

--- a/hard/ultrascale_plus/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v
+++ b/hard/ultrascale_plus/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v
@@ -11,6 +11,28 @@
 * Refer to Vivado Design Suite User Guide: Synthesis (UG901), Byte Write Enable (Block RAM)
 * https://docs.xilinx.com/v/u/2019.1-English/ug901-vivado-synthesis
 *
+*
+* By default, the tool selects which type of RAM to infer based upon heuristics
+* that give the best results for most designs. Possible RAM mappings are:
+*
+* ┌───────────┬──────────┬──────┬─────┬─────┬─────┬──────────────────────────────┐
+* │ RAM Type  │Primitives│ Size │PortA│PortB│wb_en│           Mapping            │
+* ├───────────┼──────────┼──────┼─────┼─────┼─────┼──────────────────────────────┤
+* │Distributed│  LUTRAM  │ N/A  │ N/A │ N/A │ N/A │Memory with small depth       │
+* ├───────────┼──────────┼──────┼─────┼─────┼─────┼──────────────────────────────┤
+* │           │ RAMB18E2 │ 18Kb │ W R │  -  │  Y  │Width narrower than 2 bytes   │
+* │ Block RAM ├──────────┼──────┼─────┼─────┼─────┼──────────────────────────────┤
+* │           │ RAMB36E2 │ 36Kb │ W R │  -  │  Y  │Width narrower than 4 bytes   │
+* ├───────────┼──────────┼──────┼─────┼─────┼─────┼──────────────────────────────┤
+* │ Ultra RAM │ URAM288  │288Kb │ W R │  -  │  Y  │Width wider than 4 bytes      │
+* └───────────┴──────────┴──────┴─────┴─────┴─────┴──────────────────────────────┘
+*
+* To force the RAM into a specific type, use the RAM_STYLE attribute to tell
+* Vivado synthesis to infer the target primitives:
+*
+* (* ram_style = "x" *) logic [data_size-1:0] mem [2**addr_size-1:0];
+* Where x = [block, distributed, registers, ultra]
+*
 */
 
 `include "bsg_defines.v"

--- a/hard/ultrascale_plus/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v
+++ b/hard/ultrascale_plus/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v
@@ -46,7 +46,7 @@ module bsg_mem_1rw_sync_mask_write_byte #(parameter `BSG_INV_PARAM(els_p)
   else
   begin: nz
 
-  /* WARNING: This implementation will use BRAM inference.
+  /* WARNING: This implementation will use BRAM/URAM inference.
    *
    * We also can support URAM inference
    * (https://github.com/bespoke-silicon-group/basejump_stl/pull/564/files)

--- a/hard/ultrascale_plus/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v
+++ b/hard/ultrascale_plus/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v
@@ -55,17 +55,21 @@ module bsg_mem_1rw_sync_mask_write_byte #(parameter `BSG_INV_PARAM(els_p)
    */
 
     logic [data_width_p-1:0] mem [els_p-1:0];
+    logic [write_mask_width_lp-1:0] write_enable;
 
     for(genvar i = 0; i < write_mask_width_lp; i++)
       begin: write
+        assign write_enable[i] = w_i & write_mask_i[i];
         always_ff @(posedge clk_i)
-            if(v_i & w_i & write_mask_i[i])
-                mem[addr_i][i*8+:8] <= data_i[i*8+:8];
+            if(v_i)
+                if(write_enable[i])
+                    mem[addr_i][i*8+:8] <= data_i[i*8+:8];
       end
 
     always_ff @(posedge clk_i)
-        if(v_i & ~w_i)
-            data_o <= mem[addr_i];
+        if(v_i)
+            if(~|write_enable)
+                data_o <= mem[addr_i];
 
   end
 

--- a/hard/ultrascale_plus/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v
+++ b/hard/ultrascale_plus/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v
@@ -57,6 +57,12 @@ module bsg_mem_1rw_sync_mask_write_byte #(parameter `BSG_INV_PARAM(els_p)
     logic [data_width_p-1:0] mem [els_p-1:0];
     logic [write_mask_width_lp-1:0] write_enable;
 
+  /* In order to synthesize into a byte masked BRAM/URAM, follow instruction in
+   * Xilinx doc "UG901", Section "Byte Write Enable (Block RAM)"
+   *
+   * Note: must follow the example code line-to-line, Vivado is very inflexible on this
+   */
+
     for(genvar i = 0; i < write_mask_width_lp; i++)
       begin: write
         assign write_enable[i] = w_i & write_mask_i[i];

--- a/hard/ultrascale_plus/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v
+++ b/hard/ultrascale_plus/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v
@@ -1,0 +1,65 @@
+/*
+* bsg_mem_1rw_sync_mask_write_byte.v
+*
+* 1-port byte write mask block ram for xilinx ultrascale or ultrascale plus FPGA
+* Write mode: No-change | Read mode: No-change
+* Note:
+* There are 2 basic BRAM library primitives, RAMB18E2 and RAMB36E2 in Vivado
+* Both of them support byte write enable
+*
+* Refer to Vivado Design Suite User Guide: Synthesis (UG901), Byte Write Enable (Block RAM)
+* https://docs.xilinx.com/v/u/2019.1-English/ug901-vivado-synthesis
+*
+*/
+
+`include "bsg_defines.v"
+
+module bsg_mem_1rw_sync_mask_write_byte #(parameter `BSG_INV_PARAM(els_p)
+                                          ,parameter addr_width_lp = `BSG_SAFE_CLOG2(els_p)
+
+                                          ,parameter `BSG_INV_PARAM(data_width_p )
+                                          ,parameter latch_last_read_p=0
+                                          ,parameter write_mask_width_lp = data_width_p>>3
+                                          ,parameter enable_clock_gating_p=0
+                                         )
+  ( input clk_i
+   ,input reset_i
+
+   ,input v_i
+   ,input w_i
+
+   ,input [addr_width_lp-1:0]       addr_i
+   ,input [`BSG_SAFE_MINUS(data_width_p, 1):0]        data_i
+    // for each bit set in the mask, a byte is written
+   ,input [`BSG_SAFE_MINUS(write_mask_width_lp, 1):0] write_mask_i
+
+   ,output logic [`BSG_SAFE_MINUS(data_width_p, 1):0] data_o
+  );
+
+  if (data_width_p == 0)
+  begin: z
+    wire unused0 = &{clk_i, reset_i, v_i, w_i, addr_i, data_i, write_mask_i};
+    assign data_o = '0;
+  end
+  else
+  begin: nz
+
+    logic [data_width_p-1:0] mem [els_p-1:0];
+
+    for(genvar i = 0; i < write_mask_width_lp; i++)
+      begin: write
+        always_ff @(posedge clk_i)
+            if(v_i & w_i & write_mask_i[i])
+                mem[addr_i][i*8+:8] <= data_i[i*8+:8];
+      end
+
+    always_ff @(posedge clk_i)
+      begin: read
+        if(v_i & ~w_i)
+            data_o <= mem[addr_i];
+      end
+
+  end
+
+endmodule
+`BSG_ABSTRACT_MODULE(bsg_mem_1rw_sync_mask_write_byte)


### PR DESCRIPTION
Original code causes inefficient block ram mapping with Xilinx Ultrascale FPGAs, since every byte is mapped to a separate RAMB18E2 (50% utilization in the best case).

This PR hardens the byte masking block ram for Ultrascale Plus FPGAs. With this change, byte make BRAM utilization will reduce at least by half.

Reference: Vivado Design Suite User Guide: Synthesis (UG901), Byte Write Enable (Block RAM), https://docs.xilinx.com/v/u/2019.1-English/ug901-vivado-synthesis