### PR TITLE
Async fifo with cleaner CDC

### DIFF
--- a/bsg_async/bsg_async_fifo.v
+++ b/bsg_async/bsg_async_fifo.v
@@ -19,7 +19,14 @@ module bsg_async_fifo #(parameter `BSG_INV_PARAM(  lg_size_p )
                         // the data bits to allow for better control optimization.
                         // control_width_p is how many of the width_p bits are control bits;
                         // these bits should be at the top of the array
-                        , parameter   control_width_p = 0)
+                        , parameter   control_width_p = 0
+                        // When the fifo is empty, the rdata output of this fifo changes based
+                        // on wvalid, while rvalid is synchronized to the rclk. This can cause
+                        // timing violations on flops which directly latch the rdata without
+                        // considering the enable signal. This parameter zeros out data when
+                        // the fifo is empty to avoid these glitches. If receiving logic uses 
+                        // the rvalid signal, this extra hardware is unnecessary
+                        , parameter   glitchless_p = 1)
    (
     input    w_clk_i
     , input  w_reset_i
@@ -47,6 +54,9 @@ module bsg_async_fifo #(parameter `BSG_INV_PARAM(  lg_size_p )
    wire               r_valid_o_tmp; // remove inout warning from Lint
    assign r_valid_o = r_valid_o_tmp;
 
+   wire [width_p-1:0] r_data_o_tmp;
+   assign r_data_o = (glitchless_p & ~r_valid_o_tmp) ? '0 : r_data_o_tmp;
+
    bsg_mem_1r1w #(.width_p(width_p-control_width_p)
                   ,.els_p(size_lp)
 		  ,.read_write_same_addr_p(0)
@@ -60,7 +70,7 @@ module bsg_async_fifo #(parameter `BSG_INV_PARAM(  lg_size_p )
 
       ,.r_v_i   (r_valid_o_tmp                            )
       ,.r_addr_i(r_ptr_binary_r[0+:lg_size_p]             )
-      ,.r_data_o(r_data_o[0+:(width_p - control_width_p)] )
+      ,.r_data_o(r_data_o_tmp[0+:(width_p - control_width_p)] )
       );
 
    if (control_width_p > 0)
@@ -78,7 +88,7 @@ module bsg_async_fifo #(parameter `BSG_INV_PARAM(  lg_size_p )
 
            ,.r_v_i    (r_valid_o_tmp                     )
            ,.r_addr_i (r_ptr_binary_r[0+:lg_size_p]      )
-           ,.r_data_o (r_data_o[(width_p-1)-:control_width_p])
+           ,.r_data_o (r_data_o_tmp[(width_p-1)-:control_width_p])
            );
      end
 


### PR DESCRIPTION
This PR fixes an apparent problem with the async fifo when is connected to a module which unconditionally latches the output data (without considering the valid).

```
We're seeing a timing violation by connecting an async fifo to bsg_serial_in_parallel_out:
https://github.com/bespoke-silicon-group/basejump_stl/blob/master/bsg_async/bsg_async_fifo.v
https://github.com/bespoke-silicon-group/basejump_stl/blob/master/bsg_dataflow/bsg_serial_in_parallel_out.v
What's happening is the async fifo memory is getting updated with the write clock. Then, the data is asynchronously read by the reader. Note: the rvalid is low at this point, as expected. However, the bsg_serial_in_parallel_out updates its data every cycle, regardless of valid. Therefore, the data gets corrupted. It doesn't affect correctness as the valid signal comes a cycle after the data has settled. 
```

See header comment for further details