### PR TITLE
Adding Word Tracking to BSG Cache

### DIFF
--- a/bsg_cache/bsg_cache.v
+++ b/bsg_cache/bsg_cache.v
@@ -32,7 +32,7 @@ module bsg_cache
     ,parameter dma_data_width_p=data_width_p // default value. it can also be pow2 multiple of data_width_p.
 
     ,localparam bsg_cache_pkt_width_lp=`bsg_cache_pkt_width(addr_width_p,data_width_p)
-    ,localparam bsg_cache_dma_pkt_width_lp=`bsg_cache_dma_pkt_width(addr_width_p)
+    ,localparam bsg_cache_dma_pkt_width_lp=`bsg_cache_dma_pkt_width(addr_width_p, block_size_in_words_p)
     ,localparam burst_size_in_words_lp=(dma_data_width_p/data_width_p)
 
     ,parameter debug_p=0
@@ -58,7 +58,6 @@ module bsg_cache
     ,output logic dma_data_ready_o
 
     ,output logic [dma_data_width_p-1:0] dma_data_o
-    ,output logic [burst_size_in_words_lp-1:0] dma_wmask_o
     ,output logic dma_data_v_o
     ,input dma_data_yumi_i
 
@@ -543,7 +542,6 @@ end
     ,.dma_data_ready_o(dma_data_ready_o)
     
     ,.dma_data_o(dma_data_o)
-    ,.dma_wmask_o(dma_wmask_o)
     ,.dma_data_v_o(dma_data_v_o)
     ,.dma_data_yumi_i(dma_data_yumi_i)
 

--- a/bsg_cache/bsg_cache.v
+++ b/bsg_cache/bsg_cache.v
@@ -303,7 +303,8 @@ end
       ,data_v_r
       ,valid_v_r
       ,lock_v_r
-      ,tag_v_r} <= '0;
+      ,tag_v_r
+      ,track_data_v_r} <= '0;
     end
     else begin
       if (v_we) begin
@@ -437,6 +438,7 @@ end
   logic sbuf_empty_lo, tbuf_empty_lo;
   logic [lg_ways_lp-1:0] chosen_way_lo;
   logic select_snoop_data_r_lo;
+  logic miss_track_data_we_lo;
 
   bsg_cache_miss #(
     .addr_width_p(addr_width_p)
@@ -468,6 +470,8 @@ end
     ,.dma_way_o(dma_way_lo)
     ,.dma_addr_o(dma_addr_lo)
     ,.dma_done_i(dma_done_li)
+
+    ,.track_data_we_o(miss_track_data_we_lo)
 
     ,.stat_info_i(stat_mem_data_lo)
 
@@ -525,6 +529,8 @@ end
     ,.dma_way_i(dma_way_lo)
     ,.dma_addr_i(dma_addr_lo)
     ,.done_o(dma_done_li)
+
+    ,.track_data_we_i(miss_track_data_we_lo)
 
     ,.snoop_word_o(snoop_word_lo)
     

--- a/bsg_cache/bsg_cache.v
+++ b/bsg_cache/bsg_cache.v
@@ -22,6 +22,7 @@ module bsg_cache
     ,parameter `BSG_INV_PARAM(block_size_in_words_p)
     ,parameter `BSG_INV_PARAM(sets_p)
     ,parameter `BSG_INV_PARAM(ways_p)
+    ,parameter `BSG_INV_PARAM(word_tracking_p)
 
     // Explicit size prevents size inference and allows for ((foo == bar) << e_cache_amo_swap)
     ,parameter [31:0] amo_support_p=(1 << e_cache_amo_swap)
@@ -30,8 +31,9 @@ module bsg_cache
     // dma burst width
     ,parameter dma_data_width_p=data_width_p // default value. it can also be pow2 multiple of data_width_p.
 
-    ,parameter bsg_cache_pkt_width_lp=`bsg_cache_pkt_width(addr_width_p,data_width_p)
-    ,parameter bsg_cache_dma_pkt_width_lp=`bsg_cache_dma_pkt_width(addr_width_p)
+    ,localparam bsg_cache_pkt_width_lp=`bsg_cache_pkt_width(addr_width_p,data_width_p)
+    ,localparam bsg_cache_dma_pkt_width_lp=`bsg_cache_dma_pkt_width(addr_width_p)
+    ,localparam burst_size_in_words_lp=(dma_data_width_p/data_width_p)
 
     ,parameter debug_p=0
   )
@@ -56,6 +58,7 @@ module bsg_cache
     ,output logic dma_data_ready_o
 
     ,output logic [dma_data_width_p-1:0] dma_data_o
+    ,output logic [burst_size_in_words_lp-1:0] dma_wmask_o
     ,output logic dma_data_v_o
     ,input dma_data_yumi_i
 
@@ -81,7 +84,6 @@ module bsg_cache
   localparam data_sel_mux_els_lp = `BSG_MIN(4,lg_data_mask_width_lp+1);
   localparam lg_data_sel_mux_els_lp = `BSG_SAFE_CLOG2(data_sel_mux_els_lp);
 
-  localparam burst_size_in_words_lp=(dma_data_width_p/data_width_p);
   localparam lg_burst_size_in_words_lp=`BSG_SAFE_CLOG2(burst_size_in_words_lp);
   localparam burst_len_lp=(block_size_in_words_p*data_width_p/dma_data_width_p);
   localparam lg_burst_len_lp=`BSG_SAFE_CLOG2(burst_len_lp);
@@ -245,6 +247,38 @@ module bsg_cache
     ,.data_o(data_mem_data_lo)
   );
 
+
+  // track_mem
+  //
+  logic track_mem_v_li;
+  logic track_mem_w_li;
+  logic [lg_sets_lp-1:0] track_mem_addr_li;
+  logic [ways_p-1:0][block_size_in_words_p-1:0] track_mem_data_li;
+  logic [ways_p-1:0][block_size_in_words_p-1:0] track_mem_w_mask_li;
+  logic [ways_p-1:0][block_size_in_words_p-1:0] track_mem_data_lo;
+
+if (word_tracking_p) begin
+  bsg_mem_1rw_sync_mask_write_bit #(
+    .width_p(block_size_in_words_p*ways_p)
+    ,.els_p(sets_p)
+    ,.latch_last_read_p(1)
+  ) track_mem (
+    .clk_i(clk_i)
+    ,.reset_i(reset_i)
+    ,.v_i(track_mem_v_li)
+    ,.w_i(track_mem_w_li)
+    ,.addr_i(track_mem_addr_li)
+    ,.data_i(track_mem_data_li)
+    ,.w_mask_i(track_mem_w_mask_li)
+    ,.data_o(track_mem_data_lo)
+  );
+end
+else begin
+  for (genvar i = 0; i < ways_p; i++) begin
+    assign track_mem_data_lo[i] = {block_size_in_words_p{1'b1}};
+  end
+end
+
   // v stage
   //
   logic v_we;
@@ -257,6 +291,7 @@ module bsg_cache
   logic [ways_p-1:0] lock_v_r;
   logic [ways_p-1:0][tag_width_lp-1:0] tag_v_r;
   logic [ways_p-1:0][dma_data_width_p-1:0] ld_data_v_r;
+  logic [ways_p-1:0][block_size_in_words_p-1:0] track_data_v_r;
   logic retval_op_v;
 
   always_ff @ (posedge clk_i) begin
@@ -282,6 +317,7 @@ module bsg_cache
           tag_v_r <= tag_tl;
           lock_v_r <= lock_tl;
           ld_data_v_r <= data_mem_data_lo;
+          track_data_v_r <= track_mem_data_lo;
         end
       end
     end
@@ -291,7 +327,8 @@ module bsg_cache
   
   logic [tag_width_lp-1:0] addr_tag_v;
   logic [lg_sets_lp-1:0] addr_index_v;
-  logic [lg_ways_lp-1:0] addr_way_v; 
+  logic [lg_ways_lp-1:0] addr_way_v;
+  logic [lg_block_size_in_words_lp-1:0] addr_block_offset_v;
   logic [ways_p-1:0] tag_hit_v;
 
   assign addr_tag_v =
@@ -300,6 +337,8 @@ module bsg_cache
     addr_v_r[block_offset_width_lp+:lg_sets_lp];
   assign addr_way_v =
     addr_v_r[block_offset_width_lp+lg_sets_lp+:lg_ways_lp];
+  assign addr_block_offset_v =
+    addr_v_r[lg_data_mask_width_lp+:lg_block_size_in_words_lp];
 
   for (genvar i = 0; i < ways_p; i++) begin
     assign tag_hit_v[i] = (addr_tag_v == tag_v_r[i]) & valid_v_r[i];
@@ -318,18 +357,25 @@ module bsg_cache
     ,.v_o(tag_hit_found)
   );
 
-  wire ld_st_miss = ~tag_hit_found & (decode_v_r.ld_op | decode_v_r.st_op);
+  logic bypass_track_lo;
+
+  wire partial_st    = decode.st_op & (decode.data_size_op < lg_data_mask_width_lp);
+  wire partial_st_tl = decode_tl_r.st_op & (decode_tl_r.data_size_op < lg_data_mask_width_lp);
+  wire partial_st_v  = decode_v_r.st_op & (decode_v_r.data_size_op < lg_data_mask_width_lp);
+
+  wire ld_st_amo_tag_miss = (decode_v_r.ld_op | decode_v_r.st_op | decode_v_r.atomic_op) & ~tag_hit_found;
+  wire track_miss = (decode_v_r.ld_op | decode_v_r.atomic_op | partial_st_v)
+                    & tag_hit_found & ~(track_data_v_r[tag_hit_way_id][addr_block_offset_v] | bypass_track_lo); 
   wire tagfl_hit = decode_v_r.tagfl_op & valid_v_r[addr_way_v];
   wire aflinv_hit = (decode_v_r.afl_op | decode_v_r.aflinv_op| decode_v_r.ainv_op) & tag_hit_found;
   wire alock_miss = decode_v_r.alock_op & (tag_hit_found ? ~lock_v_r[tag_hit_way_id] : 1'b1);   // either the line is miss, or the line is unlocked.
   wire aunlock_hit = decode_v_r.aunlock_op & (tag_hit_found ? lock_v_r[tag_hit_way_id] : 1'b0); // the line is hit and locked. 
-  wire atomic_miss = decode_v_r.atomic_op & ~tag_hit_found;
 
   // miss_v signal activates the miss handling unit.
   // MBT: the ~decode_v_r.tagst_op is necessary at the top of this expression
   //      to avoid X-pessimism post synthesis due to X's coming out of the tags
   wire miss_v = (~decode_v_r.tagst_op) & v_v_r
-    & (ld_st_miss | tagfl_hit | aflinv_hit | alock_miss | aunlock_hit | atomic_miss);
+    & (ld_st_amo_tag_miss | track_miss | tagfl_hit | aflinv_hit | alock_miss | aunlock_hit);
   
   // ops that return some value other than '0.
   assign retval_op_v = decode_v_r.ld_op | decode_v_r.taglv_op | decode_v_r.tagla_op | decode_v_r.atomic_op; 
@@ -382,7 +428,13 @@ module bsg_cache
   bsg_cache_tag_info_s [ways_p-1:0] miss_tag_mem_data_lo;
   bsg_cache_tag_info_s [ways_p-1:0] miss_tag_mem_w_mask_lo;
 
-  logic sbuf_empty_li;
+  logic miss_track_mem_v_lo;
+  logic miss_track_mem_w_lo;
+  logic [lg_sets_lp-1:0] miss_track_mem_addr_lo;
+  logic [ways_p-1:0][block_size_in_words_p-1:0] miss_track_mem_w_mask_lo;
+  logic [ways_p-1:0][block_size_in_words_p-1:0] miss_track_mem_data_lo;
+
+  logic sbuf_empty_lo, tbuf_empty_lo;
   logic [lg_ways_lp-1:0] chosen_way_lo;
   logic select_snoop_data_r_lo;
 
@@ -392,22 +444,25 @@ module bsg_cache
     ,.sets_p(sets_p)
     ,.block_size_in_words_p(block_size_in_words_p)
     ,.ways_p(ways_p)
+    ,.word_tracking_p(word_tracking_p)
   ) miss (
     .clk_i(clk_i)
     ,.reset_i(reset_i)
     
     ,.miss_v_i(miss_v)
+    ,.track_miss_i(track_miss)
     ,.decode_v_i(decode_v_r)
     ,.addr_v_i(addr_v_r)
 
     ,.tag_v_i(tag_v_r)
     ,.valid_v_i(valid_v_r)
     ,.lock_v_i(lock_v_r)
-    ,.tag_hit_way_id_i(tag_hit_way_id)
     ,.tag_hit_v_i(tag_hit_v)
+    ,.tag_hit_way_id_i(tag_hit_way_id)
     ,.tag_hit_found_i(tag_hit_found)
 
-    ,.sbuf_empty_i(sbuf_empty_li)
+    ,.sbuf_empty_i(sbuf_empty_lo)
+    ,.tbuf_empty_i(tbuf_empty_lo)
  
     ,.dma_cmd_o(dma_cmd_lo) 
     ,.dma_way_o(dma_way_lo)
@@ -427,6 +482,12 @@ module bsg_cache
     ,.tag_mem_addr_o(miss_tag_mem_addr_lo)
     ,.tag_mem_data_o(miss_tag_mem_data_lo)
     ,.tag_mem_w_mask_o(miss_tag_mem_w_mask_lo)
+
+    ,.track_mem_v_o(miss_track_mem_v_lo)
+    ,.track_mem_w_o(miss_track_mem_w_lo)
+    ,.track_mem_addr_o(miss_track_mem_addr_lo)
+    ,.track_mem_w_mask_o(miss_track_mem_w_mask_lo)
+    ,.track_mem_data_o(miss_track_mem_data_lo)
 
     ,.recover_o(recover_lo)
     ,.done_o(miss_done_lo) 
@@ -453,6 +514,7 @@ module bsg_cache
     ,.block_size_in_words_p(block_size_in_words_p)
     ,.sets_p(sets_p)
     ,.ways_p(ways_p)
+    ,.word_tracking_p(word_tracking_p)
     ,.dma_data_width_p(dma_data_width_p)
     ,.debug_p(debug_p)
   ) dma (
@@ -475,6 +537,7 @@ module bsg_cache
     ,.dma_data_ready_o(dma_data_ready_o)
     
     ,.dma_data_o(dma_data_o)
+    ,.dma_wmask_o(dma_wmask_o)
     ,.dma_data_v_o(dma_data_v_o)
     ,.dma_data_yumi_i(dma_data_yumi_i)
 
@@ -484,7 +547,10 @@ module bsg_cache
     ,.data_mem_w_mask_o(dma_data_mem_w_mask_lo)
     ,.data_mem_data_o(dma_data_mem_data_lo)
     ,.data_mem_data_i(data_mem_data_lo)
-    
+
+    ,.track_miss_i(track_miss)
+    ,.track_mem_data_i(track_mem_data_lo)
+
     ,.dma_evict_o(dma_evict_lo)
   ); 
 
@@ -499,8 +565,8 @@ module bsg_cache
   logic sbuf_yumi_li;
   bsg_cache_sbuf_entry_s sbuf_entry_lo;
 
-  logic [addr_width_p-1:0] bypass_addr_li;
-  logic bypass_v_li;
+  logic [addr_width_p-1:0] sbuf_bypass_addr_li;
+  logic sbuf_bypass_v_li;
   logic [data_width_p-1:0] bypass_data_lo;
   logic [data_mask_width_lp-1:0] bypass_mask_lo;
   logic sbuf_full_lo;
@@ -520,11 +586,11 @@ module bsg_cache
     ,.v_o(sbuf_v_lo)
     ,.yumi_i(sbuf_yumi_li)
 
-    ,.empty_o(sbuf_empty_li)
+    ,.empty_o(sbuf_empty_lo)
     ,.full_o(sbuf_full_lo)
 
-    ,.bypass_addr_i(bypass_addr_li)
-    ,.bypass_v_i(bypass_v_li)
+    ,.bypass_addr_i(sbuf_bypass_addr_li)
+    ,.bypass_v_i(sbuf_bypass_v_li)
     ,.bypass_data_o(bypass_data_lo)
     ,.bypass_mask_o(bypass_mask_lo)
   ); 
@@ -715,6 +781,79 @@ module bsg_cache
     end
   end
 
+  // track buffer
+  //
+  logic tbuf_v_li;
+  logic [lg_ways_lp-1:0] tbuf_way_li;
+  logic [addr_width_p-1:0] tbuf_addr_li;
+
+  logic tbuf_v_lo;
+  logic tbuf_yumi_li;
+  logic [lg_ways_lp-1:0] tbuf_way_lo;
+  logic [addr_width_p-1:0] tbuf_addr_lo;
+
+  logic [addr_width_p-1:0] tbuf_bypass_addr_li;
+  logic tbuf_bypass_v_li;
+  logic tbuf_full_lo;
+
+if (word_tracking_p) begin
+  bsg_cache_tbuf #(
+    .data_width_p(data_width_p)
+    ,.addr_width_p(addr_width_p)
+    ,.ways_p(ways_p)
+  ) tbuf (
+    .clk_i(clk_i)
+    ,.reset_i(reset_i)
+
+    ,.addr_i(tbuf_addr_li)
+    ,.way_i(tbuf_way_li)
+    ,.v_i(tbuf_v_li)
+
+    ,.addr_o(tbuf_addr_lo)
+    ,.way_o(tbuf_way_lo)
+    ,.v_o(tbuf_v_lo)
+    ,.yumi_i(tbuf_yumi_li)
+
+    ,.empty_o(tbuf_empty_lo)
+    ,.full_o(tbuf_full_lo)
+
+    ,.bypass_addr_i(tbuf_bypass_addr_li)
+    ,.bypass_v_i(tbuf_bypass_v_li)
+    ,.bypass_track_o(bypass_track_lo)
+  );
+end
+else begin
+  assign tbuf_v_lo = 1'b0;
+  assign tbuf_empty_lo = 1'b1;
+  assign tbuf_full_lo = 1'b0;
+  assign bypass_track_lo = 1'b0;
+end
+
+  logic [ways_p-1:0] tbuf_way_decode;
+  bsg_decode #(
+    .num_out_p(ways_p)
+  ) tbuf_way_demux (
+    .i(tbuf_way_lo)
+    ,.o(tbuf_way_decode)
+  );
+
+  logic [block_size_in_words_p-1:0] tbuf_word_offset_decode;
+  bsg_decode #(
+    .num_out_p(block_size_in_words_p)
+  ) tbuf_wo_demux (
+    .i(tbuf_addr_lo[lg_data_mask_width_lp+:lg_block_size_in_words_lp])
+    ,.o(tbuf_word_offset_decode)
+  );
+
+  logic [lg_sets_lp-1:0] tbuf_track_mem_addr;
+  logic [ways_p-1:0][block_size_in_words_p-1:0] tbuf_track_mem_w_mask;
+  logic [ways_p-1:0][block_size_in_words_p-1:0] tbuf_track_mem_data;
+
+  assign tbuf_track_mem_addr = tbuf_addr_lo[block_offset_width_lp+:lg_sets_lp];
+  for (genvar i = 0 ; i < ways_p; i++) begin
+    assign tbuf_track_mem_data[i] = {block_size_in_words_p{1'b1}};
+    assign tbuf_track_mem_w_mask[i] = tbuf_way_decode[i] ? tbuf_word_offset_decode : {block_size_in_words_p{1'b0}};
+  end
 
   // output stage
   //
@@ -838,12 +977,12 @@ module bsg_cache
 
   // during miss, tl pipeline cannot take next instruction when
   // 1) input is tagst
-  // 2) miss handler is writing to tag_mem
+  // 2) miss handler is writing to tag_mem or track_mem
   // 3) dma engine is writing to data_mem
   // 4) tl_stage is recovering from tag_miss
   // 5) DMA is evicting a block.
   wire tl_ready = (miss_v
-    ? (~(decode.tagst_op & v_i) & ~miss_tag_mem_v_lo & ~dma_data_mem_v_lo & ~recover_lo & ~dma_evict_lo)
+    ? (~(decode.tagst_op & v_i) & ~miss_tag_mem_v_lo & ~miss_track_mem_v_lo & ~dma_data_mem_v_lo & ~recover_lo & ~dma_evict_lo)
     : 1'b1) & ~sbuf_hazard;
 
   assign ready_o = v_tl_r
@@ -926,6 +1065,32 @@ module bsg_cache
     : sbuf_data_mem_w_mask;
 
 
+  // track_mem ctrl logic
+  //
+  assign track_mem_v_li = ((v_i & ready_o & (decode.ld_op | decode.atomic_op | partial_st))
+    | (v_tl_r & recover_lo & (decode_tl_r.ld_op | decode_tl_r.atomic_op | partial_st_tl))
+    | miss_track_mem_v_lo
+    | (tbuf_v_lo & tbuf_yumi_li)
+  );
+
+  assign track_mem_w_li = miss_track_mem_w_lo | (tbuf_v_lo & tbuf_yumi_li);
+
+  assign track_mem_data_li = miss_track_mem_v_lo
+    ? miss_track_mem_data_lo
+    : tbuf_track_mem_data;
+
+  assign track_mem_w_mask_li = miss_track_mem_v_lo
+    ? miss_track_mem_w_mask_lo
+    : tbuf_track_mem_w_mask;
+
+  assign track_mem_addr_li = recover_lo
+    ? addr_index_tl
+    : (miss_track_mem_v_lo
+      ? miss_track_mem_addr_lo
+      : (((decode.ld_op | decode.atomic_op | partial_st) & v_i & ready_o)
+        ? addr_index
+        : tbuf_track_mem_addr));
+
   // stat_mem ctrl logic
   // TAGST clears the stat_info as it exits tv stage.
   // If it's load or store, and there is a hit, it updates the dirty bits and LRU.
@@ -989,8 +1154,27 @@ module bsg_cache
     & (~dma_data_mem_v_lo)
     & ~(v_tl_r & (decode_tl_r.ld_op | decode_tl_r.atomic_op) & (~v_we) & (~miss_v)); 
 
-  assign bypass_addr_li = addr_tl_r;
-  assign bypass_v_li = (decode_tl_r.ld_op | decode_tl_r.atomic_op) & v_tl_r & v_we;
+  assign sbuf_bypass_addr_li = addr_tl_r;
+  assign sbuf_bypass_v_li = (decode_tl_r.ld_op | decode_tl_r.atomic_op) & v_tl_r & v_we;
+
+  // track buffer
+  //
+  assign tbuf_v_li = (decode_v_r.st_op & ~partial_st_v) & v_o & yumi_i;
+  assign tbuf_way_li = miss_v ? chosen_way_lo : tag_hit_way_id;
+  assign tbuf_addr_li = addr_v_r;
+  // track buffer can write to track mem when
+  // 1) there is valid entry in track buffer.
+  // 2) incoming request does not read track mem.
+  // 3) miss handler is not accessing track mem.
+  // 4) TL read track mem (and bypass from tbuf), and TV is not stalled (v_we).
+  //    During miss, the track buffer can be drained.
+  assign tbuf_yumi_li = tbuf_v_lo
+    & ~((decode.ld_op | decode.atomic_op | partial_st) & v_i & ready_o)
+    & (~miss_track_mem_v_lo)
+    & ~(v_tl_r & (decode_tl_r.ld_op | decode_tl_r.atomic_op | partial_st_tl) & (~v_we) & (~miss_v));
+
+  assign tbuf_bypass_addr_li = addr_tl_r;
+  assign tbuf_bypass_v_li = (decode_tl_r.ld_op | decode_tl_r.atomic_op | partial_st_tl) & v_tl_r & v_we;
 
 
   // synopsys translate_off

--- a/bsg_cache/bsg_cache.vh
+++ b/bsg_cache/bsg_cache.vh
@@ -15,14 +15,15 @@
 
   // bsg_cache_dma_pkt_s
   //
-  `define declare_bsg_cache_dma_pkt_s(addr_width_mp) \
-    typedef struct packed {                          \
-      logic write_not_read;                          \
-      logic [addr_width_mp-1:0] addr;                \
+  `define declare_bsg_cache_dma_pkt_s(addr_width_mp, mask_width_mp) \
+    typedef struct packed {                                         \
+      logic write_not_read;                                         \
+      logic [addr_width_mp-1:0] addr;                               \
+      logic [mask_width_mp-1:0] mask;                               \
     } bsg_cache_dma_pkt_s
 
-  `define bsg_cache_dma_pkt_width(addr_width_mp)     \
-    (1+addr_width_mp)
+  `define bsg_cache_dma_pkt_width(addr_width_mp, mask_width_mp)     \
+    (1+addr_width_mp+mask_width_mp)
 
   // tag info s
   //

--- a/bsg_cache/bsg_cache_dma.v
+++ b/bsg_cache/bsg_cache_dma.v
@@ -46,6 +46,8 @@ module bsg_cache_dma
     ,input [addr_width_p-1:0] dma_addr_i
     ,output logic done_o
 
+    ,input track_data_we_i
+
     ,output logic [data_width_p-1:0] snoop_word_o
 
     ,output logic [bsg_cache_dma_pkt_width_lp-1:0] dma_pkt_o
@@ -162,7 +164,6 @@ module bsg_cache_dma
   assign dma_pkt_o = dma_pkt;
 
   // track bits
-  logic track_mem_data_we;
   logic [ways_p-1:0][block_size_in_words_p-1:0] track_mem_data_r;
   logic [block_size_in_words_p-1:0] track_data_way_picked;
   logic [block_size_in_words_p-1:0] track_bits;
@@ -284,8 +285,6 @@ end
 
     dma_evict_o = 1'b0;
 
-    track_mem_data_we = 1'b0;
-
     case (dma_state_r)
 
       // wait for dma_cmd from bsg_cache_miss.
@@ -309,7 +308,6 @@ end
           end
 
           e_dma_send_evict_addr: begin
-            track_mem_data_we = 1'b1;
             dma_pkt_v_o = 1'b1;
             dma_pkt.write_not_read = 1'b1;
             done_o = dma_pkt_yumi_i;
@@ -317,7 +315,6 @@ end
           end
 
           e_dma_get_fill_data: begin
-            track_mem_data_we = 1'b1;
             counter_clear = 1'b1;
             dma_state_n = GET_FILL_DATA;
           end
@@ -429,7 +426,7 @@ end
         snoop_word_o <= snoop_word_n;
       end 
 
-      if (track_mem_data_we) begin
+      if (track_data_we_i) begin
         track_mem_data_r <= track_mem_data_i;
       end
 

--- a/bsg_cache/bsg_cache_miss.v
+++ b/bsg_cache/bsg_cache_miss.v
@@ -56,6 +56,8 @@ module bsg_cache_miss
     ,output logic [addr_width_p-1:0] dma_addr_o
     ,input dma_done_i
 
+    ,output logic track_data_we_o
+
     // from stat_mem
     ,input [stat_info_width_lp-1:0] stat_info_i
 
@@ -581,12 +583,14 @@ module bsg_cache_miss
       flush_way_r <= '0;
       select_snoop_data_r <= 1'b0;
       // added to be a little more X pessimism conservative
+      track_data_we_o <= 1'b0;
     end
     else begin
       miss_state_r <= miss_state_n;
       chosen_way_r <= chosen_way_n;
       flush_way_r <= flush_way_n;
       select_snoop_data_r <= select_snoop_data_n;
+      track_data_we_o <= track_mem_v_o & ~track_mem_w_o;
     end
   end
 

--- a/bsg_cache/bsg_cache_miss.v
+++ b/bsg_cache/bsg_cache_miss.v
@@ -420,7 +420,7 @@ module bsg_cache_miss
         // set stat mem entry on store tag miss.
         stat_mem_v_o = dma_done_i & st_tag_miss_op;
         stat_mem_w_o = dma_done_i & st_tag_miss_op;
-        stat_mem_data_out.dirty = {ways_p{decode_v_i.st_op | decode_v_i.atomic_op}};
+        stat_mem_data_out.dirty = {ways_p{1'b1}};
         stat_mem_data_out.lru_bits = chosen_way_lru_data;
         stat_mem_w_mask_out.dirty = chosen_way_decode;
         stat_mem_w_mask_out.lru_bits = chosen_way_lru_mask;
@@ -462,8 +462,9 @@ module bsg_cache_miss
           {(lg_data_mask_width_lp){1'b0}}
         };
 
-        // For store miss, set the dirty bit for the chosen way.
-        // For load miss, clear the dirty bit for the chosen way.
+        // For store tag miss, set the dirty bit for the chosen way.
+        // For load tag miss, clear the dirty bit for the chosen way.
+        // For track miss, do not touch the dirty bit for the chosen way.
         // Set the lru_bits, so that the chosen way is not the LRU.
         // We are choosing a way to bring in a new block, which is technically
         // the MRU. lru decode unit generates the next state LRU bits, so that
@@ -472,7 +473,7 @@ module bsg_cache_miss
         stat_mem_w_o = dma_done_i;
         stat_mem_data_out.dirty = {ways_p{decode_v_i.st_op | decode_v_i.atomic_op}};
         stat_mem_data_out.lru_bits = chosen_way_lru_data;
-        stat_mem_w_mask_out.dirty = chosen_way_decode;
+        stat_mem_w_mask_out.dirty = track_miss_i ? {ways_p{1'b0}} : chosen_way_decode;
         stat_mem_w_mask_out.lru_bits = chosen_way_lru_mask;
 
         // set the tag and the valid bit to 1'b1 for the chosen way.
@@ -522,7 +523,7 @@ module bsg_cache_miss
       STORE_TAG_MISS_ALLOCATE: begin
         stat_mem_v_o = 1'b1;
         stat_mem_w_o = 1'b1;
-        stat_mem_data_out.dirty = {ways_p{decode_v_i.st_op | decode_v_i.atomic_op}};
+        stat_mem_data_out.dirty = {ways_p{1'b1}};
         stat_mem_data_out.lru_bits = chosen_way_lru_data;
         stat_mem_w_mask_out.dirty = chosen_way_decode;
         stat_mem_w_mask_out.lru_bits = chosen_way_lru_mask;

--- a/bsg_cache/bsg_cache_tbuf.v
+++ b/bsg_cache/bsg_cache_tbuf.v
@@ -156,13 +156,13 @@ module bsg_cache_tbuf
   assign tag_hit1 = tag_hit1_n & el1_valid;
   assign tag_hit2 = tag_hit2_n & v_i;
 
-  assign bypass_track_n = bypass_v_i & (tag_hit0 | tag_hit1 | tag_hit2);
+  assign bypass_track_n = (tag_hit0 | tag_hit1 | tag_hit2);
 
   always_ff @ (posedge clk_i) begin
     if (reset_i) begin
       bypass_track_o <= '0;
     end
-    else begin
+    else if (bypass_v_i) begin
       bypass_track_o <= bypass_track_n;
     end
   end

--- a/bsg_cache/bsg_cache_tbuf.v
+++ b/bsg_cache/bsg_cache_tbuf.v
@@ -1,0 +1,180 @@
+/**
+ *  bsg_cache_tbuf.v
+ *
+ *  track (write) buffer.
+ *
+ *  input interface is valid-only.
+ *  output interface is valid-yumi;
+ *  
+ *  el1 is head of the queue.
+ *  el0 is the tail.
+ *
+ *  @author tommy
+ */
+
+`include "bsg_defines.v"
+`include "bsg_cache.vh"
+
+module bsg_cache_tbuf
+  import bsg_cache_pkg::*;
+  #(parameter `BSG_INV_PARAM(data_width_p)
+    ,parameter `BSG_INV_PARAM(addr_width_p)
+    ,parameter `BSG_INV_PARAM(ways_p)
+
+    ,localparam way_id_width_lp=`BSG_SAFE_CLOG2(ways_p)
+  )
+  (
+    input clk_i
+    ,input reset_i
+
+    ,input [addr_width_p-1:0] addr_i
+    ,input [way_id_width_lp-1:0] way_i
+    ,input v_i
+  
+    ,output logic [addr_width_p-1:0] addr_o
+    ,output logic [way_id_width_lp-1:0] way_o
+    ,output logic v_o
+    ,input logic yumi_i
+
+    ,output logic empty_o
+    ,output logic full_o
+
+    ,input [addr_width_p-1:0] bypass_addr_i
+    ,input bypass_v_i
+    ,output logic bypass_track_o
+  );
+
+  // localparam
+  //
+  localparam lg_data_mask_width_lp=`BSG_SAFE_CLOG2(data_width_p>>3);
+
+  logic [addr_width_p-1:0] el0_addr, el1_addr;
+  logic [way_id_width_lp-1:0] el0_way, el1_way;
+
+  logic [1:0] num_els_r;
+
+  logic el0_valid;
+  logic el1_valid;
+  logic mux1_sel;
+  logic mux0_sel;
+  logic el0_enable;
+  logic el1_enable;
+
+  always_comb begin
+    case (num_els_r) 
+      0: begin
+        v_o = v_i;
+        empty_o = 1;
+        full_o = 0;
+        el0_valid = 0;
+        el1_valid = 0;
+        el0_enable = 0;
+        el1_enable = v_i & ~yumi_i;
+        mux0_sel = 0;
+        mux1_sel = 0;
+      end
+      
+      1: begin
+        v_o = 1;
+        empty_o = 0;
+        full_o = 0;
+        el0_valid = 0;
+        el1_valid = 1;
+        el0_enable = v_i & ~yumi_i;
+        el1_enable = v_i & yumi_i;
+        mux0_sel = 0;
+        mux1_sel = 1;
+      end
+
+      2: begin
+        v_o = 1;
+        empty_o = 0;
+        full_o = 1;
+        el0_valid = 1;
+        el1_valid = 1;
+        el0_enable = v_i & yumi_i;
+        el1_enable = yumi_i;
+        mux0_sel = 1;
+        mux1_sel = 1;
+      end
+      default: begin
+        // this would never happen.
+        v_o = 0;
+        empty_o = 0;
+        full_o = 0;
+        el0_valid = 0;
+        el1_valid = 0;
+        el0_enable = 0;
+        el1_enable = 0;
+        mux0_sel = 0;
+        mux1_sel = 0;
+      end
+    endcase
+  end
+
+  always_ff @ (posedge clk_i) begin
+    if (reset_i) begin
+      num_els_r <= 2'b0;
+    end
+    else begin
+      num_els_r <= num_els_r + v_i - (v_o & yumi_i);
+    end
+  end
+
+  // tbuf queues 
+  // 
+  bsg_cache_sbuf_queue #(
+    .width_p(addr_width_p+way_id_width_lp)
+  ) sbq (
+    .clk_i(clk_i)
+    ,.data_i({way_i, addr_i})
+    ,.el0_en_i(el0_enable)
+    ,.el1_en_i(el1_enable)
+    ,.mux0_sel_i(mux0_sel)
+    ,.mux1_sel_i(mux1_sel)
+    ,.el0_snoop_o({el0_way, el0_addr})
+    ,.el1_snoop_o({el1_way, el1_addr})
+    ,.data_o({way_o, addr_o})
+  );
+
+
+
+  // bypassing
+  //
+  logic tag_hit0, tag_hit0_n;
+  logic tag_hit1, tag_hit1_n;
+  logic tag_hit2, tag_hit2_n;
+  logic bypass_track_n;
+  logic [addr_width_p-lg_data_mask_width_lp-1:0] bypass_word_addr;
+
+  assign bypass_word_addr = bypass_addr_i[addr_width_p-1:lg_data_mask_width_lp];
+  assign tag_hit0_n = bypass_word_addr == el0_addr[addr_width_p-1:lg_data_mask_width_lp]; 
+  assign tag_hit1_n = bypass_word_addr == el1_addr[addr_width_p-1:lg_data_mask_width_lp]; 
+  assign tag_hit2_n = bypass_word_addr == addr_i[addr_width_p-1:lg_data_mask_width_lp]; 
+
+  assign tag_hit0 = tag_hit0_n & el0_valid;
+  assign tag_hit1 = tag_hit1_n & el1_valid;
+  assign tag_hit2 = tag_hit2_n & v_i;
+
+  assign bypass_track_n = bypass_v_i & (tag_hit0 | tag_hit1 | tag_hit2);
+
+  always_ff @ (posedge clk_i) begin
+    if (reset_i) begin
+      bypass_track_o <= '0;
+    end
+    else begin
+      bypass_track_o <= bypass_track_n;
+    end
+  end
+
+  // synopsys translate_off
+  always_ff @ (negedge clk_i) begin
+    if (~reset_i & num_els_r !== 2'bx) 
+      assert(num_els_r != 3) else $error("track buffer cannot hold more than 2 entries.");
+
+  end
+  // synopsys translate_on
+
+endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_cache_tbuf)

--- a/bsg_cache/bsg_cache_to_axi.v
+++ b/bsg_cache/bsg_cache_to_axi.v
@@ -12,6 +12,7 @@ module bsg_cache_to_axi
   #(parameter `BSG_INV_PARAM(addr_width_p)
     ,parameter `BSG_INV_PARAM(block_size_in_words_p)
     ,parameter `BSG_INV_PARAM(data_width_p)
+    ,parameter `BSG_INV_PARAM(mask_width_p)
     ,parameter `BSG_INV_PARAM(num_cache_p)
     
     // tag fifo size can be greater than number of cache dma interfaces
@@ -23,7 +24,7 @@ module bsg_cache_to_axi
     ,parameter `BSG_INV_PARAM(axi_burst_len_p)
 
     ,parameter lg_num_cache_lp=`BSG_SAFE_CLOG2(num_cache_p)
-    ,parameter dma_pkt_width_lp=`bsg_cache_dma_pkt_width(addr_width_p)
+    ,parameter dma_pkt_width_lp=`bsg_cache_dma_pkt_width(addr_width_p, mask_width_p)
 
     ,parameter axi_strb_width_lp=(axi_data_width_p>>3)
   )
@@ -94,7 +95,7 @@ module bsg_cache_to_axi
 
   // dma packets from caches
   //
-  `declare_bsg_cache_dma_pkt_s(addr_width_p);
+  `declare_bsg_cache_dma_pkt_s(addr_width_p, mask_width_p);
   bsg_cache_dma_pkt_s [num_cache_p-1:0] dma_pkt;
   assign dma_pkt = dma_pkt_i;
 
@@ -235,6 +236,7 @@ module bsg_cache_to_axi
     .num_cache_p(num_cache_p)
     ,.addr_width_p(addr_width_p)
     ,.data_width_p(data_width_p)
+    ,.mask_width_p(mask_width_p)
     ,.block_size_in_words_p(block_size_in_words_p)
     ,.tag_fifo_els_p(tag_fifo_els_p)
     ,.axi_id_width_p(axi_id_width_p)
@@ -248,6 +250,7 @@ module bsg_cache_to_axi
     ,.yumi_o(write_rr_yumi_li)
     ,.cache_id_i(write_rr_tag_lo)
     ,.addr_i(write_rr_dma_pkt.addr)
+    ,.mask_i(write_rr_dma_pkt.mask)
 
     ,.dma_data_i(dma_data_i)
     ,.dma_data_v_i(dma_data_v_i)

--- a/testing/bsg_cache/common/bsg_nonsynth_dma_model.v
+++ b/testing/bsg_cache/common/bsg_nonsynth_dma_model.v
@@ -24,8 +24,9 @@ module bsg_nonsynth_dma_model
     ,parameter lg_block_size_in_words_lp=`BSG_SAFE_CLOG2(block_size_in_words_p)
     ,parameter block_offset_width_lp=(block_size_in_words_p>1) ? lg_data_mask_width_lp+lg_block_size_in_words_lp : lg_data_mask_width_lp
     ,parameter upper_addr_width_lp=(block_size_in_words_p>1) ? lg_els_lp-lg_block_size_in_words_lp : lg_els_lp
-    ,parameter dma_pkt_width_lp=`bsg_cache_dma_pkt_width(addr_width_p)
-    ,parameter word_width_lp=data_width_p/mask_width_p
+    ,parameter dma_pkt_width_lp=`bsg_cache_dma_pkt_width(addr_width_p, mask_width_p)
+    ,parameter word_width_lp=(block_size_in_words_p*data_width_p)/mask_width_p
+    ,parameter dma_ratio_lp=(mask_width_p/block_size_in_words_p)
   )
   (
     input clk_i
@@ -40,7 +41,6 @@ module bsg_nonsynth_dma_model
     ,input dma_data_ready_i
 
     ,input [data_width_p-1:0] dma_data_i
-    ,input [mask_width_p-1:0] dma_wmask_i
     ,input dma_data_v_i
     ,output logic dma_data_yumi_o
   );
@@ -48,7 +48,7 @@ module bsg_nonsynth_dma_model
   logic [data_width_p-1:0] mem [els_p-1:0];
   
   
-  `declare_bsg_cache_dma_pkt_s(addr_width_p);
+  `declare_bsg_cache_dma_pkt_s(addr_width_p, mask_width_p);
   bsg_cache_dma_pkt_s dma_pkt;
   assign dma_pkt = dma_pkt_i;
 
@@ -159,10 +159,12 @@ module bsg_nonsynth_dma_model
   // write channel
   //
   logic [addr_width_p-1:0] wr_addr_r, wr_addr_n;
+  logic [mask_width_p-1:0] wr_mask_r, wr_mask_n;
   state_e wr_state_r, wr_state_n;
   logic [lg_block_size_in_words_lp-1:0] wr_counter_r, wr_counter_n;
   integer wr_delay_r, wr_delay_n;
   integer wr_data_delay_r, wr_data_delay_n;
+  logic [dma_ratio_lp-1:0] dma_mask_li;
   
   wire wr_data_delay_zero = wr_data_delay_r == 0;
 
@@ -173,8 +175,18 @@ module bsg_nonsynth_dma_model
   logic [upper_addr_width_lp-1:0] wr_upper_addr;
   assign wr_upper_addr = wr_addr_r[block_offset_width_lp+:upper_addr_width_lp];
 
+  bsg_mux #(
+    .width_p(dma_ratio_lp)
+    ,.els_p(block_size_in_words_p)
+  ) mux (
+    .data_i(wr_mask_r)
+    ,.sel_i(wr_counter_r)
+    ,.data_o(dma_mask_li)
+  );
+
   always_comb begin
     wr_addr_n = wr_addr_r;
+    wr_mask_n = wr_mask_r;
     wr_data_delay_n = wr_data_delay_r;
     wr_req_delay_n = wr_req_delay_r;
     wr_req_ready = 1'b0;
@@ -191,6 +203,9 @@ module bsg_nonsynth_dma_model
         wr_addr_n = start_write & wr_req_delay_zero
           ? dma_pkt.addr
           : wr_addr_r;
+        wr_mask_n = start_write & wr_req_delay_zero
+          ? dma_pkt.mask
+          : wr_mask_r;
         wr_counter_n = start_write & wr_req_delay_zero
           ? '0
           : wr_counter_r;
@@ -250,14 +265,15 @@ module bsg_nonsynth_dma_model
     else begin
       wr_state_r <= wr_state_n;
       wr_addr_r <= wr_addr_n;
+      wr_mask_r <= wr_mask_n;
       wr_counter_r <= wr_counter_n;
       wr_delay_r <= wr_delay_n;
       wr_data_delay_r <= wr_data_delay_n;
       wr_req_delay_r <= wr_req_delay_n;
     
       if ((wr_state_r == BUSY) & dma_data_v_i & dma_data_yumi_o) begin
-        for (integer i = 0; i < mask_width_p; i++) begin
-          if (dma_wmask_i[i]) begin
+        for (integer i = 0; i < dma_ratio_lp; i++) begin
+          if (dma_mask_li[i]) begin
             mem[{wr_upper_addr, {(block_size_in_words_p>1){wr_counter_r}}}][i*word_width_lp+:word_width_lp] <= dma_data_i[i*word_width_lp+:word_width_lp];
           end
         end

--- a/testing/bsg_cache/regression/sv.include
+++ b/testing/bsg_cache/regression/sv.include
@@ -44,6 +44,7 @@ $BASEJUMP_STL_DIR/bsg_cache/bsg_cache_pkg.v
 $BASEJUMP_STL_DIR/bsg_cache/bsg_cache_decode.v
 $BASEJUMP_STL_DIR/bsg_cache/bsg_cache_dma.v
 $BASEJUMP_STL_DIR/bsg_cache/bsg_cache_miss.v
+$BASEJUMP_STL_DIR/bsg_cache/bsg_cache_tbuf.v
 $BASEJUMP_STL_DIR/bsg_cache/bsg_cache_sbuf.v
 $BASEJUMP_STL_DIR/bsg_cache/bsg_cache_sbuf_queue.v
 $BASEJUMP_STL_DIR/bsg_cache/bsg_cache.v

--- a/testing/bsg_cache/regression/testbench.v
+++ b/testing/bsg_cache/regression/testbench.v
@@ -14,6 +14,7 @@ module testbench();
   parameter block_size_in_words_p = 8;
   parameter sets_p = 512;
   parameter ways_p = `WAYS_P;
+  parameter word_tracking_p = 1;
 
   parameter ring_width_p = `bsg_cache_pkt_width(addr_width_p, data_width_p);
   parameter rom_addr_width_p = 32;
@@ -60,6 +61,7 @@ module testbench();
   logic dma_data_ready_lo;
 
   logic [data_width_p-1:0] dma_data_lo;
+  logic dma_wmask_lo;
   logic dma_data_v_lo;
   logic dma_data_yumi_li;
 
@@ -69,6 +71,7 @@ module testbench();
     ,.block_size_in_words_p(block_size_in_words_p)
     ,.sets_p(sets_p)
     ,.ways_p(ways_p)
+    ,.word_tracking_p(word_tracking_p)
     ,.amo_support_p(amo_support_level_arithmetic_lp)
   ) DUT (
     .clk_i(clk)
@@ -91,6 +94,7 @@ module testbench();
     ,.dma_data_ready_o(dma_data_ready_lo)
 
     ,.dma_data_o(dma_data_lo)
+    ,.dma_wmask_o(dma_wmask_lo)
     ,.dma_data_v_o(dma_data_v_lo)
     ,.dma_data_yumi_i(dma_data_yumi_li)
 
@@ -181,6 +185,7 @@ module testbench();
   bsg_nonsynth_dma_model #(
     .addr_width_p(addr_width_p)
     ,.data_width_p(data_width_p)
+    ,.mask_width_p(1)
     ,.block_size_in_words_p(block_size_in_words_p)
     ,.els_p(2**18)
   ) dma (
@@ -196,6 +201,7 @@ module testbench();
     ,.dma_data_ready_i(dma_data_ready_lo)
 
     ,.dma_data_i(dma_data_lo)
+    ,.dma_wmask_i(dma_wmask_lo)
     ,.dma_data_v_i(dma_data_v_lo)
     ,.dma_data_yumi_o(dma_data_yumi_li)
   );

--- a/testing/bsg_cache/regression/testbench.v
+++ b/testing/bsg_cache/regression/testbench.v
@@ -51,7 +51,7 @@ module testbench();
   logic cache_v_lo;
   logic cache_yumi_li;
 
-  `declare_bsg_cache_dma_pkt_s(addr_width_p);
+  `declare_bsg_cache_dma_pkt_s(addr_width_p, block_size_in_words_p);
   bsg_cache_dma_pkt_s dma_pkt;
   logic dma_pkt_v_lo;
   logic dma_pkt_yumi_li;
@@ -61,7 +61,6 @@ module testbench();
   logic dma_data_ready_lo;
 
   logic [data_width_p-1:0] dma_data_lo;
-  logic dma_wmask_lo;
   logic dma_data_v_lo;
   logic dma_data_yumi_li;
 
@@ -94,7 +93,6 @@ module testbench();
     ,.dma_data_ready_o(dma_data_ready_lo)
 
     ,.dma_data_o(dma_data_lo)
-    ,.dma_wmask_o(dma_wmask_lo)
     ,.dma_data_v_o(dma_data_v_lo)
     ,.dma_data_yumi_i(dma_data_yumi_li)
 
@@ -185,7 +183,7 @@ module testbench();
   bsg_nonsynth_dma_model #(
     .addr_width_p(addr_width_p)
     ,.data_width_p(data_width_p)
-    ,.mask_width_p(1)
+    ,.mask_width_p(block_size_in_words_p)
     ,.block_size_in_words_p(block_size_in_words_p)
     ,.els_p(2**18)
   ) dma (
@@ -201,7 +199,6 @@ module testbench();
     ,.dma_data_ready_i(dma_data_ready_lo)
 
     ,.dma_data_i(dma_data_lo)
-    ,.dma_wmask_i(dma_wmask_lo)
     ,.dma_data_v_i(dma_data_v_lo)
     ,.dma_data_yumi_o(dma_data_yumi_li)
   );

--- a/testing/bsg_cache/regression_64/sv.include
+++ b/testing/bsg_cache/regression_64/sv.include
@@ -37,6 +37,7 @@ $BASEJUMP_STL_DIR/bsg_cache/bsg_cache_pkg.v
 $BASEJUMP_STL_DIR/bsg_cache/bsg_cache_decode.v
 $BASEJUMP_STL_DIR/bsg_cache/bsg_cache_dma.v
 $BASEJUMP_STL_DIR/bsg_cache/bsg_cache_miss.v
+$BASEJUMP_STL_DIR/bsg_cache/bsg_cache_tbuf.v
 $BASEJUMP_STL_DIR/bsg_cache/bsg_cache_sbuf.v
 $BASEJUMP_STL_DIR/bsg_cache/bsg_cache_sbuf_queue.v
 $BASEJUMP_STL_DIR/bsg_cache/bsg_cache.v

--- a/testing/bsg_cache/regression_64/testbench.v
+++ b/testing/bsg_cache/regression_64/testbench.v
@@ -43,7 +43,7 @@ module testbench();
 
 
   `declare_bsg_cache_pkt_s(addr_width_p,data_width_p);
-  `declare_bsg_cache_dma_pkt_s(addr_width_p);
+  `declare_bsg_cache_dma_pkt_s(addr_width_p, block_size_in_words_p);
 
   bsg_cache_pkt_s cache_pkt;
   logic v_li;
@@ -62,7 +62,6 @@ module testbench();
   logic dma_data_ready_lo;
 
   logic [data_width_p-1:0] dma_data_lo;
-  logic dma_wmask_lo;
   logic dma_data_v_lo;
   logic dma_data_yumi_li;
 
@@ -96,7 +95,6 @@ module testbench();
     ,.dma_data_ready_o(dma_data_ready_lo)
 
     ,.dma_data_o(dma_data_lo)
-    ,.dma_wmask_o(dma_wmask_lo)
     ,.dma_data_v_o(dma_data_v_lo)
     ,.dma_data_yumi_i(dma_data_yumi_li)
 
@@ -119,7 +117,7 @@ module testbench();
   bsg_nonsynth_dma_model #(
     .addr_width_p(addr_width_p)
     ,.data_width_p(data_width_p)
-    ,.mask_width_p(1)
+    ,.mask_width_p(block_size_in_words_p)
     ,.block_size_in_words_p(block_size_in_words_p)
     ,.els_p(mem_size_p)
 
@@ -141,7 +139,6 @@ module testbench();
     ,.dma_data_ready_i(dma_data_ready_lo)
 
     ,.dma_data_i(dma_data_lo)
-    ,.dma_wmask_i(dma_wmask_lo)
     ,.dma_data_v_i(dma_data_v_lo)
     ,.dma_data_yumi_o(dma_data_yumi_li)
   );

--- a/testing/bsg_cache/regression_64/testbench.v
+++ b/testing/bsg_cache/regression_64/testbench.v
@@ -28,7 +28,7 @@ module testbench();
   localparam sets_p = 64;
   localparam ways_p = 8;
   localparam mem_size_p = 2**(17-`BSG_SAFE_CLOG2(data_width_p/8));
-
+  localparam word_tracking_p = 1;
 
   integer status;
   integer wave;
@@ -62,6 +62,7 @@ module testbench();
   logic dma_data_ready_lo;
 
   logic [data_width_p-1:0] dma_data_lo;
+  logic dma_wmask_lo;
   logic dma_data_v_lo;
   logic dma_data_yumi_li;
 
@@ -73,6 +74,7 @@ module testbench();
     ,.sets_p(sets_p)
     ,.ways_p(ways_p)
     ,.amo_support_p(amo_support_level_arithmetic_lp)
+    ,.word_tracking_p(word_tracking_p)
   ) DUT (
     .clk_i(clk)
     ,.reset_i(reset)
@@ -94,6 +96,7 @@ module testbench();
     ,.dma_data_ready_o(dma_data_ready_lo)
 
     ,.dma_data_o(dma_data_lo)
+    ,.dma_wmask_o(dma_wmask_lo)
     ,.dma_data_v_o(dma_data_v_lo)
     ,.dma_data_yumi_i(dma_data_yumi_li)
 
@@ -116,6 +119,7 @@ module testbench();
   bsg_nonsynth_dma_model #(
     .addr_width_p(addr_width_p)
     ,.data_width_p(data_width_p)
+    ,.mask_width_p(1)
     ,.block_size_in_words_p(block_size_in_words_p)
     ,.els_p(mem_size_p)
 
@@ -137,6 +141,7 @@ module testbench();
     ,.dma_data_ready_i(dma_data_ready_lo)
 
     ,.dma_data_i(dma_data_lo)
+    ,.dma_wmask_i(dma_wmask_lo)
     ,.dma_data_v_i(dma_data_v_lo)
     ,.dma_data_yumi_o(dma_data_yumi_li)
   );

--- a/testing/bsg_cache/regression_v2/sv.include
+++ b/testing/bsg_cache/regression_v2/sv.include
@@ -37,6 +37,7 @@ $BASEJUMP_STL_DIR/bsg_cache/bsg_cache_pkg.v
 $BASEJUMP_STL_DIR/bsg_cache/bsg_cache_decode.v
 $BASEJUMP_STL_DIR/bsg_cache/bsg_cache_dma.v
 $BASEJUMP_STL_DIR/bsg_cache/bsg_cache_miss.v
+$BASEJUMP_STL_DIR/bsg_cache/bsg_cache_tbuf.v
 $BASEJUMP_STL_DIR/bsg_cache/bsg_cache_sbuf.v
 $BASEJUMP_STL_DIR/bsg_cache/bsg_cache_sbuf_queue.v
 $BASEJUMP_STL_DIR/bsg_cache/bsg_cache.v

--- a/testing/bsg_cache/regression_v2/testbench.v
+++ b/testing/bsg_cache/regression_v2/testbench.v
@@ -30,7 +30,7 @@ module testbench();
   localparam sets_p = 128;
   localparam ways_p = 8;
   localparam mem_size_p = block_size_in_words_p*sets_p*ways_p*4;
-
+  localparam word_tracking_p = 1;
 
   integer status;
   integer wave;
@@ -64,6 +64,7 @@ module testbench();
   logic dma_data_ready_lo;
 
   logic [data_width_p-1:0] dma_data_lo;
+  logic dma_wmask_lo;
   logic dma_data_v_lo;
   logic dma_data_yumi_li;
 
@@ -75,6 +76,7 @@ module testbench();
     ,.sets_p(sets_p)
     ,.ways_p(ways_p)
     ,.amo_support_p(amo_support_level_arithmetic_lp)
+    ,.word_tracking_p(word_tracking_p)
   ) DUT (
     .clk_i(clk)
     ,.reset_i(reset)
@@ -96,6 +98,7 @@ module testbench();
     ,.dma_data_ready_o(dma_data_ready_lo)
 
     ,.dma_data_o(dma_data_lo)
+    ,.dma_wmask_o(dma_wmask_lo)
     ,.dma_data_v_o(dma_data_v_lo)
     ,.dma_data_yumi_i(dma_data_yumi_li)
 
@@ -118,6 +121,7 @@ module testbench();
   bsg_nonsynth_dma_model #(
     .addr_width_p(addr_width_p)
     ,.data_width_p(data_width_p)
+    ,.mask_width_p(1)
     ,.block_size_in_words_p(block_size_in_words_p)
     ,.els_p(mem_size_p)
 
@@ -139,6 +143,7 @@ module testbench();
     ,.dma_data_ready_i(dma_data_ready_lo)
 
     ,.dma_data_i(dma_data_lo)
+    ,.dma_wmask_i(dma_wmask_lo)
     ,.dma_data_v_i(dma_data_v_lo)
     ,.dma_data_yumi_o(dma_data_yumi_li)
   );

--- a/testing/bsg_cache/regression_v2/testbench.v
+++ b/testing/bsg_cache/regression_v2/testbench.v
@@ -45,7 +45,7 @@ module testbench();
 
 
   `declare_bsg_cache_pkt_s(addr_width_p,data_width_p);
-  `declare_bsg_cache_dma_pkt_s(addr_width_p);
+  `declare_bsg_cache_dma_pkt_s(addr_width_p,block_size_in_words_p);
 
   bsg_cache_pkt_s cache_pkt;
   logic v_li;
@@ -64,7 +64,6 @@ module testbench();
   logic dma_data_ready_lo;
 
   logic [data_width_p-1:0] dma_data_lo;
-  logic dma_wmask_lo;
   logic dma_data_v_lo;
   logic dma_data_yumi_li;
 
@@ -98,7 +97,6 @@ module testbench();
     ,.dma_data_ready_o(dma_data_ready_lo)
 
     ,.dma_data_o(dma_data_lo)
-    ,.dma_wmask_o(dma_wmask_lo)
     ,.dma_data_v_o(dma_data_v_lo)
     ,.dma_data_yumi_i(dma_data_yumi_li)
 
@@ -121,7 +119,7 @@ module testbench();
   bsg_nonsynth_dma_model #(
     .addr_width_p(addr_width_p)
     ,.data_width_p(data_width_p)
-    ,.mask_width_p(1)
+    ,.mask_width_p(block_size_in_words_p)
     ,.block_size_in_words_p(block_size_in_words_p)
     ,.els_p(mem_size_p)
 
@@ -143,7 +141,6 @@ module testbench();
     ,.dma_data_ready_i(dma_data_ready_lo)
 
     ,.dma_data_i(dma_data_lo)
-    ,.dma_wmask_i(dma_wmask_lo)
     ,.dma_data_v_i(dma_data_v_lo)
     ,.dma_data_yumi_o(dma_data_yumi_li)
   );


### PR DESCRIPTION
This PR adds the capability to bsg_cache to service store requests without fetching the cache-line from DRAM by tracking the written words to the cache. Changes include adding this feature to the cache pipeline, FSMs, and updating the various bsg_cache interface converters with the new DMA interface that includes a write-mask for evicting cache-line with partially valid data.