### PR TITLE
bsg_cache_word_tracking wormhole change

### DIFF
--- a/bsg_cache/bsg_cache.v
+++ b/bsg_cache/bsg_cache.v
@@ -359,9 +359,18 @@ end
 
   logic bypass_track_lo;
 
-  wire partial_st    = decode.st_op & (decode.data_size_op < lg_data_mask_width_lp);
-  wire partial_st_tl = decode_tl_r.st_op & (decode_tl_r.data_size_op < lg_data_mask_width_lp);
-  wire partial_st_v  = decode_v_r.st_op & (decode_v_r.data_size_op < lg_data_mask_width_lp);
+  //wire partial_st    = decode.st_op & (decode.data_size_op < lg_data_mask_width_lp);
+  //wire partial_st_tl = decode_tl_r.st_op & (decode_tl_r.data_size_op < lg_data_mask_width_lp);
+  //wire partial_st_v  = decode_v_r.st_op & (decode_v_r.data_size_op < lg_data_mask_width_lp);
+  wire partial_st    = decode.st_op & (decode.mask_op
+                                        ? ~(&cache_pkt.mask)
+                                        : (decode.data_size_op < lg_data_mask_width_lp));
+  wire partial_st_tl = decode_tl_r.st_op & (decode_tl_r.mask_op
+                                        ? ~(&mask_tl_r)
+                                        : (decode_tl_r.data_size_op < lg_data_mask_width_lp));
+  wire partial_st_v  = decode_v_r.st_op & (decode_v_r.mask_op
+                                        ? ~(&mask_v_r)
+                                        : (decode_v_r.data_size_op < lg_data_mask_width_lp));
 
   wire ld_st_amo_tag_miss = (decode_v_r.ld_op | decode_v_r.st_op | decode_v_r.atomic_op) & ~tag_hit_found;
   wire track_miss = (decode_v_r.ld_op | decode_v_r.atomic_op | partial_st_v)
@@ -454,6 +463,7 @@ end
     ,.track_miss_i(track_miss)
     ,.decode_v_i(decode_v_r)
     ,.addr_v_i(addr_v_r)
+    ,.mask_v_i(mask_v_r)
 
     ,.tag_v_i(tag_v_r)
     ,.valid_v_i(valid_v_r)

--- a/bsg_cache/bsg_cache.v
+++ b/bsg_cache/bsg_cache.v
@@ -359,9 +359,6 @@ end
 
   logic bypass_track_lo;
 
-  //wire partial_st    = decode.st_op & (decode.data_size_op < lg_data_mask_width_lp);
-  //wire partial_st_tl = decode_tl_r.st_op & (decode_tl_r.data_size_op < lg_data_mask_width_lp);
-  //wire partial_st_v  = decode_v_r.st_op & (decode_v_r.data_size_op < lg_data_mask_width_lp);
   wire partial_st    = decode.st_op & (decode.mask_op
                                         ? ~(&cache_pkt.mask)
                                         : (decode.data_size_op < lg_data_mask_width_lp));

--- a/bsg_cache/bsg_cache.vh
+++ b/bsg_cache/bsg_cache.vh
@@ -1,3 +1,5 @@
+ // Enum values in the structs come from bsg_cache_pkg.v
+
 `ifndef BSG_CACHE_VH
 `define BSG_CACHE_VH
   // bsg_cache_pkt_s
@@ -64,8 +66,8 @@
   //
   `define declare_bsg_cache_wh_header_flit_s(wh_flit_width_mp,wh_cord_width_mp,wh_len_width_mp,wh_cid_width_mp) \
     typedef struct packed { \
-      logic [wh_flit_width_mp-(wh_cord_width_mp*2)-1-wh_len_width_mp-(wh_cid_width_mp*2)-1:0] unused; \
-      logic write_not_read; \
+      logic [wh_flit_width_mp-(wh_cord_width_mp*2)-$bits(bsg_cache_wh_opcode_e)-wh_len_width_mp-(wh_cid_width_mp*2)-1:0] unused; \
+      bsg_cache_wh_opcode_e opcode; \
       logic [wh_cid_width_mp-1:0] src_cid; \
       logic [wh_cord_width_mp-1:0] src_cord; \
       logic [wh_cid_width_mp-1:0] cid; \

--- a/bsg_cache/bsg_cache_pkg.v
+++ b/bsg_cache/bsg_cache_pkg.v
@@ -134,4 +134,20 @@ package bsg_cache_pkg;
   } bsg_cache_dma_cmd_e;
 
 
+  // cache dma wormhole opcode
+  // This opcode is included in the cache DMA wormhole header flit.
+  typedef enum logic [1:0] {
+    // len = 1
+    // header + addr
+    e_cache_wh_read = 2'b00
+
+    // len = 1 + (# data flits)
+    // header + addr + data
+    ,e_cache_wh_write_non_masked = 2'b10
+
+    // len = 2 + (# data flits)
+    // header + addr + mask + data
+    ,e_cache_wh_write_masked = 2'b11
+  } bsg_cache_wh_opcode_e;
+
 endpackage


### PR DESCRIPTION
- Adding read, masked write, and non-masked write to the cache dma wormhole packet.
- Updating cache wormhole and  test_dram related modules.
- Making change in miss handling logic to treat SM with all the mask bits as 1'b1 like SW.