### PR TITLE
Remove unused parameter from tiehi

### DIFF
--- a/bsg_misc/bsg_tiehi.v
+++ b/bsg_misc/bsg_tiehi.v
@@ -2,7 +2,6 @@
 `include "bsg_defines.v"
 
 module bsg_tiehi #(parameter `BSG_INV_PARAM(width_p)
-                   , parameter harden_p=1
                    )
    (output [width_p-1:0] o
     );


### PR DESCRIPTION
The param was not used. This could break some backward compatibility, though, but it looks that at least it is never used. Or it is used as a blackbox somewhere and we should keep it.