### PR TITLE
Fix fatal syntax

### DIFF
--- a/bsg_cache/bsg_cache_to_test_dram_rx.v
+++ b/bsg_cache/bsg_cache_to_test_dram_rx.v
@@ -141,8 +141,8 @@ module bsg_cache_to_test_dram_rx
   
   always_ff @ (negedge dram_clk_i) begin
     if (~dram_reset_i & dram_data_v_i) begin
-      assert(~data_afifo_full) else $fatal("data async_fifo full!");
-      assert(~ch_addr_afifo_full) else $fatal("ch_addr async_fifo full!");
+      assert(~data_afifo_full) else $fatal(1, "data async_fifo full!");
+      assert(~ch_addr_afifo_full) else $fatal(1, "ch_addr async_fifo full!");
     end
   end
 

--- a/bsg_cache/bsg_cache_to_test_dram_rx_reorder.v
+++ b/bsg_cache/bsg_cache_to_test_dram_rx_reorder.v
@@ -65,7 +65,7 @@ module bsg_cache_to_test_dram_rx_reorder
     // synopsys translate_off 
     always_ff @ (negedge core_clk_i) begin
       if (~core_reset_i & dram_v_i) begin
-        assert(piso_ready_lo) else $fatal("piso is not ready!");
+        assert(piso_ready_lo) else $fatal(1, "piso is not ready!");
       end
     end
     // synopsys translate_on

--- a/testing/bsg_cache/common/basic_checker_32.v
+++ b/testing/bsg_cache/common/basic_checker_32.v
@@ -217,7 +217,7 @@ module basic_checker_32
         // output checker
         if (v_o & yumi_i) begin
           assert(result[recv_id] == data_o)
-            else $fatal("[BSG_FATAL] output does not match expected result. Id=%d, Expected: %x. Actual: %x.",
+            else $fatal(1, "[BSG_FATAL] output does not match expected result. Id=%d, Expected: %x. Actual: %x.",
                     recv_id, result[recv_id], data_o);
           recv_id++;
         end

--- a/testing/bsg_cache/regression_64/basic_checker.v
+++ b/testing/bsg_cache/regression_64/basic_checker.v
@@ -279,7 +279,7 @@ module basic_checker
         // output checker
         if (v_o & yumi_i) begin
           assert(result[recv_id] == data_o)
-            else $fatal("[BSG_FATAL] output does not match expected result. Id=%d, Expected: %x. Actual: %x.",
+            else $fatal(1, "[BSG_FATAL] output does not match expected result. Id=%d, Expected: %x. Actual: %x.",
                     recv_id, result[recv_id], data_o);
           recv_id++;
         end

--- a/testing/bsg_cache/regression_non_blocking/ainv_checker.v
+++ b/testing/bsg_cache/regression_non_blocking/ainv_checker.v
@@ -18,7 +18,7 @@ module ainv_checker
   
     if (~reset_i & en_i & v_o & yumi_i)
       assert(data_o == '0)
-        else $fatal("zero output expected.");
+        else $fatal(1, "zero output expected.");
 
   end
 

--- a/testing/bsg_cache/regression_non_blocking/basic_checker.v
+++ b/testing/bsg_cache/regression_non_blocking/basic_checker.v
@@ -155,7 +155,7 @@ module basic_checker
     if (~reset_i & v_o & yumi_i & en_i) begin
       $display("id=%d, data=%x", id_o, data_o);
       assert(result[id_o] == data_o)
-        else $fatal("[BSG_FATAL] Output does not match expected result. Id= %d, Expected: %x. Actual: %x",
+        else $fatal(1, "[BSG_FATAL] Output does not match expected result. Id= %d, Expected: %x. Actual: %x",
               id_o, result[id_o], data_o);
     end
 

--- a/testing/bsg_cache/regression_non_blocking/block_ld_checker.v
+++ b/testing/bsg_cache/regression_non_blocking/block_ld_checker.v
@@ -74,13 +74,13 @@ module block_ld_checker
 
       if (load_idx.exists(id_o)) begin
         assert(result[id_o][load_idx[id_o]] == data_o)
-          else $fatal("Output does not match expected result. Id= %d, Expected: %x. Actual: %x",
+          else $fatal(1, "Output does not match expected result. Id= %d, Expected: %x. Actual: %x",
                 id_o, result[id_o][load_idx[id_o]], data_o);
         load_idx[id_o]++;
       end
       else begin
         assert(result[id_o][0] == data_o)
-          else $fatal("Output does not match expected result. Id= %d, Expected: %x. Actual: %x",
+          else $fatal(1, "Output does not match expected result. Id= %d, Expected: %x. Actual: %x",
                 id_o, result[id_o][0], data_o);
       end
     end

--- a/testing/bsg_cache/regression_non_blocking/tag_checker.v
+++ b/testing/bsg_cache/regression_non_blocking/tag_checker.v
@@ -89,7 +89,7 @@ module tag_checker
     if (~reset_i & v_o & yumi_i & en_i) begin
       $display("id=%d, data=%x", id_o, data_o);
       assert(result[id_o] == data_o)
-        else $fatal("[BSG_FATAL] Output does not match expected result. Id= %d, Expected: %x. Actual: %x",
+        else $fatal(1, "[BSG_FATAL] Output does not match expected result. Id= %d, Expected: %x. Actual: %x",
               id_o, result[id_o], data_o);
     end
 

--- a/testing/bsg_dataflow/bsg_fifo_reorder/testbench.v
+++ b/testing/bsg_dataflow/bsg_fifo_reorder/testbench.v
@@ -188,7 +188,7 @@ module testbench();
       if (fifo_deq_yumi_li) begin
         check_count_r <= check_count_r + 1;
         $display("data out: %d", fifo_deq_data_lo);
-        assert(check_count_r == fifo_deq_data_lo) else $fatal("fail");
+        assert(check_count_r == fifo_deq_data_lo) else $fatal(1, "fail");
       end
 
     end
@@ -199,7 +199,7 @@ module testbench();
   initial begin
     wait((check_count_r == num_test_p) & (sent_r == num_test_p));
     #100000;
-    assert(empty_lo) else $fatal("[BSG_FAIL] FIFO is not empty.");
+    assert(empty_lo) else $fatal(1, "[BSG_FAIL] FIFO is not empty.");
     $finish();
   end
   

--- a/testing/bsg_misc/bsg_lru_pseudo_tree_backup/testbench.v
+++ b/testing/bsg_misc/bsg_lru_pseudo_tree_backup/testbench.v
@@ -44,7 +44,7 @@ module testbench();
     disabled_ways_li = disabled_ways;
     #10; 
     assert(lru_way_id_lo == expected)
-      else $fatal("Expected: %b, Actual: %b", expected, lru_way_id_lo);
+      else $fatal(1, "Expected: %b, Actual: %b", expected, lru_way_id_lo);
     #10; 
 
   endtask

--- a/testing/bsg_misc/bsg_lru_pseudo_tree_encode/testbench.v
+++ b/testing/bsg_misc/bsg_lru_pseudo_tree_encode/testbench.v
@@ -21,7 +21,7 @@ module testbench();
     lru_li = lru;
     #10;
     assert(expected == way_id_lo) else
-      $fatal("[BSG_FATAL] expected: %b, actual: %b", expected, way_id_lo);
+      $fatal(1, "[BSG_FATAL] expected: %b, actual: %b", expected, way_id_lo);
     #10;
 
   endtask

--- a/testing/bsg_test/dramsim3_bandwidth/testbench.v
+++ b/testing/bsg_test/dramsim3_bandwidth/testbench.v
@@ -204,7 +204,7 @@ module testbench();
 
         assert(shadow_mem[read_done_col_addr] == dramsim3_data_lo[0][0+:32])
           //$display("[BSG_INFO] output matched. Id=%d, Expected=%x, Actual=%x", recv_id, result[recv_id], dramsim3_data_lo[0][0+:32]);
-          else $fatal("[BSG_FATAL] output does not match expected result for 0x%x. Expected=%x, Actual=%x",
+          else $fatal(1, "[BSG_FATAL] output does not match expected result for 0x%x. Expected=%x, Actual=%x",
                       dramsim3_read_done_ch_addr_lo[0], shadow_mem[read_done_col_addr], dramsim3_data_lo[0][0+:32]);
       end
 


### PR DESCRIPTION
Hi there!

The fatal syntax here was incorrect and made the Morty tool unhappy (cf. [this issue](https://github.com/pulp-platform/morty/issues/46)). This should fix it.