### PR TITLE
standardizing harden_p for bsg_mem

### DIFF
--- a/bsg_mem/bsg_mem_1r1w_sync_banked.sv
+++ b/bsg_mem/bsg_mem_1r1w_sync_banked.sv
@@ -34,6 +34,7 @@ module bsg_mem_1r1w_sync_banked
     , parameter `BSG_INV_PARAM(els_p)
     , parameter read_write_same_addr_p=0
     , parameter latch_last_read_p=0
+    , parameter harden_p=0
 
     , parameter num_width_bank_p=1
     , parameter num_depth_bank_p=1
@@ -116,6 +117,7 @@ module bsg_mem_1r1w_sync_banked
           ,.els_p(bank_depth_lp)
           ,.read_write_same_addr_p(read_write_same_addr_p)
           ,.latch_last_read_p(latch_last_read_p)
+          ,.harden_p(harden_p)
         ) bank (
           .clk_i(clk_i)
           ,.reset_i(reset_i)

--- a/bsg_mem/bsg_mem_1r1w_sync_mask_write_byte.sv
+++ b/bsg_mem/bsg_mem_1r1w_sync_mask_write_byte.sv
@@ -56,7 +56,6 @@ module bsg_mem_1r1w_sync_mask_write_byte #(parameter `BSG_INV_PARAM(width_p)
        ,.els_p (els_p  )
        ,.read_write_same_addr_p(read_write_same_addr_p)
        ,.latch_last_read_p(latch_last_read_p)
-       ,.harden_p(harden_p)
        ,.disable_collision_warning_p(disable_collision_warning_p)
        ) synth
        (.clk_i(clk_lo)

--- a/bsg_mem/bsg_mem_1r1w_sync_mask_write_byte_synth.sv
+++ b/bsg_mem/bsg_mem_1r1w_sync_mask_write_byte_synth.sv
@@ -16,7 +16,6 @@ module bsg_mem_1r1w_sync_mask_write_byte_synth #(parameter `BSG_INV_PARAM(width_
 						, parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
                                                 , parameter latch_last_read_p=0
                                                 , parameter write_mask_width_lp = width_p>>3
-						, parameter harden_p=0
                                                 , parameter disable_collision_warning_p=1
                                         )
    (input   clk_i

--- a/bsg_mem/bsg_mem_1rw_sync.sv
+++ b/bsg_mem/bsg_mem_1rw_sync.sv
@@ -9,6 +9,7 @@
 module bsg_mem_1rw_sync #(parameter `BSG_INV_PARAM(width_p)
                           , parameter `BSG_INV_PARAM(els_p)
                           , parameter latch_last_read_p=0
+                          , parameter harden_p=0
                           , parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
                           , parameter enable_clock_gating_p=0
 			  , parameter verbose_if_synth_p=1

--- a/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.sv
+++ b/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.sv
@@ -9,6 +9,7 @@ module bsg_mem_1rw_sync_mask_write_bit #(
   parameter `BSG_INV_PARAM(width_p)
   , parameter `BSG_INV_PARAM(els_p)
   , parameter latch_last_read_p=0
+  , parameter harden_p=0
   , parameter enable_clock_gating_p=0
   , parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
 ) (input   clk_i

--- a/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_banked.sv
+++ b/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_banked.sv
@@ -29,6 +29,7 @@ module bsg_mem_1rw_sync_mask_write_bit_banked
   #(parameter `BSG_INV_PARAM(width_p)
     , parameter `BSG_INV_PARAM(els_p)
     , parameter latch_last_read_p=0
+    , parameter harden_p=0
 
     // bank parameters
     , parameter num_width_bank_p=1
@@ -99,6 +100,7 @@ module bsg_mem_1rw_sync_mask_write_bit_banked
           .width_p(bank_width_lp)
           ,.els_p(bank_depth_lp)
           ,.latch_last_read_p(latch_last_read_p)
+          ,.harden_p(harden_p)
         ) bank (
           .clk_i(clk_i)
           ,.reset_i(reset_i)

--- a/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_from_1r1w.sv
+++ b/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_from_1r1w.sv
@@ -28,6 +28,7 @@ module bsg_mem_1rw_sync_mask_write_bit_from_1r1w #(
   parameter    `BSG_INV_PARAM(width_p)
   , parameter  `BSG_INV_PARAM(els_p)
   , parameter  latch_last_read_p     = 0
+  , parameter  harden_p              = 0
   , parameter  enable_clock_gating_p = 0
   , parameter  verbose_p             = 0
   , localparam addr_width_lp         = `BSG_SAFE_CLOG2(els_p)
@@ -118,7 +119,8 @@ module bsg_mem_1rw_sync_mask_write_bit_from_1r1w #(
 
   bsg_mem_1r1w_sync
     #(.width_p (width_p)
-    ,.els_p    (els_p))
+    ,.els_p    (els_p)
+    ,.harden_p (harden_p))
     ram
     (.clk_i    (clk_i)
     ,.reset_i  (reset_i)

--- a/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
+++ b/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
@@ -5,6 +5,7 @@ module bsg_mem_1rw_sync_mask_write_byte #(parameter `BSG_INV_PARAM(els_p)
 
                                           ,parameter `BSG_INV_PARAM(data_width_p )
                                           ,parameter latch_last_read_p=0
+                                          ,parameter harden_p=0
                                           ,parameter write_mask_width_lp = data_width_p>>3
                                           ,parameter enable_clock_gating_p=0
                                          )

--- a/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_banked.sv
+++ b/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_banked.sv
@@ -28,6 +28,7 @@ module bsg_mem_1rw_sync_mask_write_byte_banked
   #(parameter `BSG_INV_PARAM(data_width_p)
     , parameter `BSG_INV_PARAM(els_p)
     , parameter latch_last_read_p=0
+    , parameter harden_p=0
 
     , parameter write_mask_width_lp=(data_width_p>>3)
 

--- a/bsg_mem/bsg_mem_1rw_sync_mask_write_var.sv
+++ b/bsg_mem/bsg_mem_1rw_sync_mask_write_var.sv
@@ -5,7 +5,8 @@ module bsg_mem_1rw_sync_mask_write_var #
   ,parameter `BSG_INV_PARAM(mask_width_p)
   ,parameter `BSG_INV_PARAM(els_p)
   ,parameter chunk_size_lp = width_p / mask_width_p
-  ,parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p))
+  ,parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p),
+  ,parameter harden_p=0)
   (input                      clk_i
   ,input                      reset_i
   ,input        [width_p-1:0] data_i
@@ -25,7 +26,8 @@ module bsg_mem_1rw_sync_mask_write_var #
 
     bsg_mem_1rw_sync #
       (.width_p(mask_width_p)
-      ,.els_p(els_p))
+      ,.els_p(els_p)
+      ,.harden_p(harden_p))
     mem
       (.clk_i(clk_i)
       ,.reset_i(reset_i)

--- a/bsg_mem/bsg_mem_2r1w.sv
+++ b/bsg_mem/bsg_mem_2r1w.sv
@@ -10,6 +10,7 @@
 module bsg_mem_2r1w #(parameter `BSG_INV_PARAM(width_p)
                       , parameter `BSG_INV_PARAM(els_p)
                       , parameter read_write_same_addr_p=0
+                      , parameter harden_p = 0
                       , parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
                       )
    (input   w_clk_i

--- a/bsg_mem/bsg_mem_2rw_sync.sv
+++ b/bsg_mem/bsg_mem_2rw_sync.sv
@@ -5,7 +5,7 @@ module bsg_mem_2rw_sync #( parameter `BSG_INV_PARAM(width_p )
                          , parameter `BSG_INV_PARAM(els_p )
                          , parameter read_write_same_addr_p=0
                          , parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
-                         , parameter harden_p=1
+                         , parameter harden_p=0
                          , parameter disable_collision_warning_p=0
                          , parameter enable_clock_gating_p=0
                          )
@@ -46,7 +46,6 @@ module bsg_mem_2rw_sync #( parameter `BSG_INV_PARAM(width_p )
      #(.width_p(width_p)
        ,.els_p(els_p)
        ,.read_write_same_addr_p(read_write_same_addr_p)
-       ,.harden_p(harden_p)
        ) synth
        (.clk_i (clk_lo)
        ,.reset_i

--- a/bsg_mem/bsg_mem_2rw_sync_mask_write_bit.sv
+++ b/bsg_mem/bsg_mem_2rw_sync_mask_write_bit.sv
@@ -5,7 +5,7 @@ module bsg_mem_2rw_sync_mask_write_bit #( parameter `BSG_INV_PARAM(width_p )
                          , parameter `BSG_INV_PARAM(els_p )
                          , parameter read_write_same_addr_p=0
                          , parameter addr_width_lp = `BSG_SAFE_CLOG2(els_p)
-                         , parameter harden_p=1
+                         , parameter harden_p=0
                          , parameter disable_collision_warning_p=0
                          , parameter enable_clock_gating_p=0
                          )

--- a/bsg_mem/bsg_mem_2rw_sync_mask_write_bit_synth.sv
+++ b/bsg_mem/bsg_mem_2rw_sync_mask_write_bit_synth.sv
@@ -6,7 +6,6 @@ module bsg_mem_2rw_sync_mask_write_bit_synth #( parameter `BSG_INV_PARAM(width_p
                          , parameter read_write_same_addr_p = 0
                          , parameter disable_collision_warning_p = 0
                          , parameter addr_width_lp = `BSG_SAFE_CLOG2(els_p)
-                         , parameter harden_p = 1
                          )
   ( input                      clk_i
   , input                      reset_i

--- a/bsg_mem/bsg_mem_2rw_sync_mask_write_byte.sv
+++ b/bsg_mem/bsg_mem_2rw_sync_mask_write_byte.sv
@@ -4,7 +4,7 @@ module bsg_mem_2rw_sync_mask_write_byte #( parameter `BSG_INV_PARAM(width_p )
                          , parameter `BSG_INV_PARAM(els_p )
                          , parameter read_write_same_addr_p=0
                          , parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
-                         , parameter harden_p=1
+                         , parameter harden_p=0
                          , parameter disable_collision_warning_p=0
                          , parameter enable_clock_gating_p=0
                          , parameter write_mask_width_lp=(width_p>>3)
@@ -48,7 +48,6 @@ module bsg_mem_2rw_sync_mask_write_byte #( parameter `BSG_INV_PARAM(width_p )
      #(.width_p(width_p)
        ,.els_p(els_p)
        ,.read_write_same_addr_p(read_write_same_addr_p)
-       ,.harden_p(harden_p)
        ) synth
        (.clk_i (clk_lo)
        ,.reset_i

--- a/bsg_mem/bsg_mem_2rw_sync_mask_write_byte_synth.sv
+++ b/bsg_mem/bsg_mem_2rw_sync_mask_write_byte_synth.sv
@@ -4,7 +4,6 @@ module bsg_mem_2rw_sync_mask_write_byte_synth #( parameter `BSG_INV_PARAM(width_
                          , parameter `BSG_INV_PARAM(els_p )
                          , parameter read_write_same_addr_p=0
                          , parameter addr_width_lp = `BSG_SAFE_CLOG2(els_p)
-                         , parameter harden_p = 1
                          , parameter disable_collision_warning_p=0     
                          , parameter write_mask_width_lp=(width_p>>3)              
                          )
@@ -46,7 +45,6 @@ module bsg_mem_2rw_sync_mask_write_byte_synth #( parameter `BSG_INV_PARAM(width_
                         ,.els_p        (els_p)
                         ,.addr_width_lp(addr_width_lp)
                         ,.disable_collision_warning_p(disable_collision_warning_p)
-                        ,.harden_p(harden_p)
                       ) mem_2rw_sync
                       ( .clk_i  (clk_i)
                        ,.reset_i(reset_i)

--- a/bsg_mem/bsg_mem_2rw_sync_synth.sv
+++ b/bsg_mem/bsg_mem_2rw_sync_synth.sv
@@ -5,7 +5,6 @@ module bsg_mem_2rw_sync_synth #( parameter `BSG_INV_PARAM(width_p )
                          , parameter `BSG_INV_PARAM(els_p )
                          , parameter read_write_same_addr_p=0
                          , parameter addr_width_lp = `BSG_SAFE_CLOG2(els_p)
-                         , parameter harden_p = 1
                          , parameter disable_collision_warning_p=0                   
                          )
   ( input                      clk_i

--- a/bsg_mem/bsg_mem_3r1w.sv
+++ b/bsg_mem/bsg_mem_3r1w.sv
@@ -10,6 +10,7 @@
 module bsg_mem_3r1w #(parameter `BSG_INV_PARAM(width_p)
                       , parameter `BSG_INV_PARAM(els_p)
                       , parameter read_write_same_addr_p=0
+                      , parameter harden_p=0
                       , parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
                       )
    (input   w_clk_i

--- a/hard/fakeram/bsg_mem_1rw_sync_macros.svh
+++ b/hard/fakeram/bsg_mem_1rw_sync_macros.svh
@@ -8,7 +8,7 @@
   `bsg_mem_1rw_sync_1sram_macro(words,bits)
 
 `define bsg_mem_1rw_sync_1sram_macro(words,bits,tag) \
-  if (els_p == words && width_p == bits)             \
+  if (harden_p && els_p == words && width_p == bits) \
     begin: macro                                     \
        fakeram_d``words``_w``bits`` mem              \
          (.clk(clk_i)                                \

--- a/hard/fakeram/bsg_mem_1rw_sync_mask_write_bit_macros.svh
+++ b/hard/fakeram/bsg_mem_1rw_sync_mask_write_bit_macros.svh
@@ -8,7 +8,7 @@
   `bsg_mem_1rw_sync_mask_write_bit_1sram_macro(words,bits)
 
 `define bsg_mem_1rw_sync_mask_write_bit_1sram_macro(words,bits,tag) \
-  if (els_p == words && width_p == bits)                            \
+  if (harden_p && els_p == words && width_p == bits)                \
     begin: macro                                                    \
        fakeram_d``words``_w``bits`` mem                             \
          (.clk(clk_i)                                               \

--- a/hard/fakeram/bsg_mem_1rw_sync_mask_write_byte_macros.svh
+++ b/hard/fakeram/bsg_mem_1rw_sync_mask_write_byte_macros.svh
@@ -8,7 +8,7 @@
   `bsg_mem_1rw_sync_mask_write_byte_1sram_macro(words,bits)
 
 `define bsg_mem_1rw_sync_mask_write_byte_1sram_macro(words,bits,tag) \
-  if (els_p == words && data_width_p == bits)                        \
+  if (harden_p && els_p == words && data_width_p == bits)            \
     begin: macro                                                     \
        logic [data_width_p-1:0] w_mask_lo;                           \
        bsg_expand_bitmask                                            \

--- a/hard/gf_14/bsg_misc/bsg_gate_stack_gen.py
+++ b/hard/gf_14/bsg_misc/bsg_gate_stack_gen.py
@@ -148,7 +148,7 @@ elif len(sys.argv) == 5 :
     input_params = ["input [width_p-1:0] i"+str(x) for x in range(0,num_inputs)]
     print '''
 
-module bsg_'''+sys.argv[4],'''#(width_p="inv",harden_p=1)
+module bsg_'''+sys.argv[4],'''#(width_p="inv",harden_p=0)
    ('''+"\n    ,".join(input_params)+'''
     , output [width_p-1:0] o
     );

--- a/hard/gf_14/bsg_misc/bsg_tiehi.sv
+++ b/hard/gf_14/bsg_misc/bsg_tiehi.sv
@@ -2,7 +2,7 @@
 
 module bsg_tiehi
 
-#(width_p="inv", harden_p=1)
+#(width_p="inv", harden_p=0)
 
 (output [width_p-1:0] o
 );

--- a/hard/gf_14/bsg_misc/bsg_tielo.sv
+++ b/hard/gf_14/bsg_misc/bsg_tielo.sv
@@ -2,7 +2,7 @@
 
 module bsg_tielo
 
-#(width_p="inv", harden_p=1)
+#(width_p="inv", harden_p=0)
 
 (output [width_p-1:0] o
 );

--- a/hard/pickle_40/bsg_mem/bsg_mem_1rw_sync.sv
+++ b/hard/pickle_40/bsg_mem/bsg_mem_1rw_sync.sv
@@ -1,6 +1,6 @@
 
 `define bsg_mem_1rw_sync_macro(words,bits)      \
-  if (els_p == words && width_p == bits)        \
+  if (harden_p && els_p == words && width_p == bits) \
     begin: macro                                \
       hard_mem_1rw_d``words``_w``bits``_wrapper \
         mem                                     \
@@ -20,6 +20,7 @@ module bsg_mem_1rw_sync #( parameter `BSG_INV_PARAM(width_p )
                          , parameter addr_width_lp = `BSG_SAFE_CLOG2(els_p)
                          // whether to substitute a 1r1w
                          , parameter substitute_1r1w_p = 1
+                         , parameter harden_p=1
                          )
   ( input                     clk_i
   , input                     reset_i

--- a/hard/pickle_40/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.sv
+++ b/hard/pickle_40/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.sv
@@ -1,6 +1,6 @@
 
 `define bsg_mem_1rw_sync_mask_write_bit_macro(words,bits) \
-  if (els_p == words && width_p == bits)                  \
+  if (harden_p && els_p == words && width_p == bits)      \
     begin: macro                                          \
       hard_mem_1rw_bit_mask_d``words``_w``bits``_wrapper  \
         mem                                               \
@@ -16,7 +16,7 @@
     end: macro
 
 `define bsg_mem_1rw_sync_mask_write_bit_macro_banks(words,bits) \
-  if (els_p == words && width_p == 2*``bits``)                  \
+  if (harden_p && els_p == words && width_p == 2*``bits``)      \
     begin: macro                                                \
       hard_mem_1rw_bit_mask_d``words``_w``bits``_wrapper        \
         mem0                                                    \
@@ -45,6 +45,7 @@
 module bsg_mem_1rw_sync_mask_write_bit #( parameter `BSG_INV_PARAM(width_p )
                                         , parameter `BSG_INV_PARAM(els_p )
                                         , parameter addr_width_lp = `BSG_SAFE_CLOG2(els_p)
+                                        , parameter harden_p=1
                                         )
   ( input                       clk_i
   , input                       reset_i

--- a/hard/pickle_40/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
+++ b/hard/pickle_40/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
@@ -1,6 +1,6 @@
 
 `define bsg_mem_1rw_sync_mask_write_byte_macro(words,bits) \
-  if (els_p == words && data_width_p == bits)              \
+  if (harden_p && els_p == words && data_width_p == bits)  \
     begin: macro                                           \
       hard_mem_1rw_byte_mask_d``words``_w``bits``_wrapper  \
         mem                                                \
@@ -19,6 +19,7 @@ module bsg_mem_1rw_sync_mask_write_byte #( parameter `BSG_INV_PARAM(els_p )
                                          , parameter `BSG_INV_PARAM(data_width_p )
                                          , parameter addr_width_lp = `BSG_SAFE_CLOG2(els_p)
                                          , parameter write_mask_width_lp = data_width_p>>3
+                                         , parameter harden_p=1
                                          )
 
   ( input                           clk_i

--- a/hard/pickle_40/bsg_mem/bsg_mem_2r1w_sync.sv
+++ b/hard/pickle_40/bsg_mem/bsg_mem_2r1w_sync.sv
@@ -91,7 +91,7 @@ module bsg_mem_2r1w_sync #( parameter `BSG_INV_PARAM(width_p )
         end // block: s1r1w
       else
         begin: notmacro
-          bsg_mem_2r1w_sync_synth #(.width_p(width_p), .els_p(els_p), .read_write_same_addr_p(read_write_same_addr_p), .harden_p(harden_p))
+          bsg_mem_2r1w_sync_synth #(.width_p(width_p), .els_p(els_p), .read_write_same_addr_p(read_write_same_addr_p))
             synth
               (.*);
         end // block: notmacro

--- a/hard/pickle_40/bsg_mem/bsg_mem_2r1w_sync.sv
+++ b/hard/pickle_40/bsg_mem/bsg_mem_2r1w_sync.sv
@@ -1,6 +1,6 @@
 
 `define bsg_mem_2r1w_sync_macro(words,bits)      \
-  if (els_p == words && width_p == bits)         \
+  if (harden_p && els_p == words && width_p == bits) \
     begin: macro                                 \
       hard_mem_1r1w_d``words``_w``bits``_wrapper \
         mem0                                     \
@@ -31,7 +31,7 @@ module bsg_mem_2r1w_sync #( parameter `BSG_INV_PARAM(width_p )
                           , parameter `BSG_INV_PARAM(els_p )
                           , parameter read_write_same_addr_p = 0
                           , parameter addr_width_lp = `BSG_SAFE_CLOG2(els_p)
-                          , parameter harden_p = 0
+                          , parameter harden_p=1
                           , parameter substitute_2r1w_p = 0
                           )
   ( input clk_i

--- a/hard/saed_90/bsg_mem/bsg_mem_1r1w.sv
+++ b/hard/saed_90/bsg_mem/bsg_mem_1r1w.sv
@@ -24,7 +24,7 @@ module bsg_mem_1r1w #(parameter `BSG_INV_PARAM(width_p)
                       , parameter `BSG_INV_PARAM(els_p)
                       , parameter read_write_same_addr_p=0
                       , parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
-                      , parameter harden_p=0
+                      , parameter harden_p=1
                       )
    (input   w_clk_i
     , input w_reset_i
@@ -49,7 +49,6 @@ module bsg_mem_1r1w #(parameter `BSG_INV_PARAM(width_p)
      #(.width_p(width_p)
        ,.els_p(els_p)
        ,.read_write_same_addr_p(read_write_same_addr_p)
-       ,.harden_p(harden_p)
        ) synth
        (.*);
 

--- a/hard/saed_90/bsg_mem/bsg_mem_1r1w.sv
+++ b/hard/saed_90/bsg_mem/bsg_mem_1r1w.sv
@@ -4,7 +4,7 @@
 //
 
 `define bsg_mem_1r1w_macro(bits,words) \
-  if (els_p == words && width_p == bits)    \
+  if (harden_p && els_p == words && width_p == bits)    \
     begin: macro                            \
        saed90_``bits``x``words``_2P_ASYNC mem     \
          (.CE1  (w_clk_i)                     \

--- a/hard/saed_90/bsg_mem/bsg_mem_1r1w_sync.sv
+++ b/hard/saed_90/bsg_mem/bsg_mem_1r1w_sync.sv
@@ -4,7 +4,7 @@
 //
 
 `define bsg_mem_1r1w_sync_macro(bits,words) \
-  if (els_p == words && width_p == bits)    \
+  if (harden_p && els_p == words && width_p == bits)    \
     begin: macro                            \
        saed90_``bits``x``words``_2P mem     \
          (.CE1  (clk_lo)                     \
@@ -26,7 +26,7 @@ module bsg_mem_1r1w_sync #(parameter `BSG_INV_PARAM(width_p)
                          ,parameter read_write_same_addr_p=0
                          // whether to substitute a 1r1w
                          ,parameter substitute_1r1w_p=1
-                         ,parameter harden_p = 1
+                         ,parameter harden_p=1
                          ,parameter enable_clock_gating_p=1'b0
                          )
       

--- a/hard/saed_90/bsg_mem/bsg_mem_1rw_sync.sv
+++ b/hard/saed_90/bsg_mem/bsg_mem_1rw_sync.sv
@@ -5,7 +5,7 @@
 //
 
 `define bsg_mem_1rw_sync_macro(bits,words)  \
-  if (els_p == words && width_p == bits)    \
+  if (harden_p && els_p == words && width_p == bits)    \
     begin: macro                            \
        saed90_``bits``x``words``_1P mem     \
          (.CE1  (clk_lo)                     \
@@ -24,6 +24,7 @@ module bsg_mem_1rw_sync #(parameter `BSG_INV_PARAM(width_p)
                          // whether to substitute a 1r1w
                          ,parameter substitute_1r1w_p=1
                          ,parameter enable_clock_gating_p=1'b0
+                         ,parameter harden_p=1
 			 ,parameter latch_last_read_p=0
                          )
   (input                      clk_i

--- a/hard/saed_90/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.sv
+++ b/hard/saed_90/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.sv
@@ -4,7 +4,7 @@
 // Only one read or one write may be done per cycle.
 
 `define bsg_mem_1rw_sync_mask_write_bit_macro(bits,words)  \
-  if (els_p == words && width_p == bits)    \
+  if (harden_p && els_p == words && width_p == bits)    \
     begin: macro                            \
        saed90_``bits``x``words``_1P_bit mem \
          (.CE1  (clk_lo)                     \
@@ -19,9 +19,10 @@
     end
 
 module bsg_mem_1rw_sync_mask_write_bit #(parameter `BSG_INV_PARAM(width_p)
-			               , parameter `BSG_INV_PARAM(els_p)
-			               , parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
-                     , parameter enable_clock_gating_p=1'b0
+                           , parameter `BSG_INV_PARAM(els_p)
+                           , parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
+                           , parameter enable_clock_gating_p=1'b0
+                           , parameter harden_p=1
                      )
    (input   clk_i
     , input reset_i

--- a/hard/saed_90/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
+++ b/hard/saed_90/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
@@ -5,7 +5,7 @@
 //
 
 `define bsg_mem_1rw_sync_mask_write_byte_macro(bits,words)  \
-  if (els_p == words && data_width_p == bits)    \
+  if (harden_p && els_p == words && data_width_p == bits)    \
     begin: macro                            \
        saed90_``bits``x``words``_1P_BM mem  \
          (.CE1  (clk_lo)                     \
@@ -24,6 +24,7 @@ module bsg_mem_1rw_sync_mask_write_byte #(parameter `BSG_INV_PARAM(els_p )
                                          ,parameter addr_width_lp = `BSG_SAFE_CLOG2(els_p)
                                          ,parameter write_mask_width_lp = data_width_p>>3
                                          ,parameter enable_clock_gating_p=1'b0
+                                         ,parameter harden_p=1
                                          )
   (input                           clk_i
   ,input                           reset_i

--- a/hard/saed_90/bsg_misc/bsg_dff_gatestack.sv
+++ b/hard/saed_90/bsg_misc/bsg_dff_gatestack.sv
@@ -1,4 +1,4 @@
-module bsg_dff_gatestack #(width_p="inv", harden_p=1)
+module bsg_dff_gatestack #(width_p="inv", harden_p=0)
    (input [width_p-1:0] i0
     , input [width_p-1:0] i1
     , output logic [width_p-1:0] o

--- a/hard/saed_90/bsg_misc/bsg_mux2_gatestack.sv
+++ b/hard/saed_90/bsg_misc/bsg_mux2_gatestack.sv
@@ -1,4 +1,4 @@
-module bsg_mux2_gatestack #(width_p="inv", harden_p=1)
+module bsg_mux2_gatestack #(width_p="inv", harden_p=0)
    (input [width_p-1:0] i0
     , input [width_p-1:0] i1
     , input [width_p-1:0] i2

--- a/hard/saed_90/bsg_misc/bsg_muxi2_gatestack.sv
+++ b/hard/saed_90/bsg_misc/bsg_muxi2_gatestack.sv
@@ -1,4 +1,4 @@
-module bsg_muxi2_gatestack #(width_p="inv", harden_p=1)
+module bsg_muxi2_gatestack #(width_p="inv", harden_p=0)
    (input [width_p-1:0] i0
     , input [width_p-1:0] i1
     , input [width_p-1:0] i2

--- a/hard/tsmc_16/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit.sv
+++ b/hard/tsmc_16/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit.sv
@@ -26,7 +26,7 @@
 //
 
 `define bsg_mem_1r1w_sync_mask_write_bit_macro(words,bits,lgEls)     \
-if (els_p == words && width_p == bits)                               \
+if (harden_p && els_p == words && width_p == bits)                   \
   begin: macro                                                       \
       tsmc16_1r1w_lg``lgEls``_w``bits``_bit mem (                    \
          .CLK   (clk_i)                                              \
@@ -50,7 +50,7 @@ if (els_p == words && width_p == bits)                               \
   end
 
 `define bsg_mem_1r1w_sync_mask_write_bit_macro_rf(words,bits,lgEls)  \
-if (els_p == words && width_p == bits)                               \
+if (harden_p && els_p == words && width_p == bits)                   \
   begin: macro                                                       \
       tsmc16_1r1w_rf_lg``lgEls``_w``bits``_bit mem (                 \
          .CLKA  (clk_i)                                              \

--- a/hard/tsmc_16/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit.sv
+++ b/hard/tsmc_16/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit.sv
@@ -99,7 +99,6 @@ module bsg_mem_1r1w_sync_mask_write_bit #(parameter `BSG_INV_PARAM(width_p)
        #(.width_p(width_p)
          ,.els_p (els_p  )
          ,.read_write_same_addr_p(read_write_same_addr_p)
-         ,.harden_p(harden_p)
          ) synth
          (.*);
 

--- a/hard/tsmc_16/bsg_mem/bsg_mem_1rw_sync.sv
+++ b/hard/tsmc_16/bsg_mem/bsg_mem_1rw_sync.sv
@@ -5,7 +5,7 @@
 //
 
 `define bsg_mem_1rw_sync_macro(words,bits,lgEls,newBits)                       \
-if (els_p == words && width_p == bits)                                         \
+if (harden_p && els_p == words && width_p == bits)                             \
   begin: macro                                                                 \
      tsmc16_1rw_lg``lgEls``_w``newBits``_all mem                               \
        (.CLK   (clk_i )                                                        \
@@ -23,7 +23,7 @@ if (els_p == words && width_p == bits)                                         \
   end // block: macro
 
 `define bsg_mem_1rw_sync_macro_rf(words,bits,lgEls,newBits)                   \
-if (els_p == words && width_p == bits)                                        \
+if (harden_p && els_p == words && width_p == bits)                            \
   begin: macro                                                                \
      tsmc16_1rf_lg``lgEls``_w``newBits``_all mem                              \
        (.Q     (data_o)                                                       \
@@ -44,7 +44,8 @@ module bsg_mem_1rw_sync #(parameter `BSG_INV_PARAM(width_p)
                          ,parameter `BSG_INV_PARAM(els_p)
                          ,parameter addr_width_lp=$clog2(els_p)
                          // whether to substitute a 1r1w
-                         ,parameter substitute_1r1w_p=1)
+                         ,parameter substitute_1r1w_p=1
+                         ,parameter harden_p=1)
   (input                      clk_i
   ,input                      reset_i
   ,input [width_p-1:0]        data_i

--- a/hard/tsmc_16/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.sv
+++ b/hard/tsmc_16/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.sv
@@ -19,7 +19,7 @@
 //   RET1N // Retention Mode (active low) - disabled
 
 `define bsg_mem_1rw_sync_mask_write_bit_macro(words,bits,lgEls)     \
-if (els_p == words && width_p == bits)               \
+if (harden_p && els_p == words && width_p == bits)   \
   begin: macro                                       \
       tsmc16_1rw_lg``lgEls``_w``bits``_bit mem       \
         (.CLK   (clk_i )                             \
@@ -38,7 +38,7 @@ if (els_p == words && width_p == bits)               \
   end // block: macro
 
 `define bsg_mem_1rw_sync_mask_write_bit_macro_rf(words,bits,lgEls)  \
-if (els_p == words && width_p == bits)               \
+if (harden_p && els_p == words && width_p == bits)   \
   begin: macro                                       \
       tsmc16_1rf_lg``lgEls``_w``bits``_bit mem       \
         (.Q     (data_o)                             \
@@ -58,7 +58,8 @@ if (els_p == words && width_p == bits)               \
 
 module bsg_mem_1rw_sync_mask_write_bit #(parameter `BSG_INV_PARAM(width_p)
                                        , parameter `BSG_INV_PARAM(els_p)
-                                       , parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p))
+                                       , parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
+                                       , parameter harden_p=1)
    (input   clk_i
     , input reset_i
     , input [width_p-1:0] data_i

--- a/hard/tsmc_16/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
+++ b/hard/tsmc_16/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
@@ -7,6 +7,7 @@ module bsg_mem_1rw_sync_mask_write_byte #(parameter `BSG_INV_PARAM(els_p )
                                          ,parameter `BSG_INV_PARAM(data_width_p )
                                          ,parameter addr_width_lp = `BSG_SAFE_CLOG2(els_p)
                                          ,parameter write_mask_width_lp = data_width_p>>3
+                                         ,parameter harden_p=1
                                          )
   (input                           clk_i
   ,input                           reset_i
@@ -18,7 +19,7 @@ module bsg_mem_1rw_sync_mask_write_byte #(parameter `BSG_INV_PARAM(els_p )
   ,output [data_width_p-1:0]       data_o
   );
 
-  if ((els_p == 1024) & (data_width_p == 32))
+  if (harden_p && (els_p == 1024) & (data_width_p == 32))
     begin : macro
       wire [31:0] wen = ~{{8{write_mask_i[3]}}
                          ,{8{write_mask_i[2]}}

--- a/hard/tsmc_16/bsg_mem/bsg_mem_2r1w_sync.sv
+++ b/hard/tsmc_16/bsg_mem/bsg_mem_2r1w_sync.sv
@@ -9,7 +9,7 @@ module bsg_mem_2r1w_sync #(parameter `BSG_INV_PARAM(width_p)
                            , parameter `BSG_INV_PARAM(els_p)
                            , parameter read_write_same_addr_p=0
                            , parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
-                           , parameter harden_p=0
+                           , parameter harden_p=1
                            )
    (input   clk_i
     , input reset_i
@@ -86,7 +86,6 @@ module bsg_mem_2r1w_sync #(parameter `BSG_INV_PARAM(width_p)
 	  #(.width_p(width_p)
 	    ,.els_p(els_p)
 	    ,.read_write_same_addr_p(read_write_same_addr_p)
-	    ,.harden_p(harden_p)
 	    ) synth
 	    (.*);
      end

--- a/hard/tsmc_16/bsg_misc/bsg_mux.sv
+++ b/hard/tsmc_16/bsg_misc/bsg_mux.sv
@@ -1,7 +1,7 @@
 module bsg_mux #(
   parameter `BSG_INV_PARAM(width_p    ),
   parameter `BSG_INV_PARAM(els_p      ),
-  parameter harden_p   = 1,
+  parameter harden_p   = 0,
   parameter balanced_p = 0,
   parameter lg_els_lp  = `BSG_SAFE_CLOG2(els_p)
 ) (

--- a/hard/tsmc_180_250/bsg_dataflow/bsg_fifo_shift_datapath.sv
+++ b/hard/tsmc_180_250/bsg_dataflow/bsg_fifo_shift_datapath.sv
@@ -5,7 +5,7 @@
 //
 
 `define bsg_fifo_shift_datapath_macro(words,bits)                             \
-        if (els_p == words && width_p == bits)                                \
+        if (harden_p && els_p == words && width_p == bits)                    \
           begin: macro                                                        \
              bsg_rp_tsmc_250_fifo_shift_w``words``_b``bits w``words``_b``bits \
                (.*                                                            \
@@ -18,6 +18,7 @@
 module bsg_fifo_shift_datapath #(parameter `BSG_INV_PARAM( width_p    )
                                  ,parameter `BSG_INV_PARAM(els_p      )
                                  ,parameter default_p  = { (width_p) {1'b0} }
+                                 ,parameter harden_p = 0
                                  )
    (input   clk_i
     , input [width_p-1:0]    data_i

--- a/hard/tsmc_180_250/bsg_mem/bsg_mem_1r1w.sv
+++ b/hard/tsmc_180_250/bsg_mem/bsg_mem_1r1w.sv
@@ -146,7 +146,6 @@ module bsg_mem_1r1w #(parameter `BSG_INV_PARAM(width_p)
 		  #(.width_p(width_p)
 		    ,.els_p(els_p)
 		    ,.read_write_same_addr_p(read_write_same_addr_p)
-		    ,.harden_p(harden_p)
 		    ) synth
 		    (.*);
 	     end

--- a/hard/tsmc_180_250/bsg_mem/bsg_mem_1r1w.sv
+++ b/hard/tsmc_180_250/bsg_mem/bsg_mem_1r1w.sv
@@ -7,7 +7,7 @@
 
 
 `define bsg_mem_1r1w_macro(words,bits)                                  \
-     if (els_p == words && width_p == bits)                             \
+     if (harden_p && els_p == words && width_p == bits)                 \
        begin: macro                                                     \
           wire [els_p-1:0] wa_one_hot = (w_v_i << w_addr_i);            \
           wire [els_p-1:0] ra_one_hot = (r_v_i << r_addr_i);            \
@@ -25,7 +25,7 @@ module bsg_mem_1r1w #(parameter `BSG_INV_PARAM(width_p)
                       , parameter `BSG_INV_PARAM(els_p)
                       , parameter read_write_same_addr_p=0
                       , parameter addr_width_lp=$clog2(els_p)
-		      , parameter harden_p=1)
+                      , parameter harden_p=1)
    (input   w_clk_i
     , input w_reset_i
 

--- a/hard/tsmc_180_250/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit.sv
+++ b/hard/tsmc_180_250/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit.sv
@@ -6,7 +6,7 @@
 
 
 `define bsg_mem_1r1w_sync_macro_rf(words,bits,lgEls,mux)        \
-if (els_p == words && width_p == bits)                          \
+if (harden_p && els_p == words && width_p == bits)              \
   begin: macro                                                  \
           tsmc180_2rf_lg``lgEls``_w``bits``_m``mux``_bit mem    \
             (                                                   \

--- a/hard/tsmc_180_250/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit.sv
+++ b/hard/tsmc_180_250/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit.sv
@@ -51,7 +51,6 @@ module bsg_mem_1r1w_sync_mask_write_bit #(parameter `BSG_INV_PARAM(width_p)
      #(.width_p(width_p)
        ,.els_p (els_p  )
        ,.read_write_same_addr_p(read_write_same_addr_p)
-       ,.harden_p(harden_p)
        ) synth
        (.*);
 

--- a/hard/tsmc_180_250/bsg_mem/bsg_mem_1rw_sync.sv
+++ b/hard/tsmc_180_250/bsg_mem/bsg_mem_1rw_sync.sv
@@ -5,7 +5,7 @@
 //
 
 `define bsg_mem_1rw_sync_macro(words,bits,lgEls,newBits,mux)    \
-if (els_p == words && width_p == bits)                          \
+if (harden_p && els_p == words && width_p == bits)              \
   begin: macro                                                  \
      tsmc180_1rw_lg``lgEls``_w``newBits``_m``mux``_all mem      \
           (.Q(data_o)                                           \
@@ -20,7 +20,7 @@ if (els_p == words && width_p == bits)                          \
   end
 
 `define bsg_mem_1rw_sync_macro_rf(words,bits,lgEls,newBits,mux) \
-if (els_p == words && width_p == bits)                          \
+if (harden_p && els_p == words && width_p == bits)              \
   begin: macro                                                  \
           wire [newBits-1:0] tmp_lo,tmp_li;                     \
           assign data_o = tmp_lo[bits-1:0];                     \
@@ -41,7 +41,8 @@ module bsg_mem_1rw_sync #(parameter `BSG_INV_PARAM(width_p)
                           , parameter `BSG_INV_PARAM(els_p)
                           , parameter addr_width_lp=$clog2(els_p)
                           // whether to substitute a 1r1w
-                          , parameter substitute_1r1w_p=1)
+                          , parameter substitute_1r1w_p=1
+                          , parameter harden_p=1)
    (input   clk_i
     , input reset_i
     , input [width_p-1:0] data_i

--- a/hard/tsmc_180_250/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.sv
+++ b/hard/tsmc_180_250/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.sv
@@ -6,7 +6,7 @@
 
 
 `define bsg_mem_1rw_sync_macro_2rf(words,bits,lgEls,mux)        \
-if (els_p == words && width_p == bits)                          \
+if (harden_p && els_p == words && width_p == bits)              \
   begin: macro                                                  \
           tsmc180_2rf_lg``lgEls``_w``bits``_m``mux``_bit mem    \
             (                                                   \
@@ -26,7 +26,8 @@ if (els_p == words && width_p == bits)                          \
 
 module bsg_mem_1rw_sync_mask_write_bit #(parameter `BSG_INV_PARAM(width_p)
 			               , parameter `BSG_INV_PARAM(els_p)
-			               , parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p))
+			               , parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
+                           , parameter harden_p=1)
    (input   clk_i
     , input reset_i
     , input [width_p-1:0] data_i

--- a/hard/tsmc_180_250/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
+++ b/hard/tsmc_180_250/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
@@ -9,6 +9,7 @@ module bsg_mem_1rw_sync_mask_write_byte
   ,parameter `BSG_INV_PARAM(data_width_p )
   ,parameter addr_width_lp = `BSG_SAFE_CLOG2(els_p)
   ,parameter write_mask_width_lp = data_width_p>>3
+  ,parameter harden_p=1
   )
 
   (input                           clk_i
@@ -26,7 +27,7 @@ module bsg_mem_1rw_sync_mask_write_byte
   );
 
   // TSMC 180 1024x32 Byte Mask
-  if ((els_p == 1024) & (data_width_p == 32))
+  if (harden_p && (els_p == 1024) & (data_width_p == 32))
     begin : macro
       wire [3:0] wen = {~(w_i & write_mask_i[3])
                        ,~(w_i & write_mask_i[2])

--- a/hard/tsmc_180_250/bsg_mem/bsg_mem_2r1w.sv
+++ b/hard/tsmc_180_250/bsg_mem/bsg_mem_2r1w.sv
@@ -7,7 +7,7 @@
 
 
 `define bsg_mem_2r1w_macro(words,bits)                                  \
-     if (els_p == words && width_p == bits)                             \
+     if (harden_p && els_p == words && width_p == bits)                 \
        begin: macro                                                     \
           wire [els_p-1:0] wa_one_hot = (w_v_i << w_addr_i);            \
           wire [els_p-1:0] ra_one_hot0 = (r0_v_i << r0_addr_i);         \
@@ -27,6 +27,7 @@ module bsg_mem_2r1w #(parameter `BSG_INV_PARAM(width_p)
                       , parameter `BSG_INV_PARAM(els_p)
                       , parameter read_write_same_addr_p=0
                       , parameter addr_width_lp=$clog2(els_p)
+                      , parameter harden_p=1
                       )
    (input   w_clk_i
     , input w_reset_i

--- a/hard/tsmc_180_250/bsg_mem/bsg_mem_2r1w_sync.sv
+++ b/hard/tsmc_180_250/bsg_mem/bsg_mem_2r1w_sync.sv
@@ -9,7 +9,7 @@ module bsg_mem_2r1w_sync #(parameter `BSG_INV_PARAM(width_p)
                            , parameter `BSG_INV_PARAM(els_p)
                            , parameter read_write_same_addr_p=0
                            , parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
-                           , parameter harden_p=0
+                           , parameter harden_p=1
                            )
    (input   clk_i
     , input reset_i
@@ -87,7 +87,6 @@ module bsg_mem_2r1w_sync #(parameter `BSG_INV_PARAM(width_p)
 	  #(.width_p(width_p)
 	    ,.els_p(els_p)
 	    ,.read_write_same_addr_p(read_write_same_addr_p)
-	    ,.harden_p(harden_p)
 	    ) synth
 	    (.*);
      end

--- a/hard/tsmc_180_250/bsg_mem/bsg_mem_2r1w_sync.sv
+++ b/hard/tsmc_180_250/bsg_mem/bsg_mem_2r1w_sync.sv
@@ -30,7 +30,7 @@ module bsg_mem_2r1w_sync #(parameter `BSG_INV_PARAM(width_p)
 
    wire                   unused = reset_i;
 
-   if ((width_p == 32) && (els_p == 32))
+   if (harden_p && (width_p == 32) && (els_p == 32))
      begin: macro
 `ifndef BSG_HIDE_FROM_SYNTHESIS
         initial

--- a/hard/tsmc_180_250/bsg_misc/bsg_buf.sv
+++ b/hard/tsmc_180_250/bsg_misc/bsg_buf.sv
@@ -10,7 +10,7 @@ if (harden_p && (width_p==bits) && ~vertical_p)               \
    end
 
 module bsg_buf #(parameter `BSG_INV_PARAM(width_p)
-                 , parameter harden_p=1
+                 , parameter harden_p=0
 		 , parameter vertical_p=1
                  )
    (input    [width_p-1:0] i

--- a/hard/tsmc_180_250/bsg_misc/bsg_clkbuf.sv
+++ b/hard/tsmc_180_250/bsg_misc/bsg_clkbuf.sv
@@ -6,7 +6,7 @@ if (harden_p && (width_p==bits) && (strength==strength_p))     \
 
 module bsg_clkbuf #(parameter width_p=1
 		 , parameter strength_p=8
-                 , parameter harden_p=1
+                 , parameter harden_p=0
                  )
    (input    [width_p-1:0] i
     , output [width_p-1:0] o

--- a/hard/tsmc_180_250/bsg_misc/bsg_dff.sv
+++ b/hard/tsmc_180_250/bsg_misc/bsg_dff.sv
@@ -4,7 +4,7 @@ if (harden_p && (width_p==bits) && (strength_p==strength)) \
      bsg_rp_tsmc_250_dff_s``strength``_b``bits dff(.*);   \
   end
 
-module bsg_dff #(width_p=-1, harden_p=1, strength_p=1)
+module bsg_dff #(width_p=-1, harden_p=0, strength_p=1)
    (input   clock_i
     ,input  [width_p-1:0] data_i
     ,output [width_p-1:0] data_o

--- a/hard/tsmc_180_250/bsg_misc/bsg_dff_en.sv
+++ b/hard/tsmc_180_250/bsg_misc/bsg_dff_en.sv
@@ -10,7 +10,7 @@ if (harden_p && width_p==bits && (strength_p==womp))                         \
 
 
 module bsg_dff_en #(width_p="inv"
-                    , harden_p=1
+                    , harden_p=0
                     , strength_p=1
                     )
    (input   clock_i

--- a/hard/tsmc_180_250/bsg_misc/bsg_dff_reset.sv
+++ b/hard/tsmc_180_250/bsg_misc/bsg_dff_reset.sv
@@ -7,7 +7,7 @@ if (harden_p && width_p==bits)                                          \
                                                ,.data_o);               \
   end
 
-module bsg_dff_reset #(width_p=-1, harden_p=1)
+module bsg_dff_reset #(width_p=-1, harden_p=0)
    (input   clk_i
     ,input  reset_i
     ,input  [width_p-1:0] data_i

--- a/hard/tsmc_180_250/bsg_misc/bsg_dff_reset_en.sv
+++ b/hard/tsmc_180_250/bsg_misc/bsg_dff_reset_en.sv
@@ -10,7 +10,7 @@ if (harden_p && width_p==bits)                                          \
                                                ,.data_o);               \
   end
 
-module bsg_dff_reset_en #(width_p=-1, harden_p=1)
+module bsg_dff_reset_en #(width_p=-1, harden_p=0)
    (input   clk_i
     ,input  reset_i
     ,input  [width_p-1:0] data_i

--- a/hard/tsmc_180_250/bsg_misc/bsg_gate_stack_gen.py
+++ b/hard/tsmc_180_250/bsg_misc/bsg_gate_stack_gen.py
@@ -148,7 +148,7 @@ elif len(sys.argv) == 5 :
     input_params = ["input [width_p-1:0] i"+str(x) for x in range(0,num_inputs)]
     print '''
 
-module bsg_'''+sys.argv[4],'''#(width_p="inv",harden_p=1)
+module bsg_'''+sys.argv[4],'''#(width_p="inv",harden_p=0)
    ('''+"\n    ,".join(input_params)+'''
     , output [width_p-1:0] o
     );

--- a/hard/tsmc_180_250/bsg_misc/bsg_inv.sv
+++ b/hard/tsmc_180_250/bsg_misc/bsg_inv.sv
@@ -10,7 +10,7 @@ if (harden_p && (width_p==bits) && ~vertical_p)                   \
   end
 
 module bsg_inv #(parameter `BSG_INV_PARAM(width_p)
-                 , parameter harden_p=1
+                 , parameter harden_p=0
 		 , parameter vertical_p=1
                  )
    (input    [width_p-1:0] i

--- a/hard/tsmc_180_250/bsg_misc/bsg_mux.sv
+++ b/hard/tsmc_180_250/bsg_misc/bsg_mux.sv
@@ -31,7 +31,7 @@ end
 
 module bsg_mux #(parameter `BSG_INV_PARAM(width_p)
                  , els_p=1
-                 , harden_p=1
+                 , harden_p=0
                  , balanced_p=0
                  , lg_els_lp=`BSG_SAFE_CLOG2(els_p)
                  )

--- a/hard/tsmc_180_250/bsg_misc/bsg_mux_one_hot.sv
+++ b/hard/tsmc_180_250/bsg_misc/bsg_mux_one_hot.sv
@@ -8,7 +8,7 @@ end
 
 module bsg_mux_one_hot #(parameter `BSG_INV_PARAM(width_p)
                          , els_p=1
-			 , harden_p=1
+			 , harden_p=0
                          )
    (
     input [els_p-1:0][width_p-1:0] data_i

--- a/hard/tsmc_180_250/bsg_misc/bsg_tiehi.sv
+++ b/hard/tsmc_180_250/bsg_misc/bsg_tiehi.sv
@@ -5,7 +5,7 @@ if (harden_p && (width_p==bits))                    \
   end
 
 module bsg_tiehi #(parameter `BSG_INV_PARAM(width_p)
-                 , parameter harden_p=1
+                 , parameter harden_p=0
                  )
    (output [width_p-1:0] o
     );

--- a/hard/tsmc_180_250/bsg_misc/bsg_tielo.sv
+++ b/hard/tsmc_180_250/bsg_misc/bsg_tielo.sv
@@ -5,7 +5,7 @@ if (harden_p && (width_p==bits))                    \
   end
 
 module bsg_tielo #(parameter `BSG_INV_PARAM(width_p)
-                 , parameter harden_p=1
+                 , parameter harden_p=0
                  )
    (output [width_p-1:0] o
     );

--- a/hard/tsmc_28/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_macros.svh
+++ b/hard/tsmc_28/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_macros.svh
@@ -22,7 +22,7 @@ if (harden_p && els_p == words && data_width_p == bits)         \
     bsg_mem_1rw_sync_mask_write_bit                             \
      #(.width_p(data_width_p), .els_p(els_p))                   \
      bit_mem                                                    \
-      (.w_mask_i(w_mask_li), .*);                               \
+      (.write_mask_i(w_mask_li), .*);                               \
   end
 
 `define bsg_mem_1rw_sync_mask_write_byte_banked_macro(words,bits,wbank,dbank) \

--- a/hard/tsmc_28/bsg_misc/bsg_buf.sv
+++ b/hard/tsmc_28/bsg_misc/bsg_buf.sv
@@ -11,7 +11,7 @@ if (harden_p && (width_p==bits))                              \
   end
 
 module bsg_buf #(parameter `BSG_INV_PARAM(width_p)
-                 , parameter harden_p=1
+                 , parameter harden_p=0
 		 , parameter vertical_p=1
                  )
    (input    [width_p-1:0] i

--- a/hard/tsmc_28/bsg_misc/bsg_dff.sv
+++ b/hard/tsmc_28/bsg_misc/bsg_dff.sv
@@ -10,7 +10,7 @@ if (harden_p && (width_p==bits) && (strength_p==strength)) \
       end                                                     \
   end
 
-module bsg_dff #(`BSG_INV_PARAM(width_p), harden_p=1, strength_p=1)
+module bsg_dff #(`BSG_INV_PARAM(width_p), harden_p=0, strength_p=1)
    (input   clk_i
     ,input  [width_p-1:0] data_i
     ,output [width_p-1:0] data_o

--- a/hard/tsmc_28/bsg_misc/bsg_tiehi.sv
+++ b/hard/tsmc_28/bsg_misc/bsg_tiehi.sv
@@ -2,7 +2,7 @@
 
 module bsg_tiehi
 
-#(`BSG_INV_PARAM(width_p), harden_p=1)
+#(`BSG_INV_PARAM(width_p), harden_p=0)
 
 (output [width_p-1:0] o
 );

--- a/hard/tsmc_28/bsg_misc/bsg_tielo.sv
+++ b/hard/tsmc_28/bsg_misc/bsg_tielo.sv
@@ -2,7 +2,7 @@
 
 module bsg_tielo
 
-#(`BSG_INV_PARAM(width_p), harden_p=1)
+#(`BSG_INV_PARAM(width_p), harden_p=0)
 
 (output [width_p-1:0] o
 );

--- a/hard/tsmc_40/bsg_mem/bsg_mem_1r1w.sv
+++ b/hard/tsmc_40/bsg_mem/bsg_mem_1r1w.sv
@@ -7,7 +7,7 @@
 
 
 `define bsg_mem_1r1w_macro(words,bits)                                  \
-     if (els_p == words && width_p == bits)                             \
+     if (harden_p && els_p == words && width_p == bits)                             \
        begin: macro                                                     \
           wire [els_p-1:0] wa_one_hot = (w_v_i << w_addr_i);            \
           wire [els_p-1:0] ra_one_hot = (r_v_i << r_addr_i);            \
@@ -26,7 +26,7 @@ module bsg_mem_1r1w
     , parameter `BSG_INV_PARAM(els_p)
     , parameter read_write_same_addr_p=0
     , parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
-		, parameter harden_p=1
+    , parameter harden_p=1
     , parameter debug_p=0
   )
    (input   w_clk_i

--- a/hard/tsmc_40/bsg_mem/bsg_mem_1r1w.sv
+++ b/hard/tsmc_40/bsg_mem/bsg_mem_1r1w.sv
@@ -156,7 +156,6 @@ module bsg_mem_1r1w
 		  #(.width_p(width_p)
 		    ,.els_p(els_p)
 		    ,.read_write_same_addr_p(read_write_same_addr_p)
-		    ,.harden_p(harden_p)
 		    ) synth
 		    (.*);
 	     end

--- a/hard/tsmc_40/bsg_mem/bsg_mem_1r1w_sync.sv
+++ b/hard/tsmc_40/bsg_mem/bsg_mem_1r1w_sync.sv
@@ -10,7 +10,7 @@
 // Register File Compiler Databook"
 //
 `define bsg_mem_1r1w_sync_macro_rf(words,bits,lgEls,newBits,mux) \
-if (els_p == words && width_p == bits)                          \
+if (harden_p && els_p == words && width_p == bits)                          \
   begin: macro                                                  \
           wire [newBits-1:0] tmp_lo,tmp_li;                     \
           assign r_data_o = tmp_lo[bits-1:0];                    \
@@ -39,6 +39,7 @@ module bsg_mem_1r1w_sync #(parameter `BSG_INV_PARAM(width_p)
                           , parameter addr_width_lp=$clog2(els_p)
                           // whether to substitute a 1r1w
                           , parameter read_write_same_addr_p= 0
+                          , parameter harden_p=1
                           , parameter substitute_1r1w_p=1)
    (input   clk_i
     , input reset_i

--- a/hard/tsmc_40/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit.sv
+++ b/hard/tsmc_40/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit.sv
@@ -11,7 +11,7 @@
 //
 
 `define bsg_mem_1r1w_sync_macro_rf(words,bits,lgEls,mux)        \
-if (els_p == words && width_p == bits)                          \
+if (harden_p && els_p == words && width_p == bits)                          \
   begin: macro                                                  \
           tsmc40_2rf_lg``lgEls``_w``bits``_m``mux``_bit mem    \
             (                                                   \

--- a/hard/tsmc_40/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit.sv
+++ b/hard/tsmc_40/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit.sv
@@ -59,7 +59,6 @@ module bsg_mem_1r1w_sync_mask_write_bit #(parameter `BSG_INV_PARAM(width_p)
      #(.width_p(width_p)
        ,.els_p (els_p  )
        ,.read_write_same_addr_p(read_write_same_addr_p)
-       ,.harden_p(harden_p)
        ) synth
        (.*);
 

--- a/hard/tsmc_40/bsg_mem/bsg_mem_1rw_sync.sv
+++ b/hard/tsmc_40/bsg_mem/bsg_mem_1rw_sync.sv
@@ -5,7 +5,7 @@
 //
 
 `define bsg_mem_1rw_sync_macro(words,bits,lgEls,mux) \
-if (els_p == words && width_p == bits)               \
+if (harden_p && els_p == words && width_p == bits)               \
   begin: macro                                       \
     tsmc40_1rw_lg``lgEls``_w``bits``_m``mux mem      \
       (.A     ( addr_i           )                   \
@@ -20,7 +20,7 @@ if (els_p == words && width_p == bits)               \
   end
 
 `define bsg_mem_1rf_sync_macro(words,bits,lgEls,mux) \
-if (els_p == words && width_p == bits)               \
+if (harden_p && els_p == words && width_p == bits)               \
   begin: macro                                       \
     tsmc40_1rf_lg``lgEls``_w``bits``_m``mux mem      \
       (.A     ( addr_i           )                   \
@@ -38,6 +38,7 @@ module bsg_mem_1rw_sync #(parameter `BSG_INV_PARAM(width_p)
                           , parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
                           //, parameter addr_width_lp=$clog2(els_p)
                           // whether to substitute a 1r1w
+                          , parameter harden_p=1
                           , parameter substitute_1r1w_p=1)
    (input   clk_i
     , input reset_i

--- a/hard/tsmc_40/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.sv
+++ b/hard/tsmc_40/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.sv
@@ -4,7 +4,7 @@
 // Only one read or one write may be done per cycle.
 
 `define bsg_mem_1rw_sync_macro_bit(words,bits,lgEls,mux) \
-if (els_p == words && width_p == bits)                   \
+if (harden_p && els_p == words && width_p == bits)                   \
   begin: macro                                           \
     tsmc40_1rw_lg``lgEls``_w``bits``_m``mux mem          \
       (.A     ( addr_i    )                              \
@@ -19,7 +19,7 @@ if (els_p == words && width_p == bits)                   \
   end
 
 `define bsg_mem_1rf_sync_macro_bit(words,bits,lgEls,mux) \
-if (els_p == words && width_p == bits)                   \
+if (harden_p && els_p == words && width_p == bits)                   \
   begin: macro                                           \
     tsmc40_1rf_lg``lgEls``_w``bits``_m``mux mem          \
       (.A     ( addr_i    )                              \
@@ -34,7 +34,8 @@ if (els_p == words && width_p == bits)                   \
 
 module bsg_mem_1rw_sync_mask_write_bit #(parameter `BSG_INV_PARAM(width_p)
 			               , parameter `BSG_INV_PARAM(els_p)
-			               , parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p))
+			               , parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
+                           , parameter harden_p=1)
    (input   clk_i
     , input reset_i
     , input [width_p-1:0] data_i

--- a/hard/tsmc_40/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
+++ b/hard/tsmc_40/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
@@ -5,7 +5,7 @@
 //
 
 `define bsg_mem_1rw_sync_macro_byte(words,bits,lgEls,mux) \
-if (els_p == words && data_width_p == bits)               \
+if (harden_p && els_p == words && data_width_p == bits)   \
   begin: macro                                            \
     wire [data_width_p-1:0] wen;                          \
     genvar i;                                             \
@@ -24,7 +24,7 @@ if (els_p == words && data_width_p == bits)               \
   end
 
 `define bsg_mem_1rf_sync_macro_byte(words,bits,lgEls,mux) \
-if (els_p == words && data_width_p == bits)               \
+if (harden_p && els_p == words && data_width_p == bits)               \
   begin: macro                                            \
     wire [data_width_p-1:0] wen;                          \
     genvar i;                                             \
@@ -79,6 +79,7 @@ module bsg_mem_1rw_sync_mask_write_byte
   ,parameter `BSG_INV_PARAM(data_width_p )
   ,parameter addr_width_lp = `BSG_SAFE_CLOG2(els_p)
   ,parameter write_mask_width_lp = data_width_p>>3
+  ,parameter harden_p=1
   )
 
   (input                           clk_i

--- a/hard/tsmc_40/bsg_mem/bsg_mem_2r1w.sv
+++ b/hard/tsmc_40/bsg_mem/bsg_mem_2r1w.sv
@@ -7,7 +7,7 @@
 
 
 `define bsg_mem_2r1w_macro(words,bits)                                  \
-     if (els_p == words && width_p == bits)                             \
+     if (harden_p && els_p == words && width_p == bits)                             \
        begin: macro                                                     \
           wire [els_p-1:0] wa_one_hot = (w_v_i << w_addr_i);            \
           wire [els_p-1:0] ra_one_hot0 = (r0_v_i << r0_addr_i);         \
@@ -27,6 +27,7 @@ module bsg_mem_2r1w #(parameter `BSG_INV_PARAM(width_p)
                       , parameter `BSG_INV_PARAM(els_p)
                       , parameter read_write_same_addr_p=0
                       , parameter addr_width_lp=$clog2(els_p)
+                      , parameter harden_p=1
                       )
    (input   w_clk_i
     , input w_reset_i

--- a/hard/tsmc_40/bsg_mem/bsg_mem_2r1w_sync.sv
+++ b/hard/tsmc_40/bsg_mem/bsg_mem_2r1w_sync.sv
@@ -9,7 +9,7 @@ module bsg_mem_2r1w_sync #(parameter `BSG_INV_PARAM(width_p)
                            , parameter `BSG_INV_PARAM(els_p)
                            , parameter read_write_same_addr_p=0
                            , parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
-                           , parameter harden_p=0
+                           , parameter harden_p=1
                            // add a parameter to switch between implementations of hard and soft macro
                            , parameter substitute_2r1w_p=0
                            )
@@ -121,7 +121,6 @@ module bsg_mem_2r1w_sync #(parameter `BSG_INV_PARAM(width_p)
 	  #(.width_p(width_p)
 	    ,.els_p(els_p)
 	    ,.read_write_same_addr_p(read_write_same_addr_p)
-	    ,.harden_p(harden_p)
 	    ) synth
 	    (.*);
      end

--- a/hard/tsmc_40/bsg_misc/bsg_buf.sv
+++ b/hard/tsmc_40/bsg_misc/bsg_buf.sv
@@ -10,7 +10,7 @@ if (harden_p && (width_p==bits) && ~vertical_p)               \
    end
 
 module bsg_buf #(parameter `BSG_INV_PARAM(width_p)
-                 , parameter harden_p=1
+                 , parameter harden_p=0
 		 , parameter vertical_p=1
                  )
    (input    [width_p-1:0] i

--- a/hard/tsmc_40/bsg_misc/bsg_clkbuf.sv
+++ b/hard/tsmc_40/bsg_misc/bsg_clkbuf.sv
@@ -6,7 +6,7 @@ if (harden_p && (width_p==bits) && (strength==strength_p))     \
 
 module bsg_clkbuf #(parameter width_p=1
 		 , parameter strength_p=8
-                 , parameter harden_p=1
+                 , parameter harden_p=0
                  )
    (input    [width_p-1:0] i
     , output [width_p-1:0] o

--- a/hard/tsmc_40/bsg_misc/bsg_dff.sv
+++ b/hard/tsmc_40/bsg_misc/bsg_dff.sv
@@ -4,7 +4,7 @@ if (harden_p && (width_p==bits) && (strength_p==strength)) \
      bsg_rp_tsmc_40_dff_s``strength``_b``bits dff(.*);   \
   end
 
-module bsg_dff #(width_p=-1, harden_p=1, strength_p=1)
+module bsg_dff #(width_p=-1, harden_p=0, strength_p=1)
    (input   clk_i
     ,input  [width_p-1:0] data_i
     ,output [width_p-1:0] data_o

--- a/hard/tsmc_40/bsg_misc/bsg_dff_en.sv
+++ b/hard/tsmc_40/bsg_misc/bsg_dff_en.sv
@@ -10,7 +10,7 @@ if (harden_p && width_p==bits && (strength_p==womp))                         \
 
 
 module bsg_dff_en #(width_p="inv"
-                    , harden_p=1
+                    , harden_p=0
                     , strength_p=1
                     )
    (input   clk_i

--- a/hard/tsmc_40/bsg_misc/bsg_dff_reset.sv
+++ b/hard/tsmc_40/bsg_misc/bsg_dff_reset.sv
@@ -7,7 +7,7 @@ if (harden_p && width_p==bits)                                          \
                                                ,.data_o);               \
   end
 
-module bsg_dff_reset #(width_p=-1, harden_p=1)
+module bsg_dff_reset #(width_p=-1, harden_p=0)
    (input   clk_i
     ,input  reset_i
     ,input  [width_p-1:0] data_i

--- a/hard/tsmc_40/bsg_misc/bsg_dff_reset_en.sv
+++ b/hard/tsmc_40/bsg_misc/bsg_dff_reset_en.sv
@@ -10,7 +10,7 @@ if (harden_p && width_p==bits)                                          \
                                                ,.data_o);               \
   end
 
-module bsg_dff_reset_en #(width_p=-1, harden_p=1)
+module bsg_dff_reset_en #(width_p=-1, harden_p=0)
    (input   clk_i
     ,input  reset_i    
     ,input  [width_p-1:0] data_i

--- a/hard/tsmc_40/bsg_misc/bsg_gate_stack_gen.py
+++ b/hard/tsmc_40/bsg_misc/bsg_gate_stack_gen.py
@@ -148,7 +148,7 @@ elif len(sys.argv) == 5 :
     input_params = ["input [width_p-1:0] i"+str(x) for x in range(0,num_inputs)]
     print '''
 
-module bsg_'''+sys.argv[4],'''#(width_p="inv",harden_p=1)
+module bsg_'''+sys.argv[4],'''#(width_p="inv",harden_p=0)
    ('''+"\n    ,".join(input_params)+'''
     , output [width_p-1:0] o
     );

--- a/hard/tsmc_40/bsg_misc/bsg_inv.sv
+++ b/hard/tsmc_40/bsg_misc/bsg_inv.sv
@@ -10,7 +10,7 @@ if (harden_p && (width_p==bits) && ~vertical_p)                   \
   end
 
 module bsg_inv #(parameter `BSG_INV_PARAM(width_p)
-                 , parameter harden_p=1
+                 , parameter harden_p=0
 		 , parameter vertical_p=1
                  )
    (input    [width_p-1:0] i

--- a/hard/tsmc_40/bsg_misc/bsg_mux.sv
+++ b/hard/tsmc_40/bsg_misc/bsg_mux.sv
@@ -31,7 +31,7 @@ end
 
 module bsg_mux #(parameter `BSG_INV_PARAM(width_p)
                  , els_p=1
-                 , harden_p=1
+                 , harden_p=0
                  , balanced_p=0
                  , lg_els_lp=`BSG_SAFE_CLOG2(els_p)
                  )

--- a/hard/tsmc_40/bsg_misc/bsg_mux_one_hot.sv
+++ b/hard/tsmc_40/bsg_misc/bsg_mux_one_hot.sv
@@ -8,7 +8,7 @@ end
 
 module bsg_mux_one_hot #(parameter `BSG_INV_PARAM(width_p)
                          , els_p=1
-			 , harden_p=1
+			 , harden_p=0
                          )
    (
     input [els_p-1:0][width_p-1:0] data_i

--- a/hard/tsmc_40/bsg_misc/bsg_tiehi.sv
+++ b/hard/tsmc_40/bsg_misc/bsg_tiehi.sv
@@ -5,7 +5,7 @@ if (harden_p && (width_p==bits))                    \
   end
 
 module bsg_tiehi #(parameter `BSG_INV_PARAM(width_p)
-                 , parameter harden_p=1
+                 , parameter harden_p=0
                  )
    (output [width_p-1:0] o
     );

--- a/hard/tsmc_40/bsg_misc/bsg_tielo.sv
+++ b/hard/tsmc_40/bsg_misc/bsg_tielo.sv
@@ -5,7 +5,7 @@ if (harden_p && (width_p==bits))                    \
   end
 
 module bsg_tielo #(parameter `BSG_INV_PARAM(width_p)
-                 , parameter harden_p=1
+                 , parameter harden_p=0
                  )
    (output [width_p-1:0] o
     );

--- a/hard/ultrascale_plus/bsg_mem/bsg_mem_1r1w_sync_mask_write_byte.sv
+++ b/hard/ultrascale_plus/bsg_mem/bsg_mem_1r1w_sync_mask_write_byte.sv
@@ -48,7 +48,7 @@ module bsg_mem_1r1w_sync_mask_write_byte #(parameter `BSG_INV_PARAM(width_p)
                                          , parameter read_write_same_addr_p=0
                                          , parameter latch_last_read_p=0 
                                          , parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
-                                         , parameter harden_p=0
+                                         , parameter harden_p=1
                                          , parameter disable_collision_warning_p=0
                                          , parameter write_mask_width_lp = width_p>>3
                                          , parameter enable_clock_gating_p=0

--- a/hard/ultrascale_plus/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.sv
+++ b/hard/ultrascale_plus/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.sv
@@ -18,7 +18,8 @@
 module bsg_mem_1rw_sync_mask_write_bit_distributed #(
   parameter `BSG_INV_PARAM(width_p )
   , parameter `BSG_INV_PARAM(els_p )
-  , parameter latch_last_read_p=0
+  , parameter latch_last_read_p=1
+  , parameter harden_p=1
   , parameter enable_clock_gating_p=0
   , localparam addr_width_lp = `BSG_SAFE_CLOG2(els_p)
 ) (


### PR DESCRIPTION
Standardizing the harden_p scheme for memories. 

This means 
1) removing harden_p from _synth memories 
2) Adding harden_p to all other mems 
3) In hardened directories default harden_p = 1
4) In non-hardened directories default harden_p = 0