### PR TITLE
[bsg_cache] fix track_mem_data_r X when word_tracking_p = 0

### DIFF
--- a/bsg_cache/bsg_cache_dma.v
+++ b/bsg_cache/bsg_cache_dma.v
@@ -303,7 +303,11 @@ module bsg_cache_dma
             // so the counter is incremented to 1.
             counter_clear = 1'b1;
             counter_up = 1'b1;
-            data_mem_v_o = (|track_bits_offset_picked);
+            // When word_tracking_p is off, track_data_we_i is always zero, which means track_mem_data_r will always be 'X;
+            // So if word_tracking_p is off, we tie this to constant 1.
+            data_mem_v_o = word_tracking_p 
+              ?(|track_bits_offset_picked)
+              : 1'b1;
             dma_state_n = SEND_EVICT_DATA;
           end
 
@@ -348,7 +352,10 @@ module bsg_cache_dma
 
         // we only need to read words that have valid data
         // for invalid words we just send the previously read word from data_mem
-        data_mem_v_o = out_fifo_ready_lo & ~counter_evict_max & (|track_bits_offset_picked);
+        data_mem_v_o = out_fifo_ready_lo & ~counter_evict_max 
+                      & (word_tracking_p 
+                        ? (|track_bits_offset_picked)
+                        : 1'b1);
 
         done_o = counter_evict_max & out_fifo_ready_lo;
 

--- a/testing/bsg_cache/regression_v2/Makefile
+++ b/testing/bsg_cache/regression_v2/Makefile
@@ -26,7 +26,6 @@ BASIC_TEST += test_aflinv1
 
 HIGHLIGHT = grep --color -E '^|Fatal|Error|Warning|Implicit wire is used|Too few instance port connections|Port connection width mismatch|Width mismatch'
 
-
 ### TEST parameters ####
 YUMI_MIN_DELAY_P  ?= 0
 YUMI_MAX_DELAY_P  ?= 0
@@ -34,6 +33,8 @@ DMA_READ_DELAY_P  ?= 0
 DMA_WRITE_DELAY_P ?= 0
 DMA_REQ_DELAY_P   ?= 0
 DMA_DATA_DELAY_P  ?= 0
+WORD_TRACKING_P   ?= 1
+
 
 VCS_DEFINES += +define+YUMI_MIN_DELAY_P=$(YUMI_MIN_DELAY_P)
 VCS_DEFINES += +define+YUMI_MAX_DELAY_P=$(YUMI_MAX_DELAY_P)
@@ -42,6 +43,7 @@ VCS_DEFINES += +define+DMA_READ_DELAY_P=$(DMA_READ_DELAY_P)
 VCS_DEFINES += +define+DMA_WRITE_DELAY_P=$(DMA_WRITE_DELAY_P)
 VCS_DEFINES += +define+DMA_REQ_DELAY_P=$(DMA_REQ_DELAY_P)
 VCS_DEFINES += +define+DMA_DATA_DELAY_P=$(DMA_DATA_DELAY_P)
+VCS_DEFINES += +define+WORD_TRACKING_P=$(WORD_TRACKING_P)
 ########################
 
 

--- a/testing/bsg_cache/regression_v2/Makefile
+++ b/testing/bsg_cache/regression_v2/Makefile
@@ -6,6 +6,7 @@ INCDIR += +incdir+$(BASEJUMP_STL_DIR)/bsg_cache
 
 VCS_FLAGS =  -full64 +lint=all,noSVA-UA,noSVA-NSVU,noVCDE -debug_access
 VCS_FLAGS += +v2k -sverilog -timescale=1ps/1ps -O4 -assert svaext
+VCS_FLAGS +=  -reportstats
 
 
 ##### Test Suite #######
@@ -68,7 +69,7 @@ out/%/trace.tr:
 	python $*.py > $@
 
 %.basic.run: simv out/%/trace.tr
-	(cd out/$*; $(SIMV) +wave=$(WAVE) +checker=basic -l simv.log)
+	(cd out/$*; $(SIMV) -reportstats +vcs+nostdout +wave=$(WAVE) +checker=basic -l simv.log)
 
 %.dve:
 	$(DVE) -full64 -vpd out/$*/vcdplus.vpd &

--- a/testing/bsg_cache/regression_v2/Makefile
+++ b/testing/bsg_cache/regression_v2/Makefile
@@ -21,6 +21,7 @@ BASIC_TEST += test_store_load test_store_load2
 BASIC_TEST += test_alock1
 BASIC_TEST += test_tagfl1
 BASIC_TEST += test_aflinv1
+BASIC_TEST += test_store_random1
 
 
 ########################

--- a/testing/bsg_cache/regression_v2/test_store_random1.py
+++ b/testing/bsg_cache/regression_v2/test_store_random1.py
@@ -1,0 +1,27 @@
+import sys
+import random
+from test_base import *
+
+class TestStoreRandom1(TestBase):
+  
+  def generate(self):
+    self.clear_tag()
+  
+    for n in range(100):
+      tag = random.randint(0,15)
+      index = 0
+      block_offset = 0
+      byte_offset = 0
+      taddr = self.get_addr(tag,index,block_offset,byte_offset)
+      self.send_sw(taddr)
+      self.tg.wait(100)
+        
+
+    self.tg.done()
+
+
+# main()
+if __name__ == "__main__":
+  t = TestStoreRandom1()
+  t.generate()
+    

--- a/testing/bsg_cache/regression_v2/testbench.v
+++ b/testing/bsg_cache/regression_v2/testbench.v
@@ -227,4 +227,13 @@ module testbench();
     $finish;
   end
 
+  // check for X in handshaking signals
+  always @ (negedge clk) begin
+    if (reset !== 1'b1) begin
+      assert (ready_lo !== 1'bx) else $fatal(1, "[BSG_FATAL]  ready_o == x");
+      assert (v_lo !== 1'bx) else $fatal(1, "[BSG_FATAL]  v_o == x");
+    end
+  end
+
+
 endmodule

--- a/testing/bsg_cache/regression_v2/testbench.v
+++ b/testing/bsg_cache/regression_v2/testbench.v
@@ -30,7 +30,7 @@ module testbench();
   localparam sets_p = 128;
   localparam ways_p = 8;
   localparam mem_size_p = block_size_in_words_p*sets_p*ways_p*4;
-  localparam word_tracking_p = 1;
+  localparam word_tracking_p = `WORD_TRACKING_P;
 
   integer status;
   integer wave;


### PR DESCRIPTION
- basically, when word_tracking_p = 0, track_data_we_i will always be zero in bsg_cache_dma. This means that track_mem_data_r will always be 'X.  Then data_mem_v_o will also become X, and so will tl_ready at the top.
- added word_tracking_p switch to regression_v2
- Added asserting to check if ready_o or v_o ever goes X in testbench, because the testbench didn't fail even when there was x.