### PR TITLE
Adding Verilator Timing Check to bsg_nonsynth_clock_gen

### DIFF
--- a/bsg_misc/bsg_defines.v
+++ b/bsg_misc/bsg_defines.v
@@ -124,4 +124,67 @@
 `define rpgroup(x)
 `endif
 
+// verilog preprocessing -> if defined(A) && defined(B) then define C
+`define BSG_DEFIF_A_AND_B(A,B,C) \
+    `undef C \
+    `ifdef A \
+        `ifdef B \
+            `define C \
+        `endif \
+    `endif
+
+// verilog preprocessing -> if defined(A) && !defined(B) then define C
+`define BSG_DEFIF_A_AND_NOT_B(A,B,C) \
+    `undef C \
+    `ifdef A \
+        `ifndef B \
+            `define C \
+        `endif \
+    `endif
+
+// verilog preprocessing -> if !defined(A) && defined(B) then define C
+`define BSG_DEFIF_NOT_A_AND_B(A,B,C) `BSG_DEFIF_A_AND_NOT_B(B,A,C)
+
+// verilog preprocessing -> if !defined(A) && !defined(B) then define C
+`define BSG_DEFIF_NOT_A_AND_NOT_B(A,B,C) \
+    `undef C \
+    `ifndef A \
+        `ifndef B \
+            `define C \
+        `endif \
+    `endif
+
+// verilog preprocessing -> if defined(A) || defined(B) then define C
+`define BSG_DEFIF_A_OR_B(A,B,C) \
+    `undef C \
+    `ifdef A \
+        `define C \
+    `endif \
+    `ifdef B \
+        `define C \
+    `endif
+
+// verilog preprocessing -> if defined(A) || !defined(B) then define C
+`define BSG_DEFIF_A_OR_NOT_B(A,B,C) \
+    `undef C \
+    `ifdef A \
+        `define C \
+    `endif \
+    `ifndef B \
+        `define C \
+    `endif
+
+// verilog preprocessing -> if !defined(A) || defined(B) then define C
+`define BSG_DEFIF_NOT_A_OR_B(A,B,C) `BSG_DEFIF_A_OR_NOT_B(B,A,C)
+
+// verilog preprocessing -> if !defined(A) || !defined(B) then define C
+`define BSG_DEFIF_NOT_A_OR_NOT_B(A,B,C) \
+    `undef C \
+    `ifndef A \
+        `define C \
+    `endif \
+    `ifndef B \
+        `define C \
+    `endif
+
 `endif

--- a/bsg_test/bsg_nonsynth_clock_gen.v
+++ b/bsg_test/bsg_nonsynth_clock_gen.v
@@ -6,11 +6,13 @@
  `timescale 1ps/1ps
 `endif
 
+`BSG_DEFIF_NOT_A_OR_B(VERILATOR, VERILATOR_TIMING, USE_DELAY_CLOCK_GEN)
+
 module bsg_nonsynth_clock_gen
   #(parameter `BSG_INV_PARAM(cycle_time_p))
    (output bit o);
 
-`ifndef VERILATOR
+`ifdef USE_DELAY_CLOCK_GEN
   initial begin
     $display("%m with cycle_time_p ",cycle_time_p);
     assert(cycle_time_p >= 2)


### PR DESCRIPTION
This also includes some help macros to bsg_defines.v to do some logical and and logical or operations to defined macros.