### PR TITLE
(Basejump STL 2.0) Updates bsg_dataflow style and testing infrastructure

### DIFF
--- a/bsg_cache/bsg_cache_to_axi_tx.v
+++ b/bsg_cache/bsg_cache_to_axi_tx.v
@@ -123,7 +123,7 @@ module bsg_cache_to_axi_tx
   // axi write data channel
   //
   logic sipo_v_li;
-  logic sipo_ready_lo;
+  logic sipo_ready_and_lo;
   logic [data_width_p-1:0] sipo_data_li;
   logic [strb_width_lp-1:0] sipo_strb_li;
   logic [$clog2(data_width_ratio_lp+1)-1:0] sipo_yumi_cnt_li;
@@ -148,7 +148,7 @@ module bsg_cache_to_axi_tx
   );
 
   assign sipo_data_li = dma_data_i[tag_lo];
-  assign dma_data_yumi_o = cache_sel & dma_data_v_i & {num_cache_p{sipo_ready_lo}};
+  assign dma_data_yumi_o = cache_sel & dma_data_v_i & {num_cache_p{sipo_ready_and_lo}};
  
   bsg_serial_in_parallel_out #(
     .width_p(data_width_p+strb_width_lp)
@@ -159,7 +159,7 @@ module bsg_cache_to_axi_tx
 
     ,.valid_i(sipo_v_li)
     ,.data_i({sipo_strb_li, sipo_data_li})
-    ,.ready_o(sipo_ready_lo)
+    ,.ready_and_o(sipo_ready_and_lo)
 
     ,.valid_o(sipo_v_lo)
     ,.data_o({axi_wstrb_o, axi_wdata_o})

--- a/bsg_cache/bsg_cache_to_dram_ctrl_rx.v
+++ b/bsg_cache/bsg_cache_to_dram_ctrl_rx.v
@@ -54,7 +54,7 @@ module bsg_cache_to_dram_ctrl_rx
 
     ,.v_i(app_rd_data_valid_i)
     ,.data_i(app_rd_data_i)
-    ,.ready_o()
+    ,.ready_and_o()
 
     ,.v_o(fifo_v_lo)
     ,.data_o(fifo_data_lo)

--- a/bsg_dataflow/bsg_1_to_n_tagged.v
+++ b/bsg_dataflow/bsg_1_to_n_tagged.v
@@ -28,7 +28,7 @@ module bsg_1_to_n_tagged #(
     , output                   yumi_o
 
     , output [num_out_p-1:0]   v_o
-    , input  [num_out_p-1:0]   ready_i
+    , input  [num_out_p-1:0]   ready_and_i
 
     // to downstream
     );
@@ -39,7 +39,7 @@ module bsg_1_to_n_tagged #(
    if (num_out_p == 1)
      begin : one
         assign v_o = v_i;
-        assign yumi_o  = ready_i & v_i;
+        assign yumi_o  = ready_and_i & v_i;
      end
    else
      begin: many
@@ -52,7 +52,7 @@ module bsg_1_to_n_tagged #(
            ,.o(v_o)
            );
 
-        assign yumi_o = ready_i[tag_i] & v_i;
+        assign yumi_o = ready_and_i[tag_i] & v_i;
      end
 
 endmodule // bsg_1_to_n_tagged

--- a/bsg_dataflow/bsg_1_to_n_tagged_fifo.v
+++ b/bsg_dataflow/bsg_1_to_n_tagged_fifo.v
@@ -36,7 +36,7 @@ module bsg_1_to_n_tagged_fifo   #(parameter `BSG_INV_PARAM(width_p)
     );
 
    wire [num_out_p-1:0]               valid_lo;
-   wire [num_out_p-1:0]               ready_li;
+   wire [num_out_p-1:0]               ready_and_li;
 
    bsg_1_to_n_tagged #(.num_out_p   (num_out_p   )
                        ) _1_to_n
@@ -48,7 +48,7 @@ module bsg_1_to_n_tagged_fifo   #(parameter `BSG_INV_PARAM(width_p)
       ,.yumi_o
 
       ,.v_o(valid_lo)
-      ,.ready_i(ready_li)
+      ,.ready_and_i(ready_and_li)
       );
 
    genvar i;
@@ -57,9 +57,9 @@ module bsg_1_to_n_tagged_fifo   #(parameter `BSG_INV_PARAM(width_p)
      begin: rof
         if (unbuffered_mask_p[i])
           begin: unbuf
-             assign v_o     [i] = valid_lo[i];
-             assign data_o  [i] = data_i;
-             assign ready_li[i] = 1'b1;
+             assign v_o         [i] = valid_lo[i];
+             assign data_o      [i] = data_i;
+             assign ready_and_li[i] = 1'b1;
           end
         else if (use_pseudo_large_fifo_p)
           begin : psdlrg
@@ -69,13 +69,13 @@ module bsg_1_to_n_tagged_fifo   #(parameter `BSG_INV_PARAM(width_p)
                (.clk_i
                 ,.reset_i
 
-                ,.v_i    (valid_lo[i])
+                ,.v_i        (valid_lo    [i])
                 ,.data_i
-                ,.ready_o(ready_li[i])
+                ,.ready_and_o(ready_and_li[i])
 
-                ,.v_o   (v_o   [i])
-                ,.data_o(data_o[i])
-                ,.yumi_i(yumi_i[i])
+                ,.v_o        (v_o         [i])
+                ,.data_o     (data_o      [i])
+                ,.yumi_i     (yumi_i      [i])
                 );
           end
         else
@@ -87,13 +87,13 @@ module bsg_1_to_n_tagged_fifo   #(parameter `BSG_INV_PARAM(width_p)
                (.clk_i
                 ,.reset_i
 
-                ,.v_i      (valid_lo[i])
-                ,.data_i   (data_i     )
-                ,.ready_o  (ready_li[i])
+                ,.v_i      (valid_lo    [i])
+                ,.data_i   (data_i         )
+                ,.ready_o  (ready_and_li[i])
 
-                ,.v_o      (v_o   [i])
-                ,.data_o   (data_o[i])
-                ,.yumi_i   (yumi_i[i])
+                ,.v_o      (v_o         [i])
+                ,.data_o   (data_o      [i])
+                ,.yumi_i   (yumi_i      [i])
                 );
           end // block: fi
      end

--- a/bsg_dataflow/bsg_1_to_n_tagged_fifo_shared.v
+++ b/bsg_dataflow/bsg_1_to_n_tagged_fifo_shared.v
@@ -86,7 +86,7 @@ module bsg_1_to_n_tagged_fifo_shared   #(parameter `BSG_INV_PARAM(width_p       
       ,.yumi_o
 
       ,.valid_o(tag_one_hot_or_not)
-      ,.ready_i(~full)
+      ,.ready_and_i(~full)
       );
 
    assign enque = (~full)

--- a/bsg_dataflow/bsg_channel_tunnel_wormhole.v
+++ b/bsg_dataflow/bsg_channel_tunnel_wormhole.v
@@ -115,7 +115,7 @@ module  bsg_channel_tunnel_wormhole
   // incoming multiplexed data
   ,input  [width_p-1:0] multi_data_i
   ,input                multi_v_i
-  ,output               multi_ready_o
+  ,output               multi_ready_and_o
 
   // outgoing multiplexed data
   ,output [width_p-1:0] multi_data_o
@@ -439,7 +439,7 @@ module  bsg_channel_tunnel_wormhole
   
 /*************************** Channel Tunnel Input ****************************/
   
-  logic [mux_num_in_lp-1:0] ififo_valid_li, ififo_ready_lo; 
+  logic [mux_num_in_lp-1:0] ififo_valid_li, ififo_ready_and_lo; 
   
   // Channel Tunnel Multiplexed Input Demux
   
@@ -464,8 +464,8 @@ module  bsg_channel_tunnel_wormhole
   
   // Update counter only when packet flit accepted to fifo
   // and upcoming packet is not for credit returning
-  assign istate_down_lo     = multi_v_i & multi_ready_o & ~istate_r_is_min_lo;
-  assign istate_set_lo      = multi_v_i & multi_ready_o & istate_r_is_min_lo 
+  assign istate_down_lo     = multi_v_i & multi_ready_and_o & ~istate_r_is_min_lo;
+  assign istate_set_lo      = multi_v_i & multi_ready_and_o & istate_r_is_min_lo 
                              & ~multi_data_i_is_credit;
   assign istate_r_is_min_lo = (istate_r == counter_min_value_lp);
   
@@ -507,9 +507,9 @@ module  bsg_channel_tunnel_wormhole
  #(.width_p(1)
   ,.els_p(mux_num_in_lp)
   ) in_ready_mux
-  (.data_i(ififo_ready_lo)
+  (.data_i(ififo_ready_and_lo)
   ,.sel_i (imux_sel_lo)
-  ,.data_o(multi_ready_o)
+  ,.data_o(multi_ready_and_o)
   );
   
   // valid selection
@@ -530,7 +530,7 @@ module  bsg_channel_tunnel_wormhole
   (.clk_i  (clk_i)
   ,.reset_i(reset_i)
 
-  ,.ready_o(ififo_ready_lo[num_in_p])
+  ,.ready_o(ififo_ready_and_lo[num_in_p])
   ,.data_i (multi_data_i)
   ,.v_i    (ififo_valid_li[num_in_p])
 
@@ -558,36 +558,36 @@ module  bsg_channel_tunnel_wormhole
       begin: use_large
         bsg_fifo_1r1w_large 
        #(.width_p(width_p)
-        ,.els_p(remote_credits_p*max_payload_flits_p)
+        ,.els_p  (remote_credits_p*max_payload_flits_p)
         ) ififo
-        (.clk_i  (clk_i)
-        ,.reset_i(reset_i)
+        (.clk_i      (clk_i)
+        ,.reset_i    (reset_i)
 
-        ,.ready_o(ififo_ready_lo[i])
-        ,.data_i (multi_data_i)
-        ,.v_i    (ififo_valid_li[i])
+        ,.ready_and_o(ififo_ready_and_lo[i])
+        ,.data_i     (multi_data_i)
+        ,.v_i        (ififo_valid_li[i])
 
-        ,.v_o    (ififo_valid_lo)
-        ,.data_o (ififo_data_lo)
-        ,.yumi_i (ififo_yumi_li)
+        ,.v_o        (ififo_valid_lo)
+        ,.data_o     (ififo_data_lo)
+        ,.yumi_i     (ififo_yumi_li)
         );
       end
     else
       begin: pseudo_large
         bsg_fifo_1r1w_pseudo_large 
-       #(.width_p(width_p)
-        ,.els_p(remote_credits_p*max_payload_flits_p)
+       #(.width_p (width_p)
+        ,.els_p   (remote_credits_p*max_payload_flits_p)
         ) ififo
-        (.clk_i  (clk_i)
-        ,.reset_i(reset_i)
+        (.clk_i      (clk_i)
+        ,.reset_i    (reset_i)
 
-        ,.ready_o(ififo_ready_lo[i])
-        ,.data_i (multi_data_i)
-        ,.v_i    (ififo_valid_li[i])
+        ,.ready_and_o(ififo_ready_and_lo[i])
+        ,.data_i     (multi_data_i)
+        ,.v_i        (ififo_valid_li[i])
 
-        ,.v_o    (ififo_valid_lo)
-        ,.data_o (ififo_data_lo)
-        ,.yumi_i (ififo_yumi_li)
+        ,.v_o        (ififo_valid_lo)
+        ,.data_o     (ififo_data_lo)
+        ,.yumi_i     (ififo_yumi_li)
         );
       end
     

--- a/bsg_dataflow/bsg_fifo_1r1w_large.v
+++ b/bsg_dataflow/bsg_fifo_1r1w_large.v
@@ -118,7 +118,7 @@ module bsg_fifo_1r1w_large #(parameter `BSG_INV_PARAM(width_p)
 
     , input [width_p-1:0]  data_i
     , input                v_i
-    , output               ready_o
+    , output               ready_and_o
 
     , output               v_o
     , output [width_p-1:0] data_o
@@ -152,13 +152,13 @@ module bsg_fifo_1r1w_large #(parameter `BSG_INV_PARAM(width_p)
                                 ,.els_p(3)
                                 ,.out_els_p(2)
                                 ) sipo
-   (.clk_i      (clk_i)
-    ,.reset_i   (reset_i)
-    ,.valid_i   (v_i)
-    ,.data_i    (data_i)
-    ,.ready_o   (ready_o)
-    ,.valid_o   (valid_sipo)
-    ,.data_o    (data_sipo)
+   (.clk_i        (clk_i)
+    ,.reset_i     (reset_i)
+    ,.valid_i     (v_i)
+    ,.data_i      (data_i)
+    ,.ready_and_o (ready_and_o)
+    ,.valid_o     (valid_sipo)
+    ,.data_o      (data_sipo)
 
     ,.yumi_cnt_i(yumi_cnt_sipo)
     );

--- a/bsg_dataflow/bsg_fifo_1r1w_large_banked.v
+++ b/bsg_dataflow/bsg_fifo_1r1w_large_banked.v
@@ -72,7 +72,7 @@ module bsg_fifo_1r1w_large_banked #(parameter `BSG_INV_PARAM(width_p         )
     , input                reset_i
     , input [width_p-1:0]  data_i
     , input                v_i
-    , output               ready_o
+    , output               ready_and_o
 
     , output               v_o
     , output [width_p-1:0] data_o
@@ -84,7 +84,7 @@ module bsg_fifo_1r1w_large_banked #(parameter `BSG_INV_PARAM(width_p         )
 
    genvar i;
 
-   wire [1:0]               v_i_demux, ready_o_mux;
+   wire [1:0]               v_i_demux, ready_and_o_mux;
 
    bsg_round_robin_1_to_n #(.width_p(width_p)
                             ,.num_out_p(2)
@@ -93,10 +93,10 @@ module bsg_fifo_1r1w_large_banked #(parameter `BSG_INV_PARAM(width_p         )
     ,.reset_i(reset_i    )
 
     ,.valid_i(v_i        )
-    ,.ready_o(ready_o    )
+    ,.ready_and_o(ready_and_o)
 
     ,.valid_o(v_i_demux  )
-    ,.ready_i(ready_o_mux)
+    ,.ready_and_i(ready_and_o_mux)
     );
 
    wire [1:0]               v_int, yumi_int;
@@ -122,13 +122,13 @@ module bsg_fifo_1r1w_large_banked #(parameter `BSG_INV_PARAM(width_p         )
             (.clk_i   (clk_i)
              ,.reset_i(reset_i)
 
-             ,.v_i(v_i_demux  [i])
-             ,.data_i (data_i        )
-             ,.ready_o(ready_o_mux[i])
+             ,.v_i        (v_i_demux[i]      )
+             ,.data_i     (data_i            )
+             ,.ready_and_o(ready_and_o_mux[i])
 
-             ,.v_o    (v_int   [i])
-             ,.data_o (data_int[i])
-             ,.yumi_i (yumi_int[i])
+             ,.v_o        (v_int    [i]      )
+             ,.data_o     (data_int [i]      )
+             ,.yumi_i     (yumi_int [i]      )
              );
      end
 

--- a/bsg_dataflow/bsg_fifo_1r1w_pseudo_large.v
+++ b/bsg_dataflow/bsg_fifo_1r1w_pseudo_large.v
@@ -122,7 +122,7 @@ module bsg_fifo_1r1w_pseudo_large #(parameter `BSG_INV_PARAM(width_p )
 
     , input [width_p-1:0] data_i
     , input v_i
-    , output ready_o
+    , output ready_and_o
 
     , output v_o
     , output [width_p-1:0] data_o
@@ -152,8 +152,8 @@ module bsg_fifo_1r1w_pseudo_large #(parameter `BSG_INV_PARAM(width_p )
        big_deq_r <= big_deq;
 
    // if the big fifo is not full, then we can take more data
-   wire ready_o_int = ~big_full_lo;
-   assign ready_o   = ready_o_int;
+   wire ready_and_o_int = ~big_full_lo;
+   assign ready_and_o   = ready_and_o_int;
 
    // ***** DEBUG ******
    // for debugging; whether we are bypassing the big fifo

--- a/bsg_dataflow/bsg_one_fifo.v
+++ b/bsg_dataflow/bsg_one_fifo.v
@@ -22,19 +22,19 @@ module bsg_one_fifo #(parameter `BSG_INV_PARAM(width_p)
     , input reset_i
 
     // input side
-    , output              ready_o // early
-    , input [width_p-1:0] data_i  // late
-    , input               v_i     // late
+    , output              ready_and_o // early
+    , input [width_p-1:0] data_i      // late
+    , input               v_i         // late
 
     // output side
-    , output              v_o     // early
-    , output[width_p-1:0] data_o  // early
-    , input               yumi_i  // late
+    , output              v_o         // early
+    , output[width_p-1:0] data_o      // early
+    , input               yumi_i      // late
     );
   
   logic             full_r;
   
-  assign ready_o = ~full_r;
+  assign ready_and_o = ~full_r;
   assign v_o     =  full_r;
   
   bsg_dff_reset #(.width_p(1)) dff_full
@@ -49,7 +49,7 @@ module bsg_one_fifo #(parameter `BSG_INV_PARAM(width_p)
    ,.data_i
    // although technically it is okay to just look at v_o
    // this will cause unnecessary toggling of flip flops
-   ,.en_i(v_i & ready_o)
+   ,.en_i(v_i & ready_and_o)
    ,.data_o
   );
 

--- a/bsg_dataflow/bsg_parallel_in_serial_out.v
+++ b/bsg_dataflow/bsg_parallel_in_serial_out.v
@@ -61,7 +61,7 @@ module bsg_parallel_in_serial_out
      * By default a two-element fifo is used to eleminate bubbling.
      * One-element fifo is optional for minimal resource utilization.
      */
-    logic fifo0_ready_lo, fifo_v_li;
+    logic fifo0_ready_and_lo, fifo_v_li;
     logic fifo_v_lo, fifo0_yumi_li;
     logic [els_p-1:0][width_p-1:0] fifo_data_lo;
 
@@ -72,7 +72,7 @@ module bsg_parallel_in_serial_out
         ) fifo0
         (.clk_i  (clk_i)
         ,.reset_i(reset_i)
-        ,.ready_o(fifo0_ready_lo)
+        ,.ready_o(fifo0_ready_and_lo)
         ,.data_i (data_li[els_p-1])
         ,.v_i    (fifo_v_li)
         ,.v_o    (fifo_v_lo)
@@ -85,14 +85,14 @@ module bsg_parallel_in_serial_out
         bsg_one_fifo
        #(.width_p(width_p)
         ) fifo0
-        (.clk_i  (clk_i)
-        ,.reset_i(reset_i)
-        ,.ready_o(fifo0_ready_lo)
-        ,.data_i (data_li[els_p-1])
-        ,.v_i    (fifo_v_li)
-        ,.v_o    (fifo_v_lo)
-        ,.data_o (fifo_data_lo[els_p-1])
-        ,.yumi_i (fifo0_yumi_li)
+        (.clk_i      (clk_i)
+        ,.reset_i    (reset_i)
+        ,.ready_and_o(fifo0_ready_and_lo)
+        ,.data_i     (data_li[els_p-1])
+        ,.v_i        (fifo_v_li)
+        ,.v_o        (fifo_v_lo)
+        ,.data_o     (fifo_data_lo[els_p-1])
+        ,.yumi_i     (fifo0_yumi_li)
         );
       end
 
@@ -103,7 +103,7 @@ module bsg_parallel_in_serial_out
     // Connect fifo0 signals directly to input/output ports
 
     assign fifo_v_li     = valid_i;
-    assign ready_and_o   = fifo0_ready_lo;
+    assign ready_and_o   = fifo0_ready_and_lo;
 
     assign valid_o       = fifo_v_lo;
     assign data_o        = fifo_data_lo;
@@ -122,25 +122,25 @@ module bsg_parallel_in_serial_out
      * valid and shift_ctr_r != (els_p-1).
      * Therefore v_o signal of fifo1 is unused to minimize hardware utilization.
      */
-    logic fifo1_ready_lo, fifo1_yumi_li;
+    logic fifo1_ready_and_lo, fifo1_yumi_li;
 
     bsg_one_fifo
    #(.width_p((els_p-1)*width_p)
     ) fifo1
-    (.clk_i  (clk_i)
-    ,.reset_i(reset_i)
-    ,.ready_o(fifo1_ready_lo)
-    ,.data_i (data_li[els_p-2:0])
-    ,.v_i    (fifo_v_li)
-    ,.v_o    ()
-    ,.data_o (fifo_data_lo[els_p-2:0])
-    ,.yumi_i (fifo1_yumi_li)
+    (.clk_i      (clk_i)
+    ,.reset_i    (reset_i)
+    ,.ready_and_o(fifo1_ready_and_lo)
+    ,.data_i     (data_li[els_p-2:0])
+    ,.v_i        (fifo_v_li)
+    ,.v_o        ()
+    ,.data_o     (fifo_data_lo[els_p-2:0])
+    ,.yumi_i     (fifo1_yumi_li)
     );
 
     /**
      * Enqueue data into fifo iff both fifos are ready
      */
-    assign ready_and_o = fifo0_ready_lo & fifo1_ready_lo;
+    assign ready_and_o = fifo0_ready_and_lo & fifo1_ready_and_lo;
     assign fifo_v_li = valid_i & ready_and_o;
 
     /**

--- a/bsg_dataflow/bsg_parallel_in_serial_out_dynamic.v
+++ b/bsg_dataflow/bsg_parallel_in_serial_out_dynamic.v
@@ -21,7 +21,7 @@ module bsg_parallel_in_serial_out_dynamic
   ,input                               v_i
   ,input  [lg_max_els_lp-1:0]          len_i
   ,input  [max_els_p-1:0][width_p-1:0] data_i
-  ,output                              ready_o
+  ,output                              ready_and_o
   
   // Output side
   ,output                              v_o
@@ -44,7 +44,7 @@ module bsg_parallel_in_serial_out_dynamic
   (.clk_i  (clk_i          )
   ,.reset_i(reset_i        )
   
-  ,.ready_o(ready_o        )
+  ,.ready_o(ready_and_o    )
   ,.data_i (len_i          )
   ,.v_i    (v_i            )
   
@@ -59,7 +59,7 @@ module bsg_parallel_in_serial_out_dynamic
   ) data_fifo
   (.clk_i  (clk_i            )
   ,.reset_i(reset_i          )
-                             
+
   ,.ready_o(                 )
   ,.data_i (data_i           )
   ,.v_i    (v_i              )

--- a/bsg_dataflow/bsg_ready_to_credit_flow_converter.v
+++ b/bsg_dataflow/bsg_ready_to_credit_flow_converter.v
@@ -16,7 +16,7 @@ module bsg_ready_to_credit_flow_converter #( parameter `BSG_INV_PARAM(credit_ini
     , input  reset_i
 
     , input  v_i
-    , output ready_o
+    , output ready_and_o
 
     , output v_o
     , input  credit_i
@@ -34,8 +34,8 @@ logic [ptr_width_lp-1:0] credit_cnt;
 // conversion between valid-credit and valid-credit protocols
 // in case of reset, credit_cnt is not zero, so the ready
 // and valid signals
-assign ready_o = (credit_cnt!=0);
-assign v_o     = v_i & ready_o;
+assign ready_and_o = (credit_cnt!=0);
+assign v_o     = v_i & ready_and_o;
 assign up      = credit_i ? step_width_lp'($unsigned(decimation_p)) : step_width_lp'(0);
 assign down    = {{(step_width_lp-1){1'b0}},v_o};
 

--- a/bsg_dataflow/bsg_relay_fifo.v
+++ b/bsg_dataflow/bsg_relay_fifo.v
@@ -8,26 +8,26 @@ module bsg_relay_fifo #(parameter `BSG_INV_PARAM(width_p))
     , input reset_i
 
     // input side
-    , output              ready_o 
+    , output              ready_and_o 
     , input [width_p-1:0] data_i 
     , input               v_i     
 
     // output side
     , output              v_o   
     , output[width_p-1:0] data_o
-    , input               ready_i 
+    , input               ready_and_i 
     );
 
 logic yumi;
 
-assign yumi = ready_i & v_o;
+assign yumi = ready_and_i & v_o;
 
 bsg_two_fifo #(.width_p(width_p)) two_fifo
     ( .clk_i(clk_i)
     , .reset_i(reset_i)
 
     // input side
-    , .ready_o(ready_o)
+    , .ready_o(ready_and_o)
     , .data_i(data_i)
     , .v_i(v_i)    
 

--- a/bsg_dataflow/bsg_round_robin_1_to_n.v
+++ b/bsg_dataflow/bsg_round_robin_1_to_n.v
@@ -19,11 +19,11 @@ module bsg_round_robin_1_to_n #(parameter `BSG_INV_PARAM(width_p )
 
     // from one fifo
     , input               valid_i
-    , output              ready_o
+    , output              ready_and_o
     
     // to many
     , output  [num_out_p-1:0]  valid_o
-    , input   [num_out_p-1:0]  ready_i
+    , input   [num_out_p-1:0]  ready_and_i
 
     // to downstream
     );
@@ -32,20 +32,21 @@ module bsg_round_robin_1_to_n #(parameter `BSG_INV_PARAM(width_p )
    if (num_out_p == 1)
      begin: one_to_one
         assign valid_o = valid_i;
-        assign ready_o = ready_i;
+        assign ready_and_o = ready_and_i;
      end
    else
      begin: one_to_n
      
        wire [`BSG_SAFE_CLOG2(num_out_p)-1:0] ptr_r;
-       wire yumi_i = valid_i & ready_o;
+       // The data for the current fifo has been consumed
+       wire yumi_li = valid_i & ready_and_o;
        
        bsg_circular_ptr #(.slots_p(num_out_p)
                           ,.max_add_p(1)
                           ) circular_ptr
          (.clk     (clk_i  )
           ,.reset_i(reset_i)
-          ,.add_i  (yumi_i )
+          ,.add_i  (yumi_li )
           ,.o      (ptr_r  )
           ,.n_o    ()
           );
@@ -55,7 +56,7 @@ module bsg_round_robin_1_to_n #(parameter `BSG_INV_PARAM(width_p )
        assign valid_o = (valid_i << ptr_r);
 
        // binary to one hot
-       assign ready_o = ready_i[ptr_r];
+       assign ready_and_o = ready_and_i[ptr_r];
        
      end
 

--- a/bsg_dataflow/bsg_serial_in_parallel_out.v
+++ b/bsg_dataflow/bsg_serial_in_parallel_out.v
@@ -24,12 +24,12 @@ module bsg_serial_in_parallel_out #(parameter `BSG_INV_PARAM(width_p)
     , input               reset_i
     , input               valid_i
     , input [width_p-1:0] data_i
-    , output              ready_o
+    , output              ready_and_o
 
     , output logic [out_els_p-1:0]                valid_o
     , output logic [out_els_p-1:0][width_p-1:0]   data_o
 
-    , input  [$clog2(out_els_p+1)-1:0]        yumi_cnt_i
+    , input  [$clog2(out_els_p+1)-1:0]            yumi_cnt_i
     );
 
    localparam double_els_lp = els_p * 2;
@@ -63,10 +63,10 @@ module bsg_serial_in_parallel_out #(parameter `BSG_INV_PARAM(width_p)
   // we are ready if we have at least
   // one spot that is not full
 
-  assign ready_o = ~valid_r[els_p-1];
+  assign ready_and_o = ~valid_r[els_p-1];
 
   // update element count
-  assign num_els_n = (num_els_r + (valid_i & ready_o)) - yumi_cnt_i;
+  assign num_els_n = (num_els_r + (valid_i & ready_and_o)) - yumi_cnt_i;
 
   always_comb begin
     data_n  = data_r;
@@ -76,7 +76,7 @@ module bsg_serial_in_parallel_out #(parameter `BSG_INV_PARAM(width_p)
 
     // bypass in values
     data_n [num_els_r] = data_i;
-    valid_n[num_els_r] = valid_i & ready_o;
+    valid_n[num_els_r] = valid_i & ready_and_o;
 
     // this temporary value is
     // the output of this function

--- a/bsg_dataflow/bsg_serial_in_parallel_out_dynamic.v
+++ b/bsg_dataflow/bsg_serial_in_parallel_out_dynamic.v
@@ -21,7 +21,7 @@ module bsg_serial_in_parallel_out_dynamic
   ,input                               v_i
   ,input  [lg_max_els_lp-1:0]          len_i
   ,input  [width_p-1:0]                data_i
-  ,output                              ready_o
+  ,output                              ready_and_o
   ,output                              len_ready_o
   
   // Output side
@@ -33,7 +33,7 @@ module bsg_serial_in_parallel_out_dynamic
   genvar i;
   
   logic yumi_lo;
-  assign yumi_lo = v_i & ready_o;
+  assign yumi_lo = v_i & ready_and_o;
   
   logic [lg_max_els_lp-1:0] count_r, count_lo, len_r, len_lo;
   logic clear_li, up_li, dff_en_li, go_fifo_v_li;
@@ -105,11 +105,11 @@ module bsg_serial_in_parallel_out_dynamic
   ,.yumi_i (yumi_i         )
   );
 
-  logic [max_els_p-1:0] fifo_valid_li, fifo_ready_lo;
+  logic [max_els_p-1:0] fifo_valid_li, fifo_ready_and_lo;
   logic [max_els_p-1:0] fifo_valid_lo, fifo_yumi_li;
   
   // Ready signal from selected fifo
-  assign ready_o = fifo_ready_lo[count_lo];
+  assign ready_and_o = fifo_ready_and_lo[count_lo];
 
   for (i = 0; i < max_els_p; i++)
   begin: rof0
@@ -149,7 +149,7 @@ module bsg_serial_in_parallel_out_dynamic
         (.clk_i  (clk_i  )
         ,.reset_i(reset_i)
 
-        ,.ready_o(fifo_ready_lo[i])
+        ,.ready_o(fifo_ready_and_lo[i])
         ,.data_i (data_i          )
         ,.v_i    (fifo_valid_li[i])
 
@@ -164,16 +164,16 @@ module bsg_serial_in_parallel_out_dynamic
         bsg_one_fifo
        #(.width_p(width_p)
         ) fifo
-        (.clk_i  (clk_i  )
-        ,.reset_i(reset_i)
+        (.clk_i      (clk_i  )
+        ,.reset_i    (reset_i)
 
-        ,.ready_o(fifo_ready_lo[i])
-        ,.data_i (data_i          )
-        ,.v_i    (fifo_valid_li[i])
+        ,.ready_and_o(fifo_ready_and_lo[i])
+        ,.data_i     (data_i          )
+        ,.v_i        (fifo_valid_li[i])
 
-        ,.v_o    (fifo_valid_lo[i])
-        ,.data_o (data_o       [i])
-        ,.yumi_i (fifo_yumi_li [i])
+        ,.v_o        (fifo_valid_lo[i])
+        ,.data_o     (data_o       [i])
+        ,.yumi_i     (fifo_yumi_li [i])
         );
       end
   end

--- a/bsg_dataflow/bsg_serial_in_parallel_out_full.v
+++ b/bsg_dataflow/bsg_serial_in_parallel_out_full.v
@@ -25,9 +25,9 @@ module bsg_serial_in_parallel_out_full
   
   (input clk_i
   ,input reset_i
-    
+
   ,input                                 v_i
-  ,output logic                          ready_o
+  ,output logic                          ready_and_o
   ,input [width_p-1:0]                   data_i
 
   ,output logic [els_p-1:0][width_p-1:0] data_o
@@ -56,7 +56,7 @@ module bsg_serial_in_parallel_out_full
     end
     
 
-  logic [els_p-1:0] fifo_valid_li, fifo_ready_lo;
+  logic [els_p-1:0] fifo_valid_li, fifo_ready_and_lo;
   logic [els_p-1:0] fifo_valid_lo;
 
   // Full array is valid when all fifos have valid data
@@ -67,12 +67,12 @@ module bsg_serial_in_parallel_out_full
  #(.width_p(width_p)
   ,.num_out_p(els_p)
   ) brr
-  (.clk_i  (clk_i)
-  ,.reset_i(reset_i)
-  ,.valid_i(v_i)
-  ,.ready_o(ready_o)
-  ,.valid_o(fifo_valid_li)
-  ,.ready_i(fifo_ready_lo)
+  (.clk_i      (clk_i)
+  ,.reset_i    (reset_i)
+  ,.valid_i    (v_i)
+  ,.ready_and_o(ready_and_o)
+  ,.valid_o    (fifo_valid_li)
+  ,.ready_and_i(fifo_ready_and_lo)
   );
 
   // Data fifos
@@ -90,7 +90,7 @@ module bsg_serial_in_parallel_out_full
         (.clk_i  (clk_i)
         ,.reset_i(reset_i)
 
-        ,.ready_o(fifo_ready_lo[i])
+        ,.ready_o(fifo_ready_and_lo[i])
         ,.data_i (data_i)
         ,.v_i    (fifo_valid_li[i])
 
@@ -105,16 +105,16 @@ module bsg_serial_in_parallel_out_full
         bsg_one_fifo
         #(.width_p(width_p)
         ) fifo
-        (.clk_i  (clk_i)
-        ,.reset_i(reset_i)
+        (.clk_i      (clk_i)
+        ,.reset_i    (reset_i)
 
-        ,.ready_o(fifo_ready_lo[i])
-        ,.data_i (data_i)
-        ,.v_i    (fifo_valid_li[i])
+        ,.ready_and_o(fifo_ready_and_lo[i])
+        ,.data_i     (data_i)
+        ,.v_i        (fifo_valid_li[i])
 
-        ,.v_o    (fifo_valid_lo[i])
-        ,.data_o (data_lo[i])
-        ,.yumi_i (yumi_i)
+        ,.v_o        (fifo_valid_lo[i])
+        ,.data_o     (data_lo[i])
+        ,.yumi_i     (yumi_i)
         );
       end
   end

--- a/bsg_dmc/bsg_dmc_controller.v
+++ b/bsg_dmc/bsg_dmc_controller.v
@@ -88,7 +88,7 @@ module bsg_dmc_controller
 
   logic                                                                tx_sipo_valid_li;
   logic                         [ui_mask_width_lp+ui_data_width_p-1:0] tx_sipo_data_li;
-  logic                                                                tx_sipo_ready_lo;
+  logic                                                                tx_sipo_ready_and_lo;
   logic                                       [ui_burst_length_lp-1:0] tx_sipo_valid_lo;
   logic [ui_burst_length_lp-1:0][ui_mask_width_lp+ui_data_width_p-1:0] tx_sipo_data_lo;
   logic                                 [$clog2(ui_burst_length_lp):0] tx_sipo_yumi_cnt_li;
@@ -120,7 +120,7 @@ module bsg_dmc_controller
 
   logic                                                                rx_sipo_valid_li;
   logic                                         [dfi_data_width_p-1:0] rx_sipo_data_li;
-  logic                                                                rx_sipo_ready_lo;
+  logic                                                                rx_sipo_ready_and_lo;
   logic                                      [dfi_burst_length_lp-1:0] rx_sipo_valid_lo;
   logic                [dfi_burst_length_lp-1:0][dfi_data_width_p-1:0] rx_sipo_data_lo;
   logic                                [$clog2(dfi_burst_length_lp):0] rx_sipo_yumi_cnt_li;
@@ -228,7 +228,7 @@ module bsg_dmc_controller
   assign wrdata_afifo_wdata = {app_wdf_mask_i,app_wdf_data_i};
   assign wrdata_afifo_rclk  = dfi_clk_i;
   assign wrdata_afifo_rrst  = dfi_clk_sync_rst_i;
-  assign wrdata_afifo_rinc  = tx_sipo_ready_lo & wrdata_afifo_rvalid;
+  assign wrdata_afifo_rinc  = tx_sipo_ready_and_lo & wrdata_afifo_rvalid;
 
   assign app_wdf_rdy_o = ~wrdata_afifo_wfull;
 
@@ -259,7 +259,7 @@ module bsg_dmc_controller
     ,.reset_i    ( dfi_clk_sync_rst_i               )
     ,.valid_i    ( tx_sipo_valid_li                 )
     ,.data_i     ( tx_sipo_data_li                  )
-    ,.ready_o    ( tx_sipo_ready_lo                 ) 
+    ,.ready_and_o( tx_sipo_ready_and_lo             ) 
     ,.valid_o    ( tx_sipo_valid_lo                 )
     ,.data_o     ( tx_sipo_data_lo                  )
     ,.yumi_cnt_i ( tx_sipo_yumi_cnt_li              ));
@@ -666,7 +666,7 @@ module bsg_dmc_controller
 
   assign rddata_afifo_rclk  = ui_clk_i;
   assign rddata_afifo_rrst  = ui_clk_sync_rst_i;
-  assign rddata_afifo_rinc  = rx_sipo_ready_lo && rddata_afifo_rvalid;
+  assign rddata_afifo_rinc  = rx_sipo_ready_and_lo && rddata_afifo_rvalid;
 
   bsg_async_fifo #
     (.width_p   ( dfi_data_width_p                             )
@@ -695,7 +695,7 @@ module bsg_dmc_controller
     ,.reset_i    ( ui_clk_sync_rst_i   )
     ,.valid_i    ( rx_sipo_valid_li    )
     ,.data_i     ( rx_sipo_data_li     )
-    ,.ready_o    ( rx_sipo_ready_lo    ) 
+    ,.ready_and_o( rx_sipo_ready_and_lo    ) 
     ,.valid_o    ( rx_sipo_valid_lo    )
     ,.data_o     ( rx_sipo_data_lo     )
     ,.yumi_cnt_i ( rx_sipo_yumi_cnt_li ));

--- a/bsg_mesosync_io/src/bsg_mesosync_core.v
+++ b/bsg_mesosync_io/src/bsg_mesosync_core.v
@@ -77,7 +77,7 @@ bsg_relay_fifo #(.width_p(width_p)) output_relay
 // internal signals
 logic yumi_to_fifo, ready_to_fifo;
 logic fifo_valid, ready, valid;
-logic valid_to_credit_counter, credit_counter_ready;
+logic valid_to_credit_counter, credit_counter_ready_and;
 logic [width_p-1:0] fifo_data;
 
 // Muxes for mode selection, between loopback or normal mode
@@ -91,7 +91,7 @@ assign ready_o_r      = loopback_en_i ? 0          : ready;
 
 // Adding ready signal from bsg_mesosync_output module, line_ready_i
 assign valid_to_credit_counter = line_ready_i & valid;
-assign ready                   = line_ready_i & credit_counter_ready;
+assign ready                   = line_ready_i & credit_counter_ready_and;
 
 // converting from raedy to yumi protocol
 assign yumi_to_fifo = ready_to_fifo & fifo_valid;
@@ -116,7 +116,7 @@ bsg_credit_to_token #( .decimation_p(decimation_p)
 bsg_fifo_1r1w_small_credit_on_input #( .width_p(width_p)
                                      , .els_p(els_p) 
                                      ) input_fifo
-                            
+
     ( .clk_i(clk_i)
     , .reset_i(reset_i)
 
@@ -141,7 +141,7 @@ bsg_ready_to_credit_flow_converter #( .credit_initial_p(credit_initial_p)
     , .reset_i(reset_i)
 
     , .v_i(valid_to_credit_counter)
-    , .ready_o(credit_counter_ready)
+    , .ready_and_o(credit_counter_ready_and)
 
     , .v_o(meso_v_o)
     , .credit_i(meso_token_i)

--- a/bsg_noc/bsg_wormhole_router_adapter_in.v
+++ b/bsg_noc/bsg_wormhole_router_adapter_in.v
@@ -57,7 +57,7 @@ module bsg_wormhole_router_adapter_in
      ,.v_i(v_i)
      ,.len_i(protocol_len_lp'(packet_cast_i.len))
      ,.data_i(packet_padded_li)
-     ,.ready_o(ready_o)
+     ,.ready_and_o(ready_o)
 
      ,.v_o(link_cast_o.v)
      ,.len_v_o(/* unused */)

--- a/testing/Makefile.sim
+++ b/testing/Makefile.sim
@@ -1,11 +1,16 @@
+
+export BSG_CADENV_DIR = $(abspath .)/../../../../bsg_cadenv
+
+include $(BSG_CADENV_DIR)/cadenv.mk
+
 ##########
 # settings for Xilinx Vivado
 BSG_IP_CORES_COMP = xvlog --sv
-BSG_IP_CORES_ELAB = xelab -debug typical -s top_sim
+BSG_IP_CORES_ELAB = xelab -debug typical -s top_sim -timescale=1ps/1ps
 BSG_IP_CORES_SIM  = xsim --runall top_sim
 BSG_IP_CORES_SIM_DEFINE_PARAM =-d@
 BSG_IP_CORES_SIM_INCLUDE_DIRS = -i $(TOP)/bsg_test -i $(TOP)/bsg_misc -i $(TOP)/bsg_dataflow
-BSG_IP_CORES_SIM_CLEAN_FILES = xvlog* xelab* webtalk* xsim* *.wdb
+BSG_IP_CORES_SIM_CLEAN_FILES = xvlog* xelab* webtalk* xsim* *.wdb .Xil
 #
 ##########
 

--- a/testing/bsg_cache/regression/testbench.v
+++ b/testing/bsg_cache/regression/testbench.v
@@ -101,7 +101,7 @@ module testbench();
 
   // output fifo
   //
-  logic fifo_ready_lo;
+  logic fifo_ready_and_lo;
   logic fifo_v_lo;
   logic fifo_yumi_li;
   logic [data_width_p-1:0] fifo_data_lo;
@@ -115,14 +115,14 @@ module testbench();
 
     ,.data_i(cache_data_lo)
     ,.v_i(cache_v_lo)
-    ,.ready_o(fifo_ready_lo)
+    ,.ready_and_o(fifo_ready_and_lo)
 
     ,.v_o(fifo_v_lo)
     ,.data_o(fifo_data_lo)
     ,.yumi_i(fifo_yumi_li)
   );
 
-  assign cache_yumi_li = cache_v_lo & fifo_ready_lo;
+  assign cache_yumi_li = cache_v_lo & fifo_ready_and_lo;
 
   // trace_replay
   //

--- a/testing/bsg_dataflow/Makefile
+++ b/testing/bsg_dataflow/Makefile
@@ -1,0 +1,14 @@
+# High Level Makefile
+# 
+# This makefile runs all other makefiles within one level of
+# scope of itself
+#
+# Brenden Page 11/19/2022
+
+TEST_DIRS = $(wildcard ./*/)
+
+all:
+	$(foreach x,$(TEST_DIRS), cd $(x) && make && cd ../;)
+
+clean:
+	$(foreach x,$(TEST_DIRS), cd $(x) && make clean && cd ../;)

--- a/testing/bsg_dataflow/bsg_channel_narrow/Makefile
+++ b/testing/bsg_dataflow/bsg_channel_narrow/Makefile
@@ -29,13 +29,14 @@ TEST_MAIN   = test_bsg.v
 TEST_MODULE = test_bsg
 
 # this is a list of all variables you want to vary for the simulation
-scan_params = WIDTH_IN_P WIDTH_OUT_P
+scan_params = WIDTH_IN_P WIDTH_OUT_P BSG_NO_TIMESCALE
 
 # this is a list of all values for each variable in the scan_params list
 # note; if you leave out values for a variable, then the product of the
 # sets is null, and nothing will run.
 WIDTH_IN_P  = 1 2 3 4 5 8
 WIDTH_OUT_P = 1 2 3 4 5 8
+BSG_NO_TIMESCALE = 1
 ############################################################################
 
 include ../../Makefile.sim

--- a/testing/bsg_dataflow/bsg_channel_tunnel/Makefile
+++ b/testing/bsg_dataflow/bsg_channel_tunnel/Makefile
@@ -17,10 +17,10 @@ BSG_TESTME_DIR      =   $(TOP)/bsg_dataflow
 BSG_MISC_FILES      =   bsg_defines.v bsg_counter_up_down.v bsg_counter_up_down_variable.v bsg_counter_clear_up.v  bsg_round_robin_arb.v  bsg_crossbar_o_by_i.v  bsg_circular_ptr.v bsg_decode_with_v.v bsg_decode.v bsg_mux_one_hot.v bsg_cycle_counter.v
 BSG_ASYNC_FILES     =
 BSG_COMM_LINK_FILES =
-BSG_DATAFLOW_FILES  = bsg_channel_tunnel_in.v bsg_channel_tunnel_out.v  bsg_round_robin_n_to_1.v bsg_1_to_n_tagged_fifo.v bsg_1_to_n_tagged.v bsg_fifo_1r1w_small.v bsg_fifo_tracker.v
+BSG_DATAFLOW_FILES  = bsg_channel_tunnel_in.v bsg_channel_tunnel_out.v  bsg_round_robin_n_to_1.v bsg_1_to_n_tagged_fifo.v bsg_1_to_n_tagged.v bsg_fifo_1r1w_small.v bsg_fifo_tracker.v bsg_fifo_1r1w_small_unhardened.v
 BSG_FSB_FILES       =
 BSG_GUTS_FILES      =
-BSG_MEM_FILES       = bsg_mem_1r1w.v
+BSG_MEM_FILES       = bsg_mem_1r1w.v bsg_mem_1r1w_synth.v
 
 BSG_TEST_FILES      =  bsg_nonsynth_reset_gen.v \
                        bsg_nonsynth_clock_gen.v \
@@ -40,6 +40,8 @@ LG_CREDIT_DECIMATION_P = 0 1 2 3
 USE_PSEUDO_LARGE_FIFO_P = 0 1
 # whether to have receive rates; or 2^n declining receive rates on each channel
 ASYMMETRIC_P = 0
+# Synthesis option
+# BSG_NO_TIMESCALE = 1
 ############################################################################
 
 # this is a list of all variables you want to vary for the simulation

--- a/testing/bsg_dataflow/bsg_channel_tunnel/test_bsg.v
+++ b/testing/bsg_dataflow/bsg_channel_tunnel/test_bsg.v
@@ -91,20 +91,20 @@ module test_bsg
             (.clk_i   (clk)
              ,.reset_i(reset)
              ,.multi_data_i (multi_data [i])
-             ,.multi_valid_i(multi_valid[i])
+             ,.multi_v_i(multi_valid[i])
              ,.multi_yumi_o (multi_yumi [i])
 
              ,.multi_data_o (multi_data [!i])
-             ,.multi_valid_o(multi_valid[!i])
+             ,.multi_v_o(multi_valid[!i])
              ,.multi_yumi_i (multi_yumi [!i])
 
              //             AB  I/O
              ,.data_i (data [i][0])
-             ,.valid_i(valid[i][0])
+             ,.v_i(valid[i][0])
              ,.yumi_o (yumi [i][0])
 
              ,.data_o (data [i][1])
-             ,.valid_o(valid[i][1])
+             ,.v_o(valid[i][1])
              ,.yumi_i (yumi [i][1])
              );
      end
@@ -183,6 +183,7 @@ module test_bsg
                   bsg_counter_up_down
                       #(.max_val_p({ 1'b0, { width_p {1'b1} }} )
                        ,.init_val_p( (i<<16)+i)
+                       ,.max_step_p(1'b1)
                        ) ctr
                       (.clk_i(clk)
                        ,.reset_i(reset   )

--- a/testing/bsg_dataflow/bsg_compare_and_swap/Makefile
+++ b/testing/bsg_dataflow/bsg_compare_and_swap/Makefile
@@ -7,6 +7,8 @@
 #
 # Edited to test bsg_thermometer_count.v
 # Bandhav Veluri 6/24/2015
+# Edited to work with Makefile.sim
+# Brenden Page 11/21/2022
 
 TOP = ../../..
 
@@ -29,9 +31,9 @@ TEST_MAIN   = test_bsg.v
 TEST_MODULE = test_bsg
 
 # this is a list of all variables you want to vary for the simulation
-scan_params  = WIDTH_P T_P # first two params here
-scan_params1 = $(scan_params) BITS_P
-scan_params2 = $(scan_params1) COND_SWAP_ON_EQUAL_P
+scan_params  = WIDTH_P T_P BITS_P COND_SWAP_ON_EQUAL_P # first two params here
+# scan_params1 = $(scan_params) BITS_P
+# scan_params2 = $(scan_params1) COND_SWAP_ON_EQUAL_P
 
 # this is a list of all values for each variable in the scan_params list
 # note; if you leave out values for a variable, then the product of the
@@ -40,56 +42,5 @@ WIDTH_P              = 1 3
 T_P                  = 0 1 2
 BITS_P               = 1 2 3
 COND_SWAP_ON_EQUAL_P = 0 1 
-############################################################################
 
-############################# SIMULATOR COMMANDS ###########################
-BSG_IP_CORES_COMP = vlog -sv -mfcu -work $(TOP)/work \
-                      +incdir+$(TOP)/bsg_test \
-                      +incdir+$(TOP)/bsg_misc $(ALL_FILES) -quiet
-BSG_IP_CORES_SIM  = vsim -batch -lib $(TOP)/work $(TEST_MODULE) -do "run -all; quit -d"
-#BSG_IP_CORES_SIM  = vsim -i -lib $(TOP)/work $(TEST_MODULE) -do "do wave.do; run -all"
-############################################################################
-
-
-
-
-ALL_FILES = $(foreach x,$(BSG_MISC_FILES),$(TOP)/bsg_misc/$(x)) \
-              $(foreach x,$(BSG_ASYNC_FILES),$(TOP)/bsg_async/$(x)) \
-              $(foreach x,$(BSG_FSB_FILES),$(TOP)/bsg_fsb/$(x)) \
-              $(foreach x,$(BSG_GUTS_FILES),$(TOP)/bsg_guts/$(x)) \
-              $(foreach x,$(BSG_COMM_LINK_FILES),$(TOP)/bsg_comm_link/$(x)) \
-              $(foreach x,$(BSG_DATAFLOW_FILES),$(TOP)/bsg_dataflow/$(x)) \
-              $(foreach x,$(BSG_TEST_FILES),$(TOP)/bsg_test/$(x)) \
-              $(foreach x,$(BSG_TESTME_FILES),$(BSG_TESTME_DIR)/$(x)) \
-              $(TEST_MAIN)
-
-# function that generates a string for each combination of the parameters;
-# spaces separated by "@" signs.
-bsg_param_scan = $(if $(1),$(foreach v__,$($(firstword $(1))),\
-                    $(call bsg_param_scan,$(filter-out $(firstword $(1)),\
-                    $(1)),$(2),$(3),$(4)@$(2)$(firstword $(1))$(3)$(v__))),\
-                    $(4))
-
-# this takes the parameters and creates a set of make targets, one for every 
-# combination of the parameters
-commands  = $(call bsg_param_scan,$(scan_params),+define+,=)
-commands1 = $(call bsg_param_scan,$(scan_params1),+define+,=)
-commands2 = $(call bsg_param_scan,$(scan_params2),+define+,=)
-
-$(warning bsg_param_scan: $(commands2))
-
-
-# default rule: run all of the targets.
-all: initial $(foreach x,$(commands2),run.$(x))
-
-# this runs an individual target
-# we replace the @ with a space so that the parameters are used as 
-# command line options
-
-run.%:
-	$(BSG_IP_CORES_COMP) $(subst @, ,$*)
-	$(BSG_IP_CORES_SIM) >> outfile
-  
-initial:
-	@echo removing outfile
-	rm -f outfile
+include ../../Makefile.sim

--- a/testing/bsg_dataflow/bsg_compare_and_swap/test_bsg.v
+++ b/testing/bsg_dataflow/bsg_compare_and_swap/test_bsg.v
@@ -1,8 +1,3 @@
-`define WIDTH_P              2
-`define T_P                  1
-`define BITS_P               1 // no. of bits included starting from T_P
-`define COND_SWAP_ON_EQUAL_P 0
-
 /**************************** TEST RATIONALE *******************************
 
 1. STATE SPACE
@@ -34,21 +29,39 @@ module test_bsg
 );
 
   wire clk;
-  wire reset;
+  wire reset_lo;
+  logic reset;
+  logic reset_prev_high;
+
+  // Ensure reset is high initially
+  always_comb begin
+    case(reset_lo)
+      1'b1: reset_prev_high = 1'b1;
+      1'b0: reset_prev_high = reset_prev_high;
+      default: reset_prev_high = 1'b0;
+    endcase 
+  end
+
+  assign reset = ~reset_prev_high | reset_lo;
   
-  bsg_nonsynth_clock_gen #(  .cycle_time_p(cycle_time_p)
-                          )  clock_gen
-                          (  .o(clk)
-                          );
+  bsg_nonsynth_clock_gen 
+    #(.cycle_time_p(cycle_time_p))
+    clock_gen (.o(clk));
+  
+  bsg_nonsynth_reset_gen
+    #(.num_clocks_p     (1)
+     ,.reset_cycles_lo_p(reset_cycles_lo_p)
+     ,.reset_cycles_hi_p(reset_cycles_hi_p)
+     )
+    reset_gen
+     (.clk_i        (clk) 
+     ,.async_reset_o(reset_lo)
+     );
+
+  always_ff @(posedge clk) begin
     
-  bsg_nonsynth_reset_gen #(  .num_clocks_p     (1)
-                           , .reset_cycles_lo_p(reset_cycles_lo_p)
-                           , .reset_cycles_hi_p(reset_cycles_hi_p)
-                          )  reset_gen
-                          (  .clk_i        (clk) 
-                           , .async_reset_o(reset)
-                          );
-                          
+  end
+
   initial
   begin
     $display(  "\n\n\n"
@@ -68,14 +81,14 @@ module test_bsg
   		            , width_p, t_p, b_p, cond_swap_on_equal_p);
           $finish;
         end
-    
+
   end
-    
+
   logic [1:0] [width_p-1:0] test_input, test_output;
   logic test_input_swap, test_output_swapped, finish_r;
   
   always_ff @(posedge clk)
-  begin          
+  begin
     if(reset)
       begin
         test_input[0]   <= width_p ' (0);    // initiate with 00..0
@@ -102,26 +115,24 @@ module test_bsg
   
   always_ff @(posedge clk)
   begin
-    if(!reset)  
-      begin
-        assert(test_output_swapped == ((test_input[0][t_p:b_p] > test_input[1][t_p:b_p])
-                                       | ((cond_swap_on_equal_p & test_input_swap)
-                                          & (test_input[0] == test_input[1])
-                                         )
+    $display("Reset: %x", reset);
+    assert(reset || (test_output_swapped == ((test_input[0][t_p:b_p] > test_input[1][t_p:b_p])
+                                    | ((cond_swap_on_equal_p & test_input_swap)
+                                      & (test_input[0] == test_input[1])
                                       )
-              )
-          else $error("swapped_o: mismatch on input %x", test_input);
+                                  ))
+          )
+      else $error("swapped_o: mismatch on input %x", test_input);
 
-        assert(test_output == ((test_input[0][t_p:b_p] > test_input[1][t_p:b_p])
-                               | ((cond_swap_on_equal_p & test_input_swap)
-                                  & (test_input[0] == test_input[1])
-                                 )
+    assert(reset || (test_output == ((test_input[0][t_p:b_p] > test_input[1][t_p:b_p])
+                            | ((cond_swap_on_equal_p & test_input_swap)
+                              & (test_input[0] == test_input[1])
                               )
-                              ? {test_input[0], test_input[1]}
-                              : test_input
-              )
-          else $error("data_o: mismatch on input %x", test_input);
-      end
+                          )
+                          ? {test_input[0], test_input[1]}
+                          : test_input)
+          )
+      else $error("data_o: mismatch on input %x", test_input);
   end
 
  // generate DUT only if params are compatible

--- a/testing/bsg_dataflow/bsg_fifo_1r1w_large/Makefile
+++ b/testing/bsg_dataflow/bsg_fifo_1r1w_large/Makefile
@@ -20,14 +20,9 @@ IO_MASTER_1_PERIOD =   2
 CORE_1_PERIOD      =   1
 endif
 
+export BSG_CADENV_DIR = $(abspath .)/../../../../bsg_cadenv
 
-export LM_LICENSE_FILE = 27000@bbfs-00.calit2.net
-export SYNOPSYS_DIR=/gro/cad/synopsys
-export VCS_RELEASE=vcs/G-2012.09-SP1
-export VCS_HOME = $(SYNOPSYS_DIR)/$(VCS_RELEASE)
-export VCS_BIN = $(VCS_HOME)/bin
-export DVE_BIN = $(VCS_HOME)/bin
-export DC_RELEASE    = syn/G-2012.06-SP5-4
+include $(BSG_CADENV_DIR)/cadenv.mk
 
 TOP = ../../..
 
@@ -43,7 +38,7 @@ BSG_COMM_LINK_FILES =
 BSG_DATAFLOW_FILES  =  bsg_fifo_1r1w_large.v bsg_fifo_1rw_large.v bsg_round_robin_2_to_2.v bsg_two_fifo.v bsg_round_robin_n_to_1.v bsg_serial_in_parallel_out.v
 BSG_FSB_FILES       =
 BSG_GUTS_FILES      =
-BSG_MEM_FILES       = bsg_mem_1r1w.v bsg_mem_1rw_sync.v
+BSG_MEM_FILES       = bsg_mem_1r1w.v bsg_mem_1rw_sync.v bsg_mem_1r1w_synth.v bsg_mem_1rw_sync_synth.v
 
 BSG_TEST_FILES =  bsg_nonsynth_reset_gen.v bsg_nonsynth_clock_gen.v
 
@@ -75,7 +70,7 @@ all: $(ALL_ALL_ALL_ALL)
 log@%: $(ALL_FILES)
 	@echo $*
 	- rm -rf simv csrc simv.daidir
-	$(VCS_BIN)/vcs $(DESIGNWARE_FLAGS) -PP -notice -full64 +lint=all,noVCDE +v2k -sverilog -timescale=100ps/10ps $(filter-out small-clean,$^) $(subst @, ,$*) +vcs+loopreport +define+BSG_IP_CORES_UNIT_TEST
+	$(VCS_BIN)/vcs $(DESIGNWARE_FLAGS) -PP -notice -full64 -assert svaext +lint=all,noVCDE +v2k -sverilog -timescale=100ps/10ps $(filter-out small-clean,$^) $(subst @, ,$*) +vcs+loopreport +define+BSG_IP_CORES_UNIT_TEST
 	./simv # | tee $@
 
 log@%: small_clean
@@ -89,6 +84,7 @@ dve:
 clean:
 	-rm log@*
 	- rm -rf simv csrc simv.daidir DVEfiles vcdplus.vpd ucli.key
+	-rm vc_hdrs.h
 
 small-clean:
 	- rm -rf simv csrc simv.daidir

--- a/testing/bsg_dataflow/bsg_fifo_1r1w_large/test_bsg_fifo_1r1w_large.v
+++ b/testing/bsg_dataflow/bsg_fifo_1r1w_large/test_bsg_fifo_1r1w_large.v
@@ -23,7 +23,7 @@ module testbench;
       );
 
    logic [width_lp-1:0] test_data_in, test_data_out, test_data_check;
-   wire test_valid_in, test_valid_out, test_ready_out, test_ready_in;
+   wire test_valid_in, test_valid_out, test_ready_and_out, test_ready_in;
 
    logic [31:0] ctr;
 
@@ -46,6 +46,7 @@ module testbench;
       ,.reset_i(reset)
       ,.add_i  (pattern_bit == (pattern_width_lp-1))
       ,.o      (test_pattern)
+      ,.n_o     ()
       );
 
    // cycles through each bit of the battern
@@ -56,6 +57,7 @@ module testbench;
       ,.reset_i(reset)
       ,.add_i  (1'b1)
       ,.o      (pattern_bit)
+      ,.n_o     ()
       );
 
    assign test_valid_in = test_pattern[pattern_bit];
@@ -74,8 +76,9 @@ module testbench;
                       ) gen
    (.clk(clk)
     ,.reset_i(reset)
-    ,.add_i  (test_valid_in & test_ready_out)
+    ,.add_i  (test_valid_in & test_ready_and_out)
     ,.o      (test_data_in)
+    ,.n_o     ()
     );
 
 
@@ -85,7 +88,7 @@ module testbench;
 
    always @(posedge clk)
      begin
-        if (test_valid_in & test_ready_out & verbose_lp)
+        if (test_valid_in & test_ready_and_out & verbose_lp)
           $display("### %x sent     %x   bypass_mode=%x",ctr, test_data_in,fifo.bypass_mode);
      end
 
@@ -99,7 +102,7 @@ module testbench;
 
       ,.data_i (test_data_in)
       ,.v_i    (test_valid_in)
-      ,.ready_o(test_ready_out)
+      ,.ready_and_o(test_ready_and_out)
 
       ,.v_o    (test_valid_out)
       ,.data_o (test_data_out)
@@ -113,6 +116,7 @@ module testbench;
     ,.reset_i(reset)
     ,.add_i  (test_yumi_in)
     ,.o      (test_data_check)
+    ,.n_o     ()
     );
 
    always_ff @(posedge clk)
@@ -144,7 +148,7 @@ module testbench;
         // IMPORTANT TEST: test that the fifo will never register full with less than els_lp
         // elements actually stored.
 
-        if (~test_ready_out & test_valid_in)
+        if (~test_ready_and_out & test_valid_in)
 	  // mbt: seems like this should be "<" -- so this fifo actually stores N+1 elements?
           if (fifo.num_elements_debug <= els_lp)
             begin

--- a/testing/bsg_dataflow/bsg_fifo_1r1w_pseudo_large/Makefile
+++ b/testing/bsg_dataflow/bsg_fifo_1r1w_pseudo_large/Makefile
@@ -20,14 +20,9 @@ IO_MASTER_1_PERIOD =   2
 CORE_1_PERIOD      =   1
 endif
 
+export BSG_CADENV_DIR = $(abspath .)/../../../../bsg_cadenv
 
-export LM_LICENSE_FILE = 27000@bbfs-00.calit2.net
-export SYNOPSYS_DIR=/gro/cad/synopsys
-export VCS_RELEASE=vcs/G-2012.09-SP1
-export VCS_HOME = $(SYNOPSYS_DIR)/$(VCS_RELEASE)
-export VCS_BIN = $(VCS_HOME)/bin
-export DVE_BIN = $(VCS_HOME)/bin
-export DC_RELEASE    = syn/G-2012.06-SP5-4
+include $(BSG_CADENV_DIR)/cadenv.mk
 
 TOP = ../../..
 
@@ -43,7 +38,7 @@ BSG_COMM_LINK_FILES =
 BSG_DATAFLOW_FILES  =  bsg_fifo_1r1w_pseudo_large.v bsg_fifo_1rw_large.v bsg_two_fifo.v bsg_round_robin_n_to_1.v 
 BSG_FSB_FILES       =
 BSG_GUTS_FILES      =
-BSG_MEM_FILES       = bsg_mem_1r1w.v bsg_mem_1rw_sync.v
+BSG_MEM_FILES       = bsg_mem_1r1w.v bsg_mem_1rw_sync.v bsg_mem_1r1w_synth.v bsg_mem_1rw_sync_synth.v
 
 BSG_TEST_FILES =  bsg_nonsynth_reset_gen.v bsg_nonsynth_clock_gen.v
 
@@ -75,7 +70,7 @@ all: $(ALL_ALL_ALL_ALL)
 log@%: $(ALL_FILES)
 	@echo $*
 	- rm -rf simv csrc simv.daidir
-	$(VCS_BIN)/vcs $(DESIGNWARE_FLAGS) -PP -notice -full64 +lint=all,noVCDE +v2k -sverilog -timescale=100ps/10ps $(filter-out small-clean,$^) $(subst @, ,$*) +vcs+loopreport +define+BSG_IP_CORES_UNIT_TEST
+	$(VCS_BIN)/vcs $(DESIGNWARE_FLAGS) -PP -notice -full64 -assert svaext +lint=all,noVCDE +v2k -sverilog -timescale=100ps/10ps $(filter-out small-clean,$^) $(subst @, ,$*) +vcs+loopreport +define+BSG_IP_CORES_UNIT_TEST
 	./simv # | tee $@
 
 log@%: small_clean
@@ -89,6 +84,7 @@ dve:
 clean:
 	-rm log@*
 	- rm -rf simv csrc simv.daidir DVEfiles vcdplus.vpd ucli.key
+	-rm vc_hdrs.h
 
 small-clean:
 	- rm -rf simv csrc simv.daidir

--- a/testing/bsg_dataflow/bsg_fifo_1r1w_pseudo_large/bsg_test.v
+++ b/testing/bsg_dataflow/bsg_fifo_1r1w_pseudo_large/bsg_test.v
@@ -24,7 +24,7 @@ module testbench;
       );
 
    logic [width_lp-1:0] test_data_in, test_data_out, test_data_check;
-   wire test_valid_in, test_valid_out, test_ready_out, test_ready_in;
+   wire test_valid_in, test_valid_out, test_ready_and_out, test_ready_in;
 
    logic [31:0] ctr;
 
@@ -75,7 +75,7 @@ module testbench;
                       ) gen
    (.clk(clk)
     ,.reset_i(reset)
-    ,.add_i  (test_valid_in & test_ready_out)
+    ,.add_i  (test_valid_in & test_ready_and_out)
     ,.o      (test_data_in)
     );
 
@@ -87,7 +87,7 @@ module testbench;
 
    always @(posedge clk)
      begin
-        if (test_valid_in & test_ready_out & verbose_lp)
+        if (test_valid_in & test_ready_and_out & verbose_lp)
           $display("### %x sent     %x (1rw r=%x w=%x f=%x e=%x) bypass_mode=%x storage=%d",ctr, test_data_in
 		   , fifo.big1p.rd_ptr, fifo.big1p.wr_ptr, fifo.big1p.fifo_full, fifo.big1p.fifo_empty
 		   , fifo.bypass_mode, fifo.num_elements_debug);
@@ -103,13 +103,13 @@ module testbench;
      (.clk_i(clk)
       ,.reset_i(reset      )
 
-      ,.data_i (test_data_in)
-      ,.v_i    (test_valid_in)
-      ,.ready_o(test_ready_out)
+      ,.data_i     (test_data_in)
+      ,.v_i        (test_valid_in)
+      ,.ready_and_o(test_ready_and_out)
 
-      ,.v_o    (test_valid_out)
-      ,.data_o (test_data_out)
-      ,.yumi_i (test_yumi_in) // recycle
+      ,.v_o        (test_valid_out)
+      ,.data_o     (test_data_out)
+      ,.yumi_i     (test_yumi_in) // recycle
       );
 
    bsg_circular_ptr #(.slots_p   (1 << width_lp)
@@ -151,7 +151,7 @@ module testbench;
         // IMPORTANT TEST: test that the fifo will never register full with less than els_lp
         // elements actually stored.
 
-        if (~test_ready_out & test_valid_in)
+        if (~test_ready_and_out & test_valid_in)
           if (fifo.num_elements_debug < els_lp)
             begin
                $display("### %x FAIL BAD FULL %x (1rw r=%x w=%x f=%x e=%x) pattern=%b storage=%d"

--- a/testing/bsg_dataflow/bsg_fifo_1r1w_pseudo_large/test_bsg_fifo_1r1w_pseudo_large.v
+++ b/testing/bsg_dataflow/bsg_fifo_1r1w_pseudo_large/test_bsg_fifo_1r1w_pseudo_large.v
@@ -26,7 +26,7 @@ module testbench;
       );
 
    logic [width_lp-1:0] test_data_in, test_data_out, test_data_check;
-   wire test_valid_in, test_valid_out, test_ready_out, test_ready_in;
+   wire test_valid_in, test_valid_out, test_ready_and_out, test_ready_in;
 
    logic [31:0] ctr;
 
@@ -49,6 +49,7 @@ module testbench;
       ,.reset_i(reset)
       ,.add_i  (pattern_bit == (pattern_width_lp-1))
       ,.o      (test_pattern)
+      ,.n_o    ()
       );
 
    // cycles through each bit of the battern
@@ -59,6 +60,7 @@ module testbench;
       ,.reset_i(reset)
       ,.add_i  (1'b1)
       ,.o      (pattern_bit)
+      ,.n_o    ()
       );
 
    assign test_valid_in = test_pattern[pattern_bit];
@@ -77,8 +79,9 @@ module testbench;
                       ) gen
    (.clk(clk)
     ,.reset_i(reset)
-    ,.add_i  (test_valid_in & test_ready_out)
+    ,.add_i  (test_valid_in & test_ready_and_out)
     ,.o      (test_data_in)
+    ,.n_o    ()
     );
 
 
@@ -89,7 +92,7 @@ module testbench;
 
    always @(posedge clk)
      begin
-        if (test_valid_in & test_ready_out & verbose_lp)
+        if (test_valid_in & test_ready_and_out & verbose_lp)
           $display("### %x sent     %x (1rw r=%x w=%x f=%x e=%x) bypass_mode=%x storage=%d",ctr, test_data_in
 		   , fifo.big1p.rd_ptr, fifo.big1p.wr_ptr, fifo.big1p.fifo_full, fifo.big1p.fifo_empty
 		   , fifo.bypass_mode, fifo.num_elements_debug);
@@ -105,13 +108,13 @@ module testbench;
      (.clk_i(clk)
       ,.reset_i(reset      )
 
-      ,.data_i (test_data_in)
-      ,.v_i    (test_valid_in)
-      ,.ready_o(test_ready_out)
+      ,.data_i     (test_data_in)
+      ,.v_i        (test_valid_in)
+      ,.ready_and_o(test_ready_and_out)
 
-      ,.v_o    (test_valid_out)
-      ,.data_o (test_data_out)
-      ,.yumi_i (test_yumi_in) // recycle
+      ,.v_o        (test_valid_out)
+      ,.data_o     (test_data_out)
+      ,.yumi_i     (test_yumi_in) // recycle
       );
 
    bsg_circular_ptr #(.slots_p   (1 << width_lp)
@@ -121,6 +124,7 @@ module testbench;
     ,.reset_i(reset)
     ,.add_i  (test_yumi_in)
     ,.o      (test_data_check)
+    ,.n_o    ()
     );
 
    always_ff @(posedge clk)
@@ -155,7 +159,7 @@ module testbench;
         // IMPORTANT TEST: test that the fifo will never register full with less than els_lp
         // elements actually stored.
 
-        if (~test_ready_out & test_valid_in)
+        if (~test_ready_and_out & test_valid_in)
           if (fifo.num_elements_debug < els_lp)
             begin
                $display("### %x FAIL BAD FULL %x (1rw r=%x w=%x f=%x e=%x) pattern=%b storage=%d"

--- a/testing/bsg_dataflow/bsg_fifo_bypass/Makefile
+++ b/testing/bsg_dataflow/bsg_fifo_bypass/Makefile
@@ -1,5 +1,9 @@
 export BASEJUMP_STL_DIR = ../../..
 
+export BSG_CADENV_DIR = $(abspath .)/../../../../bsg_cadenv
+
+include $(BSG_CADENV_DIR)/cadenv.mk
+
 INCDIR = +incdir+$(BASEJUMP_STL_DIR)/bsg_misc
 INCDIR += +incdir+$(BASEJUMP_STL_DIR)/bsg_noc
 INCDIR += +incdir+$(BASEJUMP_STL_DIR)/bsg_dataflow
@@ -20,5 +24,7 @@ clean:
 	rm -rf DVEfiles
 	rm -rf csrc
 	rm -rf simv.daidir simv.vdb
-	rm -f ucli.key vcdplus.vpd simv cm.log *.tar.gz
+	rm -f ucli.key vcdplus.vpd simv cm.log *.tar.gz vc_hdrs.h
 	rm -rf trace.tr
+	rm -rf cov.vdb
+	rm -rf urgReport

--- a/testing/bsg_dataflow/bsg_fifo_bypass/sv.include
+++ b/testing/bsg_dataflow/bsg_fifo_bypass/sv.include
@@ -9,4 +9,5 @@ $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1r1w.v
 $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1r1w_synth.v
 $BASEJUMP_STL_DIR/bsg_test/bsg_nonsynth_clock_gen.v
 $BASEJUMP_STL_DIR/bsg_test/bsg_nonsynth_reset_gen.v
+$BASEJUMP_STL_DIR/bsg_dataflow/bsg_two_fifo.v
 testbench.v

--- a/testing/bsg_dataflow/bsg_fifo_reorder/Makefile
+++ b/testing/bsg_dataflow/bsg_fifo_reorder/Makefile
@@ -7,7 +7,7 @@ INCDIR = +incdir+$(BASEJUMP_STL_DIR)/bsg_misc
 
 sim:
 	vcs +v2k -R +lint=all,noSVA-UA,noSVA-NSVU,noVCDE -sverilog -full64 -f sv.include $(INCDIR)\
-		-debug_pp -timescale=1ps/1ps +vcs+vcdpluson
+		-debug_pp -timescale=1ps/1ps +vcs+vcdpluson -assert svaext
 
 
 dve:
@@ -18,4 +18,4 @@ clean:
 	rm -rf DVEfiles
 	rm -rf csrc
 	rm -rf simv.daidir simv.vdb
-	rm -f ucli.key vcdplus.vpd simv cm.log *.tar.gz
+	rm -f ucli.key vcdplus.vpd simv cm.log *.tar.gz vc_hdrs.h

--- a/testing/bsg_dataflow/bsg_parallel_in_serial_out/Makefile
+++ b/testing/bsg_dataflow/bsg_parallel_in_serial_out/Makefile
@@ -22,7 +22,7 @@ run: $(RUNS)
 run-%:
 	mkdir run-$*;
 	cd run-$* && \
-        $(VCS_BIN)/vcs -full64 -sverilog -timescale=1ps/1ps -f $(TOP_DIR)/filelist -debug_pp -R -top bsg_parallel_in_serial_out_tester +vcs+vcdpluson \
+        $(VCS_BIN)/vcs -full64 -sverilog -timescale=1ps/1ps -assert svaext -f $(TOP_DIR)/filelist -debug_pp -R -top bsg_parallel_in_serial_out_tester +vcs+vcdpluson \
         -pvalue+top_master_clk_period_p=$(word 1, $(subst -, ,$*)) \
         -pvalue+top_piso_clk_period_p=$(word 2, $(subst -, ,$*)) \
         -pvalue+top_client_clk_period_p=$(word 3, $(subst -, ,$*)) \

--- a/testing/bsg_dataflow/bsg_parallel_in_serial_out/bsg_parallel_in_serial_out_test_node.v
+++ b/testing/bsg_dataflow/bsg_parallel_in_serial_out/bsg_parallel_in_serial_out_test_node.v
@@ -113,7 +113,7 @@ module bsg_parallel_in_serial_out_test_node
       (.clk_i  (node_clk_i)
       ,.reset_i(node_reset_i)
 
-      ,.ready_o(node_async_fifo_ready_li)
+      ,.ready_and_o(node_async_fifo_ready_li)
       ,.v_i    (node_async_fifo_valid_lo)
       ,.data_i (node_async_fifo_data_lo)
 

--- a/testing/bsg_dataflow/bsg_parallel_in_serial_out_passthrough/testbench.v
+++ b/testing/bsg_dataflow/bsg_parallel_in_serial_out_passthrough/testbench.v
@@ -28,7 +28,7 @@ module testbench;
   logic in_v_lo, in_yumi_li;
 
   logic [narrow_width_lp-1:0] out_data_li;
-  logic out_v_li, out_ready_lo;
+  logic out_v_li, out_ready_and_lo;
   logic [wide_width_lp-1:0] out_data_lo;
   logic out_v_lo, out_ready_li;
 
@@ -49,7 +49,7 @@ module testbench;
 
   assign out_data_li = in_data_lo;
   assign out_v_li = in_v_lo;
-  assign in_yumi_li = out_ready_lo & out_v_li;
+  assign in_yumi_li = out_ready_and_lo & out_v_li;
 
   bsg_serial_in_parallel_out_full
    #(.width_p(narrow_width_lp), .els_p(els_lp))
@@ -59,7 +59,7 @@ module testbench;
 
      ,.data_i(out_data_li)
      ,.v_i(out_v_li)
-     ,.ready_o(out_ready_lo)
+     ,.ready_and_o(out_ready_and_lo)
 
      ,.data_o(out_data_lo)
      ,.v_o(out_v_lo)

--- a/testing/bsg_dataflow/bsg_parallel_in_serial_out_passthrough_arb/sv.include
+++ b/testing/bsg_dataflow/bsg_parallel_in_serial_out_passthrough_arb/sv.include
@@ -1,4 +1,6 @@
 $BASEJUMP_STL_DIR/bsg_noc/bsg_noc_pkg.v
+$BASEJUMP_STL_DIR/bsg_noc/bsg_mesh_router_pkg.v
+$BASEJUMP_STL_DIR/bsg_noc/bsg_mesh_router_decoder_dor.v
 $BASEJUMP_STL_DIR/bsg_noc/bsg_mesh_router.v
 $BASEJUMP_STL_DIR/bsg_noc/bsg_mesh_router_buffered.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_mux_one_hot.v
@@ -11,6 +13,12 @@ $BASEJUMP_STL_DIR/bsg_dataflow/bsg_parallel_in_serial_out_passthrough.v
 $BASEJUMP_STL_DIR/bsg_dataflow/bsg_serial_in_parallel_out_passthrough.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_counter_clear_up_one_hot.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_dff_en.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_transpose.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_array_concentrate_static.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_concentrate_static.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_unconcentrate_static.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_arb_round_robin.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_scan.v
 $BASEJUMP_STL_DIR/bsg_test/bsg_nonsynth_clock_gen.v
 $BASEJUMP_STL_DIR/bsg_test/bsg_nonsynth_reset_gen.v
 testbench.v

--- a/testing/bsg_dataflow/bsg_serial_in_parallel_out_passthrough/sv.include
+++ b/testing/bsg_dataflow/bsg_serial_in_parallel_out_passthrough/sv.include
@@ -2,11 +2,15 @@
 $BASEJUMP_STL_DIR/bsg_dataflow/bsg_parallel_in_serial_out.v
 $BASEJUMP_STL_DIR/bsg_dataflow/bsg_serial_in_parallel_out_passthrough.v
 $BASEJUMP_STL_DIR/bsg_dataflow/bsg_two_fifo.v
+$BASEJUMP_STL_DIR/bsg_dataflow/bsg_one_fifo.v
 $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1r1w.v
 $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1r1w_synth.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_counter_clear_up_one_hot.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_dff_en.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_defines.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_counter_clear_up.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_mux.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_dff_reset.v
 $BASEJUMP_STL_DIR/bsg_test/bsg_nonsynth_clock_gen.v
 $BASEJUMP_STL_DIR/bsg_test/bsg_nonsynth_reset_gen.v
 testbench.v

--- a/testing/bsg_dataflow/bsg_serial_in_parallel_out_passthrough/testbench.v
+++ b/testing/bsg_dataflow/bsg_serial_in_parallel_out_passthrough/testbench.v
@@ -28,7 +28,7 @@ module testbench;
   logic in_v_lo, in_yumi_li;
 
   logic [wide_width_lp-1:0] out_data_li;
-  logic out_v_li, out_ready_lo;
+  logic out_v_li, out_ready_and_lo;
   logic [narrow_width_lp-1:0] out_data_lo;
   logic out_v_lo, out_ready_li;
 
@@ -49,7 +49,7 @@ module testbench;
 
   assign out_data_li = in_data_lo;
   assign out_v_li = in_v_lo;
-  assign in_yumi_li = out_ready_lo & out_v_li;
+  assign in_yumi_li = out_ready_and_lo & out_v_li;
 
   bsg_parallel_in_serial_out
    #(.width_p(narrow_width_lp), .els_p(els_lp))
@@ -59,7 +59,7 @@ module testbench;
 
      ,.data_i(out_data_li)
      ,.valid_i(out_v_li)
-     ,.ready_o(out_ready_lo)
+     ,.ready_and_o(out_ready_and_lo)
 
      ,.data_o(out_data_lo)
      ,.valid_o(out_v_lo)

--- a/testing/bsg_dmc/testbench.v
+++ b/testing/bsg_dmc/testbench.v
@@ -301,7 +301,7 @@ module testbench
     ,.reset_i    ( ui_clk_sync_rst   )
     ,.valid_i    ( app_rd_data_valid )
     ,.data_i     ( app_rd_data       )
-    ,.ready_o    (                   ) 
+    ,.ready_and_o(                   ) 
     ,.valid_o    ( sipo_valid_lo     )
     ,.data_o     ( sipo_data_lo      )
     ,.yumi_cnt_i ( sipo_yumi_cnt_li  ));

--- a/testing/bsg_noc/bsg_wormhole_network/bsg_wormhole_network_test_node_client.v
+++ b/testing/bsg_noc/bsg_wormhole_network/bsg_wormhole_network_test_node_client.v
@@ -66,38 +66,38 @@ module bsg_wormhole_router_test_node_client
     wormhole_network_header_flit_s req_in_data;
     logic                          req_in_yumi;
 
-    logic                          resp_out_ready;
+    logic                          resp_out_ready_and;
     wormhole_network_header_flit_s resp_out_data;
     logic                          resp_out_v;
 
     bsg_one_fifo
    #(.width_p(flit_width_p)
     ) req_in_fifo
-    (.clk_i  (clk_i)
-    ,.reset_i(reset_i)
+    (.clk_i      (clk_i)
+    ,.reset_i    (reset_i)
 
-    ,.ready_o(link_o_cast[i].ready_and_rev)
-    ,.v_i    (link_i_cast[i].v)
-    ,.data_i (link_i_cast[i].data)
+    ,.ready_and_o(link_o_cast[i].ready_and_rev)
+    ,.v_i        (link_i_cast[i].v)
+    ,.data_i     (link_i_cast[i].data)
 
-    ,.v_o    (req_in_v)
-    ,.data_o (req_in_data)
-    ,.yumi_i (req_in_yumi)
+    ,.v_o        (req_in_v)
+    ,.data_o     (req_in_data)
+    ,.yumi_i     (req_in_yumi)
     );
 
     bsg_one_fifo
    #(.width_p(flit_width_p)
     ) resp_out_fifo
-    (.clk_i  (clk_i)
-    ,.reset_i(reset_i)
+    (.clk_i      (clk_i)
+    ,.reset_i    (reset_i)
 
-    ,.ready_o(resp_out_ready)
-    ,.v_i    (resp_out_v)
-    ,.data_i (resp_out_data)
+    ,.ready_and_o(resp_out_ready_and)
+    ,.v_i        (resp_out_v)
+    ,.data_i     (resp_out_data)
 
-    ,.v_o    (link_o_cast[i].v)
-    ,.data_o (link_o_cast[i].data)
-    ,.yumi_i (link_o_cast[i].v & link_i_cast[i].ready_and_rev)
+    ,.v_o        (link_o_cast[i].v)
+    ,.data_o     (link_o_cast[i].data)
+    ,.yumi_i     (link_o_cast[i].v & link_i_cast[i].ready_and_rev)
     );
 
     // loopback any data received, replace cord in flit hdr
@@ -106,7 +106,7 @@ module bsg_wormhole_router_test_node_client
     assign resp_out_data.data       = req_in_data.data;
 
     assign resp_out_v  = req_in_v;
-    assign req_in_yumi = resp_out_v & resp_out_ready;
+    assign req_in_yumi = resp_out_v & resp_out_ready_and;
   
   end  
 

--- a/testing/bsg_noc/bsg_wormhole_network/bsg_wormhole_network_test_node_master.v
+++ b/testing/bsg_noc/bsg_wormhole_network/bsg_wormhole_network_test_node_master.v
@@ -86,38 +86,38 @@ module bsg_wormhole_router_test_node_master
     wormhole_network_header_flit_s resp_in_data;
     logic                          resp_in_yumi;
 
-    logic                          req_out_ready;
+    logic                          req_out_ready_and;
     wormhole_network_header_flit_s req_out_data;
     logic                          req_out_v;
 
     bsg_one_fifo
    #(.width_p(flit_width_p)
     ) resp_in_fifo
-    (.clk_i  (clk_i)
-    ,.reset_i(reset_i)
+    (.clk_i      (clk_i)
+    ,.reset_i    (reset_i)
 
-    ,.ready_o(link_o_cast[i].ready_and_rev)
-    ,.v_i    (link_i_cast[i].v)
-    ,.data_i (link_i_cast[i].data)
+    ,.ready_and_o(link_o_cast[i].ready_and_rev)
+    ,.v_i        (link_i_cast[i].v)
+    ,.data_i     (link_i_cast[i].data)
 
-    ,.v_o    (resp_in_v)
-    ,.data_o (resp_in_data)
-    ,.yumi_i (resp_in_yumi)
+    ,.v_o        (resp_in_v)
+    ,.data_o     (resp_in_data)
+    ,.yumi_i     (resp_in_yumi)
     );
 
     bsg_one_fifo
    #(.width_p(flit_width_p)
     ) req_out_fifo
-    (.clk_i  (clk_i)
-    ,.reset_i(reset_i)
+    (.clk_i      (clk_i)
+    ,.reset_i    (reset_i)
 
-    ,.ready_o(req_out_ready)
-    ,.v_i    (req_out_v)
-    ,.data_i (req_out_data)
+    ,.ready_and_o(req_out_ready_and)
+    ,.v_i        (req_out_v)
+    ,.data_i     (req_out_data)
 
-    ,.v_o    (link_o_cast[i].v)
-    ,.data_o (link_o_cast[i].data)
-    ,.yumi_i (link_o_cast[i].v & link_i_cast[i].ready_and_rev)
+    ,.v_o        (link_o_cast[i].v)
+    ,.data_o     (link_o_cast[i].data)
+    ,.yumi_i     (link_o_cast[i].v & link_i_cast[i].ready_and_rev)
     );
 
     logic [width_lp-1:0] data_gen, data_check;
@@ -128,7 +128,7 @@ module bsg_wormhole_router_test_node_master
     ) gen_out
     (.clk_i  (clk_i)
     ,.reset_i(reset_i)
-    ,.yumi_i (req_out_v & req_out_ready)
+    ,.yumi_i (req_out_v & req_out_ready_and)
     ,.o      (data_gen)
     );
 
@@ -157,7 +157,7 @@ module bsg_wormhole_router_test_node_master
     (.clk_i  (clk_i)
     ,.reset_i(reset_i)
     ,.clear_i(1'b0)
-    ,.up_i   (req_out_v & req_out_ready)
+    ,.up_i   (req_out_v & req_out_ready_and)
     ,.count_o(sent_o[i])
     );
 


### PR DESCRIPTION
## Summary

The majority of modules in `bsg_dataflow` contain improperly named ready signals. This PR primarily focuses on rectifying this by properly renaming them to the proper handshake type (mostly rv->& style) and updates the testing infrastructure to properly run at least with the environment set up on kk9.

Further, I have added a rudimentary Makefile at the scope of `testing/bsg_dataflow` to run all testbenches in the `bsg_dataflow` directory to easily verify syntax modifications. 

## Issue Fixed

Most of the testbenches have been outdated for a long time (relying on specific out-of-date version sets, missing compilation flags for assertions, running without proper automatic environment setup, etc) and therefore do not work out of the box. This PR aims to fix that (as well as updating handshake naming for clarity).

## Area

Mostly related to `bsg_dataflow` related modules, but more will come fixing the majority of the rest of `basejump_stl` (though the future PR's will focus mainly on directories that have incorrectly labelled handshake protocols).

## Verification

Makefile modification verification was done by verifying that the make commands actually began compilation, testbench and module change verification came from verifying that results of compilation and execution implied correctness.

`bsg_fifo_1r1w_large` and `bsg_fifo_1r1w_pseudo_large` still fail at the very end of compilation as there seems to be something wrong with the generation of a log file, but the test itself passes without assertion or compilation error.

`bsg_parallel_in_serial_out_passthrough_arb` and `bsg_channel_tunnel`'s testbenches fail functionally, but these failures are not unique to this PR and they were failing before I made changes to the code. Verified by reverting all my code changes and fixing the specific makefiles to allow for it to run.