### PR TITLE
Updates testbenches for bsg_dataflow

### DIFF
--- a/testing/Makefile.sim
+++ b/testing/Makefile.sim
@@ -1,3 +1,7 @@
+## To be included in other makefiles, pass arguments via
+## setting scan_params and set files by setting BSG_*_FILES
+
+## Environment Setup
 
 export BSG_CADENV_DIR = $(abspath .)/../../../../bsg_cadenv
 

--- a/testing/Makefile.sim
+++ b/testing/Makefile.sim
@@ -3,9 +3,8 @@
 
 ## Environment Setup
 
-export BSG_CADENV_DIR = $(abspath .)/../../../../bsg_cadenv
-
-include $(BSG_CADENV_DIR)/cadenv.mk
+TOP ?= $(shell git rev-parse --show-toplevel)
+BSG_CADENV_DIR ?= $(TOP)/../bsg_cadenv
 
 ##########
 # settings for Xilinx Vivado

--- a/testing/Makefile.sim
+++ b/testing/Makefile.sim
@@ -21,11 +21,13 @@ BSG_IP_CORES_SIM_CLEAN_FILES = xvlog* xelab* webtalk* xsim* *.wdb .Xil
 
 ALL_FILES = $(foreach x,$(BSG_MISC_FILES),$(TOP)/bsg_misc/$(x))     \
               $(foreach x,$(BSG_ASYNC_FILES),$(TOP)/bsg_async/$(x)) \
+              $(foreach x,$(BSG_NOC_FILES),$(TOP)/bsg_noc/$(x)) \
               $(foreach x,$(BSG_FSB_FILES),$(TOP)/bsg_fsb/$(x))     \
               $(foreach x,$(BSG_MEM_FILES),$(TOP)/bsg_mem/$(x))     \
               $(foreach x,$(BSG_GUTS_FILES),$(TOP)/bsg_guts/$(x))   \
               $(foreach x,$(BSG_COMM_LINK_FILES),$(TOP)/bsg_comm_link/$(x)) \
               $(foreach x,$(BSG_DATAFLOW_FILES),$(TOP)/bsg_dataflow/$(x))   \
+              $(foreach x,$(ADDITIONAL_FILES),./$(x))                       \
               $(foreach x,$(BSG_TEST_FILES),$(TOP)/bsg_test/$(x))           \
               $(foreach x,$(BSG_TESTME_FILES),$(BSG_TESTME_DIR)/$(x))       \
               $(TEST_MAIN)
@@ -57,5 +59,5 @@ run.%:
   
 clean:
 	@echo removing outfile
-	rm -f outfile
+	rm -f outfile output.log
 	rm -rf $(BSG_IP_CORES_SIM_CLEAN_FILES)

--- a/testing/Makefile.sim
+++ b/testing/Makefile.sim
@@ -1,11 +1,16 @@
+
+export BSG_CADENV_DIR = $(abspath .)/../../../../bsg_cadenv
+
+include $(BSG_CADENV_DIR)/cadenv.mk
+
 ##########
 # settings for Xilinx Vivado
 BSG_IP_CORES_COMP = xvlog --sv
-BSG_IP_CORES_ELAB = xelab -debug typical -s top_sim
+BSG_IP_CORES_ELAB = xelab -debug typical -s top_sim -timescale=1ps/1ps
 BSG_IP_CORES_SIM  = xsim --runall top_sim
 BSG_IP_CORES_SIM_DEFINE_PARAM =-d@
 BSG_IP_CORES_SIM_INCLUDE_DIRS = -i $(TOP)/bsg_test -i $(TOP)/bsg_misc -i $(TOP)/bsg_dataflow
-BSG_IP_CORES_SIM_CLEAN_FILES = xvlog* xelab* webtalk* xsim* *.wdb
+BSG_IP_CORES_SIM_CLEAN_FILES = xvlog* xelab* webtalk* xsim* *.wdb .Xil
 #
 ##########
 

--- a/testing/Makefile.sim
+++ b/testing/Makefile.sim
@@ -6,6 +6,8 @@
 TOP ?= $(shell git rev-parse --show-toplevel)
 BSG_CADENV_DIR ?= $(TOP)/../bsg_cadenv
 
+include $(BSG_CADENV_DIR)/cadenv.mk
+
 ##########
 # settings for Xilinx Vivado
 BSG_IP_CORES_COMP = xvlog --sv

--- a/testing/bsg_dataflow/Makefile
+++ b/testing/bsg_dataflow/Makefile
@@ -8,7 +8,7 @@
 TEST_DIRS = $(wildcard ./*/)
 
 all:
-	$(foreach x,$(TEST_DIRS), cd $(x) && make && cd ../;)
+	$(foreach x,$(TEST_DIRS), $(MAKE) -C $(x);)
 
 clean:
-	$(foreach x,$(TEST_DIRS), cd $(x) && make clean && cd ../;)
+	$(foreach x,$(TEST_DIRS), $(MAKE) -C $(x) clean;)

--- a/testing/bsg_dataflow/Makefile
+++ b/testing/bsg_dataflow/Makefile
@@ -1,0 +1,14 @@
+# High Level Makefile
+# 
+# This makefile runs all other makefiles within one level of
+# scope of itself
+#
+# Brenden Page 11/19/2022
+
+TEST_DIRS = $(wildcard ./*/)
+
+all:
+	$(foreach x,$(TEST_DIRS), cd $(x) && make && cd ../;)
+
+clean:
+	$(foreach x,$(TEST_DIRS), cd $(x) && make clean && cd ../;)

--- a/testing/bsg_dataflow/bsg_channel_narrow/Makefile
+++ b/testing/bsg_dataflow/bsg_channel_narrow/Makefile
@@ -29,13 +29,14 @@ TEST_MAIN   = test_bsg.v
 TEST_MODULE = test_bsg
 
 # this is a list of all variables you want to vary for the simulation
-scan_params = WIDTH_IN_P WIDTH_OUT_P
+scan_params = WIDTH_IN_P WIDTH_OUT_P BSG_NO_TIMESCALE
 
 # this is a list of all values for each variable in the scan_params list
 # note; if you leave out values for a variable, then the product of the
 # sets is null, and nothing will run.
 WIDTH_IN_P  = 1 2 3 4 5 8
 WIDTH_OUT_P = 1 2 3 4 5 8
+BSG_NO_TIMESCALE = 1
 ############################################################################
 
 include ../../Makefile.sim

--- a/testing/bsg_dataflow/bsg_channel_narrow/test_bsg.v
+++ b/testing/bsg_dataflow/bsg_channel_narrow/test_bsg.v
@@ -27,7 +27,7 @@ module test_bsg
                              ? (width_in_p / width_out_p)
                              : (width_in_p / width_out_p) + 1,
   parameter cycle_time_p = 20,
-  parameter reset_cycles_lo_p=0,
+  parameter reset_cycles_lo_p=1,
   parameter reset_cycles_hi_p=5
 );
 

--- a/testing/bsg_dataflow/bsg_channel_narrow/test_bsg.v
+++ b/testing/bsg_dataflow/bsg_channel_narrow/test_bsg.v
@@ -27,25 +27,27 @@ module test_bsg
                              ? (width_in_p / width_out_p)
                              : (width_in_p / width_out_p) + 1,
   parameter cycle_time_p = 20,
-  parameter reset_cycles_lo_p=1,
+  parameter reset_cycles_lo_p=0,
   parameter reset_cycles_hi_p=5
 );
 
   wire clk;
   wire reset;
 
-  bsg_nonsynth_clock_gen #(  .cycle_time_p(cycle_time_p)
-                          )  clock_gen
-                          (  .o(clk)
-                          );
+  bsg_nonsynth_clock_gen
+    #(.cycle_time_p(cycle_time_p))
+    clock_gen
+      (.o(clk));
     
-  bsg_nonsynth_reset_gen #(  .num_clocks_p     (1)
-                           , .reset_cycles_lo_p(reset_cycles_lo_p)
-                           , .reset_cycles_hi_p(reset_cycles_hi_p)
-                          )  reset_gen
-                          (  .clk_i        (clk) 
-                           , .async_reset_o(reset)
-                          );
+  bsg_nonsynth_reset_gen
+    #(.num_clocks_p     (1)
+     ,.reset_cycles_lo_p(reset_cycles_lo_p)
+     ,.reset_cycles_hi_p(reset_cycles_hi_p)
+     )
+    reset_gen
+     (.clk_i        (clk) 
+     ,.async_reset_o(reset)
+     );
 
   initial
   begin
@@ -126,18 +128,18 @@ module test_bsg
                        );
 
          temp = (test_output_data_0 ==
-                 width_out_lp ' (test_input_data >> (width_out_lp*(divisions_lp - count_r - 1))));
+                 width_out_p ' (test_input_data >> (width_out_p*(divisions_p - count_r - 1))));
 
          assert(temp)
            else $error("2 msb_to_lsb_data: mismatch on input %x ", test_input_data
                        , "division %x", count_r);
 
-         temp = (test_output_deque_1 == (count_r == divisions_lp-1));
+         temp = (test_output_deque_1 == (count_r == divisions_p-1));
          assert(temp)
            else $error("3 lsb_to_msb_deque: mismatch on input %x ", test_input_data
                        , "division %x", count_r);
 
-         temp = (test_output_deque_0 == (count_r == divisions_lp-1));
+         temp = (test_output_deque_0 == (count_r == divisions_p-1));
          assert(temp)
           else $error("4 msb_to_lsb_deque: mismatch on input %x ", test_input_data
                          , "division %x", count_r);

--- a/testing/bsg_dataflow/bsg_channel_tunnel/Makefile
+++ b/testing/bsg_dataflow/bsg_channel_tunnel/Makefile
@@ -17,10 +17,10 @@ BSG_TESTME_DIR      =   $(TOP)/bsg_dataflow
 BSG_MISC_FILES      =   bsg_defines.v bsg_counter_up_down.v bsg_counter_up_down_variable.v bsg_counter_clear_up.v  bsg_round_robin_arb.v  bsg_crossbar_o_by_i.v  bsg_circular_ptr.v bsg_decode_with_v.v bsg_decode.v bsg_mux_one_hot.v bsg_cycle_counter.v
 BSG_ASYNC_FILES     =
 BSG_COMM_LINK_FILES =
-BSG_DATAFLOW_FILES  = bsg_channel_tunnel_in.v bsg_channel_tunnel_out.v  bsg_round_robin_n_to_1.v bsg_1_to_n_tagged_fifo.v bsg_1_to_n_tagged.v bsg_fifo_1r1w_small.v bsg_fifo_tracker.v
+BSG_DATAFLOW_FILES  = bsg_channel_tunnel_in.v bsg_channel_tunnel_out.v  bsg_round_robin_n_to_1.v bsg_1_to_n_tagged_fifo.v bsg_1_to_n_tagged.v bsg_fifo_1r1w_small.v bsg_fifo_tracker.v bsg_fifo_1r1w_small_unhardened.v
 BSG_FSB_FILES       =
 BSG_GUTS_FILES      =
-BSG_MEM_FILES       = bsg_mem_1r1w.v
+BSG_MEM_FILES       = bsg_mem_1r1w.v bsg_mem_1r1w_synth.v
 
 BSG_TEST_FILES      =  bsg_nonsynth_reset_gen.v \
                        bsg_nonsynth_clock_gen.v \
@@ -40,6 +40,8 @@ LG_CREDIT_DECIMATION_P = 0 1 2 3
 USE_PSEUDO_LARGE_FIFO_P = 0 1
 # whether to have receive rates; or 2^n declining receive rates on each channel
 ASYMMETRIC_P = 0
+# Synthesis option
+# BSG_NO_TIMESCALE = 1
 ############################################################################
 
 # this is a list of all variables you want to vary for the simulation

--- a/testing/bsg_dataflow/bsg_channel_tunnel/test_bsg.v
+++ b/testing/bsg_dataflow/bsg_channel_tunnel/test_bsg.v
@@ -91,20 +91,20 @@ module test_bsg
             (.clk_i   (clk)
              ,.reset_i(reset)
              ,.multi_data_i (multi_data [i])
-             ,.multi_valid_i(multi_valid[i])
+             ,.multi_v_i(multi_valid[i])
              ,.multi_yumi_o (multi_yumi [i])
 
              ,.multi_data_o (multi_data [!i])
-             ,.multi_valid_o(multi_valid[!i])
+             ,.multi_v_o(multi_valid[!i])
              ,.multi_yumi_i (multi_yumi [!i])
 
              //             AB  I/O
              ,.data_i (data [i][0])
-             ,.valid_i(valid[i][0])
+             ,.v_i(valid[i][0])
              ,.yumi_o (yumi [i][0])
 
              ,.data_o (data [i][1])
-             ,.valid_o(valid[i][1])
+             ,.v_o(valid[i][1])
              ,.yumi_i (yumi [i][1])
              );
      end
@@ -183,6 +183,7 @@ module test_bsg
                   bsg_counter_up_down
                       #(.max_val_p({ 1'b0, { width_p {1'b1} }} )
                        ,.init_val_p( (i<<16)+i)
+                       ,.max_step_p(1'b1)
                        ) ctr
                       (.clk_i(clk)
                        ,.reset_i(reset   )

--- a/testing/bsg_dataflow/bsg_compare_and_swap/Makefile
+++ b/testing/bsg_dataflow/bsg_compare_and_swap/Makefile
@@ -7,6 +7,8 @@
 #
 # Edited to test bsg_thermometer_count.v
 # Bandhav Veluri 6/24/2015
+# Edited to work with Makefile.sim
+# Brenden Page 11/21/2022
 
 TOP = ../../..
 
@@ -29,9 +31,9 @@ TEST_MAIN   = test_bsg.v
 TEST_MODULE = test_bsg
 
 # this is a list of all variables you want to vary for the simulation
-scan_params  = WIDTH_P T_P # first two params here
-scan_params1 = $(scan_params) BITS_P
-scan_params2 = $(scan_params1) COND_SWAP_ON_EQUAL_P
+scan_params  = WIDTH_P T_P BITS_P COND_SWAP_ON_EQUAL_P # first two params here
+# scan_params1 = $(scan_params) BITS_P
+# scan_params2 = $(scan_params1) COND_SWAP_ON_EQUAL_P
 
 # this is a list of all values for each variable in the scan_params list
 # note; if you leave out values for a variable, then the product of the
@@ -40,56 +42,5 @@ WIDTH_P              = 1 3
 T_P                  = 0 1 2
 BITS_P               = 1 2 3
 COND_SWAP_ON_EQUAL_P = 0 1 
-############################################################################
 
-############################# SIMULATOR COMMANDS ###########################
-BSG_IP_CORES_COMP = vlog -sv -mfcu -work $(TOP)/work \
-                      +incdir+$(TOP)/bsg_test \
-                      +incdir+$(TOP)/bsg_misc $(ALL_FILES) -quiet
-BSG_IP_CORES_SIM  = vsim -batch -lib $(TOP)/work $(TEST_MODULE) -do "run -all; quit -d"
-#BSG_IP_CORES_SIM  = vsim -i -lib $(TOP)/work $(TEST_MODULE) -do "do wave.do; run -all"
-############################################################################
-
-
-
-
-ALL_FILES = $(foreach x,$(BSG_MISC_FILES),$(TOP)/bsg_misc/$(x)) \
-              $(foreach x,$(BSG_ASYNC_FILES),$(TOP)/bsg_async/$(x)) \
-              $(foreach x,$(BSG_FSB_FILES),$(TOP)/bsg_fsb/$(x)) \
-              $(foreach x,$(BSG_GUTS_FILES),$(TOP)/bsg_guts/$(x)) \
-              $(foreach x,$(BSG_COMM_LINK_FILES),$(TOP)/bsg_comm_link/$(x)) \
-              $(foreach x,$(BSG_DATAFLOW_FILES),$(TOP)/bsg_dataflow/$(x)) \
-              $(foreach x,$(BSG_TEST_FILES),$(TOP)/bsg_test/$(x)) \
-              $(foreach x,$(BSG_TESTME_FILES),$(BSG_TESTME_DIR)/$(x)) \
-              $(TEST_MAIN)
-
-# function that generates a string for each combination of the parameters;
-# spaces separated by "@" signs.
-bsg_param_scan = $(if $(1),$(foreach v__,$($(firstword $(1))),\
-                    $(call bsg_param_scan,$(filter-out $(firstword $(1)),\
-                    $(1)),$(2),$(3),$(4)@$(2)$(firstword $(1))$(3)$(v__))),\
-                    $(4))
-
-# this takes the parameters and creates a set of make targets, one for every 
-# combination of the parameters
-commands  = $(call bsg_param_scan,$(scan_params),+define+,=)
-commands1 = $(call bsg_param_scan,$(scan_params1),+define+,=)
-commands2 = $(call bsg_param_scan,$(scan_params2),+define+,=)
-
-$(warning bsg_param_scan: $(commands2))
-
-
-# default rule: run all of the targets.
-all: initial $(foreach x,$(commands2),run.$(x))
-
-# this runs an individual target
-# we replace the @ with a space so that the parameters are used as 
-# command line options
-
-run.%:
-	$(BSG_IP_CORES_COMP) $(subst @, ,$*)
-	$(BSG_IP_CORES_SIM) >> outfile
-  
-initial:
-	@echo removing outfile
-	rm -f outfile
+include ../../Makefile.sim

--- a/testing/bsg_dataflow/bsg_compare_and_swap/test_bsg.v
+++ b/testing/bsg_dataflow/bsg_compare_and_swap/test_bsg.v
@@ -24,7 +24,7 @@ module test_bsg
   parameter b_p                  = (`T_P - `BITS_P + 1),
   parameter cond_swap_on_equal_p = `COND_SWAP_ON_EQUAL_P,
   parameter cycle_time_p = 20,
-  parameter reset_cycles_lo_p=0,
+  parameter reset_cycles_lo_p=1,
   parameter reset_cycles_hi_p=5
 );
 

--- a/testing/bsg_dataflow/bsg_compare_and_swap/test_bsg.v
+++ b/testing/bsg_dataflow/bsg_compare_and_swap/test_bsg.v
@@ -1,8 +1,3 @@
-`define WIDTH_P              2
-`define T_P                  1
-`define BITS_P               1 // no. of bits included starting from T_P
-`define COND_SWAP_ON_EQUAL_P 0
-
 /**************************** TEST RATIONALE *******************************
 
 1. STATE SPACE
@@ -29,26 +24,27 @@ module test_bsg
   parameter b_p                  = (`T_P - `BITS_P + 1),
   parameter cond_swap_on_equal_p = `COND_SWAP_ON_EQUAL_P,
   parameter cycle_time_p = 20,
-  parameter reset_cycles_lo_p=1,
+  parameter reset_cycles_lo_p=0,
   parameter reset_cycles_hi_p=5
 );
 
   wire clk;
   wire reset;
   
-  bsg_nonsynth_clock_gen #(  .cycle_time_p(cycle_time_p)
-                          )  clock_gen
-                          (  .o(clk)
-                          );
-    
-  bsg_nonsynth_reset_gen #(  .num_clocks_p     (1)
-                           , .reset_cycles_lo_p(reset_cycles_lo_p)
-                           , .reset_cycles_hi_p(reset_cycles_hi_p)
-                          )  reset_gen
-                          (  .clk_i        (clk) 
-                           , .async_reset_o(reset)
-                          );
-                          
+  bsg_nonsynth_clock_gen
+    #(.cycle_time_p(cycle_time_p))
+    clock_gen (.o(clk));
+  
+  bsg_nonsynth_reset_gen
+    #(.num_clocks_p     (1)
+     ,.reset_cycles_lo_p(reset_cycles_lo_p)
+     ,.reset_cycles_hi_p(reset_cycles_hi_p)
+     )
+    reset_gen
+     (.clk_i        (clk)
+     ,.async_reset_o(reset)
+     );
+
   initial
   begin
     $display(  "\n\n\n"
@@ -68,14 +64,13 @@ module test_bsg
   		            , width_p, t_p, b_p, cond_swap_on_equal_p);
           $finish;
         end
-    
   end
-    
+
   logic [1:0] [width_p-1:0] test_input, test_output;
   logic test_input_swap, test_output_swapped, finish_r;
   
   always_ff @(posedge clk)
-  begin          
+  begin
     if(reset)
       begin
         test_input[0]   <= width_p ' (0);    // initiate with 00..0
@@ -102,26 +97,23 @@ module test_bsg
   
   always_ff @(posedge clk)
   begin
-    if(!reset)  
-      begin
-        assert(test_output_swapped == ((test_input[0][t_p:b_p] > test_input[1][t_p:b_p])
-                                       | ((cond_swap_on_equal_p & test_input_swap)
-                                          & (test_input[0] == test_input[1])
-                                         )
+    assert(reset || (test_output_swapped == ((test_input[0][t_p:b_p] > test_input[1][t_p:b_p])
+                                    | ((cond_swap_on_equal_p & test_input_swap)
+                                      & (test_input[0] == test_input[1])
                                       )
-              )
-          else $error("swapped_o: mismatch on input %x", test_input);
+                                  ))
+          )
+      else $error("swapped_o: mismatch on input %x", test_input);
 
-        assert(test_output == ((test_input[0][t_p:b_p] > test_input[1][t_p:b_p])
-                               | ((cond_swap_on_equal_p & test_input_swap)
-                                  & (test_input[0] == test_input[1])
-                                 )
+    assert(reset || (test_output == ((test_input[0][t_p:b_p] > test_input[1][t_p:b_p])
+                            | ((cond_swap_on_equal_p & test_input_swap)
+                              & (test_input[0] == test_input[1])
                               )
-                              ? {test_input[0], test_input[1]}
-                              : test_input
-              )
-          else $error("data_o: mismatch on input %x", test_input);
-      end
+                          )
+                          ? {test_input[0], test_input[1]}
+                          : test_input)
+          )
+      else $error("data_o: mismatch on input %x", test_input);
   end
 
  // generate DUT only if params are compatible

--- a/testing/bsg_dataflow/bsg_fifo_1r1w_large/Makefile
+++ b/testing/bsg_dataflow/bsg_fifo_1r1w_large/Makefile
@@ -20,7 +20,8 @@ IO_MASTER_1_PERIOD =   2
 CORE_1_PERIOD      =   1
 endif
 
-export BSG_CADENV_DIR = $(abspath .)/../../../../bsg_cadenv
+TOP ?= $(shell git rev-parse --show-toplevel)
+BSG_CADENV_DIR ?= $(TOP)/../bsg_cadenv
 
 include $(BSG_CADENV_DIR)/cadenv.mk
 

--- a/testing/bsg_dataflow/bsg_fifo_1r1w_large/Makefile
+++ b/testing/bsg_dataflow/bsg_fifo_1r1w_large/Makefile
@@ -20,14 +20,9 @@ IO_MASTER_1_PERIOD =   2
 CORE_1_PERIOD      =   1
 endif
 
+export BSG_CADENV_DIR = $(abspath .)/../../../../bsg_cadenv
 
-export LM_LICENSE_FILE = 27000@bbfs-00.calit2.net
-export SYNOPSYS_DIR=/gro/cad/synopsys
-export VCS_RELEASE=vcs/G-2012.09-SP1
-export VCS_HOME = $(SYNOPSYS_DIR)/$(VCS_RELEASE)
-export VCS_BIN = $(VCS_HOME)/bin
-export DVE_BIN = $(VCS_HOME)/bin
-export DC_RELEASE    = syn/G-2012.06-SP5-4
+include $(BSG_CADENV_DIR)/cadenv.mk
 
 TOP = ../../..
 
@@ -43,7 +38,7 @@ BSG_COMM_LINK_FILES =
 BSG_DATAFLOW_FILES  =  bsg_fifo_1r1w_large.v bsg_fifo_1rw_large.v bsg_round_robin_2_to_2.v bsg_two_fifo.v bsg_round_robin_n_to_1.v bsg_serial_in_parallel_out.v
 BSG_FSB_FILES       =
 BSG_GUTS_FILES      =
-BSG_MEM_FILES       = bsg_mem_1r1w.v bsg_mem_1rw_sync.v
+BSG_MEM_FILES       = bsg_mem_1r1w.v bsg_mem_1rw_sync.v bsg_mem_1r1w_synth.v bsg_mem_1rw_sync_synth.v
 
 BSG_TEST_FILES =  bsg_nonsynth_reset_gen.v bsg_nonsynth_clock_gen.v
 
@@ -75,7 +70,7 @@ all: $(ALL_ALL_ALL_ALL)
 log@%: $(ALL_FILES)
 	@echo $*
 	- rm -rf simv csrc simv.daidir
-	$(VCS_BIN)/vcs $(DESIGNWARE_FLAGS) -PP -notice -full64 +lint=all,noVCDE +v2k -sverilog -timescale=100ps/10ps $(filter-out small-clean,$^) $(subst @, ,$*) +vcs+loopreport +define+BSG_IP_CORES_UNIT_TEST
+	$(VCS_BIN)/vcs $(DESIGNWARE_FLAGS) -PP -notice -full64 -assert svaext +lint=all,noVCDE +v2k -sverilog -timescale=100ps/10ps $(filter-out small-clean,$^) $(subst @, ,$*) +vcs+loopreport +define+BSG_IP_CORES_UNIT_TEST
 	./simv # | tee $@
 
 log@%: small_clean
@@ -89,6 +84,7 @@ dve:
 clean:
 	-rm log@*
 	- rm -rf simv csrc simv.daidir DVEfiles vcdplus.vpd ucli.key
+	-rm vc_hdrs.h
 
 small-clean:
 	- rm -rf simv csrc simv.daidir

--- a/testing/bsg_dataflow/bsg_fifo_1r1w_large/Makefile
+++ b/testing/bsg_dataflow/bsg_fifo_1r1w_large/Makefile
@@ -25,8 +25,6 @@ BSG_CADENV_DIR ?= $(TOP)/../bsg_cadenv
 
 include $(BSG_CADENV_DIR)/cadenv.mk
 
-TOP = ../../..
-
 DESIGNWARE_DIR = $(SYNOPSYS_DIR)/$(DC_RELEASE)/dw/sim_ver
 DESIGNWARE_FLAGS = -y $(DESIGNWARE_DIR) +incdir+$(DESIGNWARE_DIR) +incdir+$(TOP)/bsg_test +incdir+$(TOP)/bsg_misc +libext+.v
 

--- a/testing/bsg_dataflow/bsg_fifo_1r1w_large/test_bsg_fifo_1r1w_large.v
+++ b/testing/bsg_dataflow/bsg_fifo_1r1w_large/test_bsg_fifo_1r1w_large.v
@@ -46,6 +46,7 @@ module testbench;
       ,.reset_i(reset)
       ,.add_i  (pattern_bit == (pattern_width_lp-1))
       ,.o      (test_pattern)
+      ,.n_o     ()
       );
 
    // cycles through each bit of the battern
@@ -56,6 +57,7 @@ module testbench;
       ,.reset_i(reset)
       ,.add_i  (1'b1)
       ,.o      (pattern_bit)
+      ,.n_o     ()
       );
 
    assign test_valid_in = test_pattern[pattern_bit];
@@ -76,6 +78,7 @@ module testbench;
     ,.reset_i(reset)
     ,.add_i  (test_valid_in & test_ready_out)
     ,.o      (test_data_in)
+    ,.n_o     ()
     );
 
 
@@ -113,6 +116,7 @@ module testbench;
     ,.reset_i(reset)
     ,.add_i  (test_yumi_in)
     ,.o      (test_data_check)
+    ,.n_o     ()
     );
 
    always_ff @(posedge clk)

--- a/testing/bsg_dataflow/bsg_fifo_1r1w_pseudo_large/Makefile
+++ b/testing/bsg_dataflow/bsg_fifo_1r1w_pseudo_large/Makefile
@@ -20,14 +20,9 @@ IO_MASTER_1_PERIOD =   2
 CORE_1_PERIOD      =   1
 endif
 
+export BSG_CADENV_DIR = $(abspath .)/../../../../bsg_cadenv
 
-export LM_LICENSE_FILE = 27000@bbfs-00.calit2.net
-export SYNOPSYS_DIR=/gro/cad/synopsys
-export VCS_RELEASE=vcs/G-2012.09-SP1
-export VCS_HOME = $(SYNOPSYS_DIR)/$(VCS_RELEASE)
-export VCS_BIN = $(VCS_HOME)/bin
-export DVE_BIN = $(VCS_HOME)/bin
-export DC_RELEASE    = syn/G-2012.06-SP5-4
+include $(BSG_CADENV_DIR)/cadenv.mk
 
 TOP = ../../..
 
@@ -43,7 +38,7 @@ BSG_COMM_LINK_FILES =
 BSG_DATAFLOW_FILES  =  bsg_fifo_1r1w_pseudo_large.v bsg_fifo_1rw_large.v bsg_two_fifo.v bsg_round_robin_n_to_1.v 
 BSG_FSB_FILES       =
 BSG_GUTS_FILES      =
-BSG_MEM_FILES       = bsg_mem_1r1w.v bsg_mem_1rw_sync.v
+BSG_MEM_FILES       = bsg_mem_1r1w.v bsg_mem_1rw_sync.v bsg_mem_1r1w_synth.v bsg_mem_1rw_sync_synth.v
 
 BSG_TEST_FILES =  bsg_nonsynth_reset_gen.v bsg_nonsynth_clock_gen.v
 
@@ -75,7 +70,7 @@ all: $(ALL_ALL_ALL_ALL)
 log@%: $(ALL_FILES)
 	@echo $*
 	- rm -rf simv csrc simv.daidir
-	$(VCS_BIN)/vcs $(DESIGNWARE_FLAGS) -PP -notice -full64 +lint=all,noVCDE +v2k -sverilog -timescale=100ps/10ps $(filter-out small-clean,$^) $(subst @, ,$*) +vcs+loopreport +define+BSG_IP_CORES_UNIT_TEST
+	$(VCS_BIN)/vcs $(DESIGNWARE_FLAGS) -PP -notice -full64 -assert svaext +lint=all,noVCDE +v2k -sverilog -timescale=100ps/10ps $(filter-out small-clean,$^) $(subst @, ,$*) +vcs+loopreport +define+BSG_IP_CORES_UNIT_TEST
 	./simv # | tee $@
 
 log@%: small_clean
@@ -89,6 +84,7 @@ dve:
 clean:
 	-rm log@*
 	- rm -rf simv csrc simv.daidir DVEfiles vcdplus.vpd ucli.key
+	-rm vc_hdrs.h
 
 small-clean:
 	- rm -rf simv csrc simv.daidir

--- a/testing/bsg_dataflow/bsg_fifo_1r1w_pseudo_large/test_bsg_fifo_1r1w_pseudo_large.v
+++ b/testing/bsg_dataflow/bsg_fifo_1r1w_pseudo_large/test_bsg_fifo_1r1w_pseudo_large.v
@@ -49,6 +49,7 @@ module testbench;
       ,.reset_i(reset)
       ,.add_i  (pattern_bit == (pattern_width_lp-1))
       ,.o      (test_pattern)
+      ,.n_o    ()
       );
 
    // cycles through each bit of the battern
@@ -59,6 +60,7 @@ module testbench;
       ,.reset_i(reset)
       ,.add_i  (1'b1)
       ,.o      (pattern_bit)
+      ,.n_o    ()
       );
 
    assign test_valid_in = test_pattern[pattern_bit];
@@ -79,6 +81,7 @@ module testbench;
     ,.reset_i(reset)
     ,.add_i  (test_valid_in & test_ready_out)
     ,.o      (test_data_in)
+    ,.n_o    ()
     );
 
 
@@ -121,6 +124,7 @@ module testbench;
     ,.reset_i(reset)
     ,.add_i  (test_yumi_in)
     ,.o      (test_data_check)
+    ,.n_o    ()
     );
 
    always_ff @(posedge clk)

--- a/testing/bsg_dataflow/bsg_fifo_bypass/Makefile
+++ b/testing/bsg_dataflow/bsg_fifo_bypass/Makefile
@@ -1,5 +1,9 @@
 export BASEJUMP_STL_DIR = ../../..
 
+export BSG_CADENV_DIR = $(abspath .)/../../../../bsg_cadenv
+
+include $(BSG_CADENV_DIR)/cadenv.mk
+
 INCDIR = +incdir+$(BASEJUMP_STL_DIR)/bsg_misc
 INCDIR += +incdir+$(BASEJUMP_STL_DIR)/bsg_noc
 INCDIR += +incdir+$(BASEJUMP_STL_DIR)/bsg_dataflow
@@ -20,5 +24,7 @@ clean:
 	rm -rf DVEfiles
 	rm -rf csrc
 	rm -rf simv.daidir simv.vdb
-	rm -f ucli.key vcdplus.vpd simv cm.log *.tar.gz
+	rm -f ucli.key vcdplus.vpd simv cm.log *.tar.gz vc_hdrs.h
 	rm -rf trace.tr
+	rm -rf cov.vdb
+	rm -rf urgReport

--- a/testing/bsg_dataflow/bsg_fifo_bypass/Makefile
+++ b/testing/bsg_dataflow/bsg_fifo_bypass/Makefile
@@ -1,6 +1,7 @@
 export BASEJUMP_STL_DIR = ../../..
 
-export BSG_CADENV_DIR = $(abspath .)/../../../../bsg_cadenv
+TOP ?= $(shell git rev-parse --show-toplevel)
+BSG_CADENV_DIR ?= $(TOP)/../bsg_cadenv
 
 include $(BSG_CADENV_DIR)/cadenv.mk
 

--- a/testing/bsg_dataflow/bsg_fifo_bypass/sv.include
+++ b/testing/bsg_dataflow/bsg_fifo_bypass/sv.include
@@ -9,4 +9,5 @@ $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1r1w.v
 $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1r1w_synth.v
 $BASEJUMP_STL_DIR/bsg_test/bsg_nonsynth_clock_gen.v
 $BASEJUMP_STL_DIR/bsg_test/bsg_nonsynth_reset_gen.v
+$BASEJUMP_STL_DIR/bsg_dataflow/bsg_two_fifo.v
 testbench.v

--- a/testing/bsg_dataflow/bsg_fifo_reorder/Makefile
+++ b/testing/bsg_dataflow/bsg_fifo_reorder/Makefile
@@ -7,7 +7,7 @@ INCDIR = +incdir+$(BASEJUMP_STL_DIR)/bsg_misc
 
 sim:
 	vcs +v2k -R +lint=all,noSVA-UA,noSVA-NSVU,noVCDE -sverilog -full64 -f sv.include $(INCDIR)\
-		-debug_pp -timescale=1ps/1ps +vcs+vcdpluson
+		-debug_pp -timescale=1ps/1ps +vcs+vcdpluson -assert svaext
 
 
 dve:
@@ -18,4 +18,4 @@ clean:
 	rm -rf DVEfiles
 	rm -rf csrc
 	rm -rf simv.daidir simv.vdb
-	rm -f ucli.key vcdplus.vpd simv cm.log *.tar.gz
+	rm -f ucli.key vcdplus.vpd simv cm.log *.tar.gz vc_hdrs.h

--- a/testing/bsg_dataflow/bsg_parallel_in_serial_out/Makefile
+++ b/testing/bsg_dataflow/bsg_parallel_in_serial_out/Makefile
@@ -22,7 +22,7 @@ run: $(RUNS)
 run-%:
 	mkdir run-$*;
 	cd run-$* && \
-        $(VCS_BIN)/vcs -full64 -sverilog -timescale=1ps/1ps -f $(TOP_DIR)/filelist -debug_pp -R -top bsg_parallel_in_serial_out_tester +vcs+vcdpluson \
+        $(VCS_BIN)/vcs -full64 -sverilog -timescale=1ps/1ps -assert svaext -f $(TOP_DIR)/filelist -debug_pp -R -top bsg_parallel_in_serial_out_tester +vcs+vcdpluson \
         -pvalue+top_master_clk_period_p=$(word 1, $(subst -, ,$*)) \
         -pvalue+top_piso_clk_period_p=$(word 2, $(subst -, ,$*)) \
         -pvalue+top_client_clk_period_p=$(word 3, $(subst -, ,$*)) \

--- a/testing/bsg_dataflow/bsg_parallel_in_serial_out_passthrough_arb/sv.include
+++ b/testing/bsg_dataflow/bsg_parallel_in_serial_out_passthrough_arb/sv.include
@@ -1,4 +1,6 @@
 $BASEJUMP_STL_DIR/bsg_noc/bsg_noc_pkg.v
+$BASEJUMP_STL_DIR/bsg_noc/bsg_mesh_router_pkg.v
+$BASEJUMP_STL_DIR/bsg_noc/bsg_mesh_router_decoder_dor.v
 $BASEJUMP_STL_DIR/bsg_noc/bsg_mesh_router.v
 $BASEJUMP_STL_DIR/bsg_noc/bsg_mesh_router_buffered.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_mux_one_hot.v
@@ -11,6 +13,12 @@ $BASEJUMP_STL_DIR/bsg_dataflow/bsg_parallel_in_serial_out_passthrough.v
 $BASEJUMP_STL_DIR/bsg_dataflow/bsg_serial_in_parallel_out_passthrough.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_counter_clear_up_one_hot.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_dff_en.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_transpose.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_array_concentrate_static.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_concentrate_static.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_unconcentrate_static.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_arb_round_robin.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_scan.v
 $BASEJUMP_STL_DIR/bsg_test/bsg_nonsynth_clock_gen.v
 $BASEJUMP_STL_DIR/bsg_test/bsg_nonsynth_reset_gen.v
 testbench.v

--- a/testing/bsg_dataflow/bsg_serial_in_parallel_out_passthrough/sv.include
+++ b/testing/bsg_dataflow/bsg_serial_in_parallel_out_passthrough/sv.include
@@ -2,11 +2,15 @@
 $BASEJUMP_STL_DIR/bsg_dataflow/bsg_parallel_in_serial_out.v
 $BASEJUMP_STL_DIR/bsg_dataflow/bsg_serial_in_parallel_out_passthrough.v
 $BASEJUMP_STL_DIR/bsg_dataflow/bsg_two_fifo.v
+$BASEJUMP_STL_DIR/bsg_dataflow/bsg_one_fifo.v
 $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1r1w.v
 $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1r1w_synth.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_counter_clear_up_one_hot.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_dff_en.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_defines.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_counter_clear_up.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_mux.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_dff_reset.v
 $BASEJUMP_STL_DIR/bsg_test/bsg_nonsynth_clock_gen.v
 $BASEJUMP_STL_DIR/bsg_test/bsg_nonsynth_reset_gen.v
 testbench.v

--- a/testing/bsg_dataflow/bsg_serial_in_parallel_out_passthrough/testbench.v
+++ b/testing/bsg_dataflow/bsg_serial_in_parallel_out_passthrough/testbench.v
@@ -28,7 +28,7 @@ module testbench;
   logic in_v_lo, in_yumi_li;
 
   logic [wide_width_lp-1:0] out_data_li;
-  logic out_v_li, out_ready_lo;
+  logic out_v_li, out_ready_and_lo;
   logic [narrow_width_lp-1:0] out_data_lo;
   logic out_v_lo, out_ready_li;
 
@@ -49,7 +49,7 @@ module testbench;
 
   assign out_data_li = in_data_lo;
   assign out_v_li = in_v_lo;
-  assign in_yumi_li = out_ready_lo & out_v_li;
+  assign in_yumi_li = out_ready_and_lo & out_v_li;
 
   bsg_parallel_in_serial_out
    #(.width_p(narrow_width_lp), .els_p(els_lp))
@@ -59,7 +59,7 @@ module testbench;
 
      ,.data_i(out_data_li)
      ,.valid_i(out_v_li)
-     ,.ready_o(out_ready_lo)
+     ,.ready_and_o(out_ready_and_lo)
 
      ,.data_o(out_data_lo)
      ,.valid_o(out_v_lo)


### PR DESCRIPTION
Refactored testbench infrastructure update from https://github.com/bespoke-silicon-group/basejump_stl/pull/610

## Summary

Fixes testbenches and makefiles (allows them to compile and run) for all existing dataflow tests.

Adds `bsg_dataflow` level makefile to run all make commands in directory (for easy syntax verification and directory-level clean commands)

## Issue Fixed

Previous infrastructure had not been updated in a number of years, leading to issues regarding compilation from updated module port lists and outdated tooling/non-automated tooling setup in Makefiles

## Verification

I have verified that all testbenches are properly run via using `make` on each subdirectory in `testing/bsg_dataflow`

`bsg_fifo_1r1w_large` and `bsg_fifo_1r1w_large` do not properly finish as they have log file errors I do not understand but the tests themselves run and pass

`bsg_parallel_in_serial_out_passthrough_arb` and `bsg_channel_tunnel` fail for reasons unknown but most likely for reasons outside the scope of this PR. 