### PR TITLE
Adding burst length input to nonsynth axi mem

### DIFF
--- a/bsg_test/bsg_nonsynth_axi_mem.v
+++ b/bsg_test/bsg_nonsynth_axi_mem.v
@@ -77,7 +77,7 @@ module bsg_nonsynth_axi_mem
     axi_bid_o = awid_r;
     axi_bresp_o = '0;
     axi_bvalid_o = 1'b0;
-    
+
     awaddr_n = awaddr_r;
     awid_n = awid_r;
 

--- a/bsg_test/bsg_nonsynth_axi_mem.v
+++ b/bsg_test/bsg_nonsynth_axi_mem.v
@@ -77,6 +77,9 @@ module bsg_nonsynth_axi_mem
     axi_bid_o = awid_r;
     axi_bresp_o = '0;
     axi_bvalid_o = 1'b0;
+    
+    awaddr_n = awaddr_r;
+    awid_n = awid_r;
 
     case (wr_state_r)
       WR_RESET: begin

--- a/bsg_test/bsg_nonsynth_axi_mem.v
+++ b/bsg_test/bsg_nonsynth_axi_mem.v
@@ -2,6 +2,8 @@
  *  bsg_nonsynth_axi_mem.v
  */
 
+`include "bsg_defines.v"
+
 module bsg_nonsynth_axi_mem
   #(parameter `BSG_INV_PARAM(axi_id_width_p)
     , parameter `BSG_INV_PARAM(axi_addr_width_p)
@@ -221,7 +223,7 @@ module bsg_nonsynth_axi_mem
       if ((wr_state_r == WR_WAIT_DATA) & axi_wvalid_i) begin
         for (integer i = 0; i < axi_strb_width_lp; i++) begin
           if (axi_wstrb_i[i]) begin
-            ram[wr_ram_idx][i*8+:8] = axi_wdata_i[i*8+:8];
+            ram[wr_ram_idx][i*8+:8] <= axi_wdata_i[i*8+:8];
           end
         end
       end


### PR DESCRIPTION
Adding nonsynth AXI memory from: https://github.com/black-parrot-hdk/zynq-parrot/pull/36.

The previous behavior is supported by passing a constant burst length into arlen/awlen. This is a nonsynth module so there are no PPA implications