### PR TITLE
Allowing multiple outstanding reads to a single dramsim3 channel to return at …

### DIFF
--- a/bsg_test/bsg_dramsim3.cpp
+++ b/bsg_test/bsg_dramsim3.cpp
@@ -36,9 +36,9 @@ public:
     static constexpr bool READ  = false;
 
     BSGDRAMSim3(int num_channels_p, char *config_p):
-        _read_done(num_channels_p, false),
+        _read_done(num_channels_p, 0),
         _read_done_addr(num_channels_p, 0),
-        _write_done(num_channels_p, false),
+        _write_done(num_channels_p, 0),
         _write_done_addr(num_channels_p, 0)
         {
 
@@ -54,9 +54,9 @@ public:
                 int ch = _memory_system->GetConfig()->AddressMapping(addr).channel;
                 pr_dbg("read_done called: ch=%d, addr=0x%010" PRIx64 "\n", ch, addr);
                 if (_read_done[ch]) {
-                    pr_dbg("ERROR: read done called twice in the same cycle. ch=%d\n", ch);
+                    pr_dbg("WARNING: read done called twice in the same cycle. ch=%d\n", ch);
                 }
-                _read_done[ch] = true;
+                _read_done[ch]++;
                 _read_done_addr[ch] = addr;
             };
 
@@ -150,8 +150,8 @@ public:
     ////////////////
     void clockTick() {
         for (int ch = 0; ch < _memory_system->GetConfig()->channels; ch++) {
-            _read_done[ch] = false;
-            _write_done[ch] = false;
+            if (_read_done[ch] > 0) _read_done[ch]--;
+            if (_write_done[ch] > 0) _write_done[ch]--;
         }
         _memory_system->ClockTick();
     }
@@ -171,11 +171,11 @@ public:
     // Query completed requests //
     //////////////////////////////
     bool getReadDone(int channel) const {
-        return _read_done[channel];
+        return _read_done[channel] > 0;
     }
 
     bool getWriteDone(int channel) const {
-        return _write_done[channel];
+        return _write_done[channel] > 0;
     }
 
     addr_t getReadDoneAddr(int channel) const {
@@ -189,9 +189,9 @@ public:
 
 private:
     std::unique_ptr<MemorySystem>       _memory_system;
-    std::vector<bool>   _read_done;
+    std::vector<uint8_t> _read_done;
     std::vector<addr_t> _read_done_addr;
-    std::vector<bool>   _write_done;
+    std::vector<uint8_t> _write_done;
     std::vector<addr_t> _write_done_addr;
 };
 


### PR DESCRIPTION
…once.

This reflects a DRAM controller which received multiple requests for a single address and returns them sequentially. Current behavior is to silently drop the second request in a monkey's paw form of coalescing.

You can expose this bug by modifying the testbench like so:

```
diff --git a/testing/bsg_test/bsg_nonsynth_dramsim3/hbm_trace_gen.py b/testing/bsg_test/bsg_nonsynth_dramsim3/hbm_trace_gen.py
index 9a2fdd8a..48a6d168 100644
--- a/testing/bsg_test/bsg_nonsynth_dramsim3/hbm_trace_gen.py
+++ b/testing/bsg_test/bsg_nonsynth_dramsim3/hbm_trace_gen.py
@@ -68,7 +68,7 @@ if __name__ == "__main__":
   tg = HBMTraceGen(addr_width_p)
   for i in range(n_strides):
     # stride is by column
-    tg.send(READ, start + i * stride)
-    tg.wait_cycles(500)
+    tg.send(READ, start)# + i * stride)
+    #tg.wait_cycles(500)
```

which will drop some number of duplicate requests

```
[petrisko@kk9 bsg_nonsynth_dramsim3]$ grep "req sent" vcs.log | wc -l
1000
[petrisko@kk9 bsg_nonsynth_dramsim3]$ grep "read done" vcs.log | wc -l
493
```