### PR TITLE
Dramsim3 multiple reads proper fix

### DIFF
--- a/bsg_test/bsg_dramsim3.cpp
+++ b/bsg_test/bsg_dramsim3.cpp
@@ -7,6 +7,8 @@
 #include <cassert>
 #include <cstdio>
 #include <inttypes.h>
+#include <deque>
+#define DEBUG
 
 #define __stringify(x)                          \
     #x
@@ -36,10 +38,8 @@ public:
     static constexpr bool READ  = false;
 
     BSGDRAMSim3(int num_channels_p, char *config_p):
-        _read_done(num_channels_p, false),
-        _read_done_addr(num_channels_p, 0),
-        _write_done(num_channels_p, false),
-        _write_done_addr(num_channels_p, 0)
+        _read_done_addr(num_channels_p, std::deque<addr_t>()),
+        _write_done_addr(num_channels_p, std::deque<addr_t>())
         {
 
             // construct path to the configuration file
@@ -53,19 +53,14 @@ public:
             auto read_done  = [this](uint64_t addr) {
                 int ch = _memory_system->GetConfig()->AddressMapping(addr).channel;
                 pr_dbg("read_done called: ch=%d, addr=0x%010" PRIx64 "\n", ch, addr);
-                if (_read_done[ch]) {
-                    pr_dbg("ERROR: read done called twice in the same cycle. ch=%d\n", ch);
-                }
-                _read_done[ch] = true;
-                _read_done_addr[ch] = addr;
+                _read_done_addr[ch].push_back(addr);
             };
 
             /* called when write completes */
             auto write_done = [this](uint64_t addr) {
                 int ch = _memory_system->GetConfig()->AddressMapping(addr).channel;
                 pr_dbg("write_done called: ch=%d, addr=0x%010" PRIx64 "\n", ch, addr);
-                _write_done[ch] = true;
-                _write_done_addr[ch] = addr;
+                _write_done_addr[ch].push_back(addr);
             };
 
             _memory_system = std::unique_ptr<MemorySystem>(new MemorySystem(config_file, output_dir, read_done, write_done));
@@ -150,8 +145,8 @@ public:
     ////////////////
     void clockTick() {
         for (int ch = 0; ch < _memory_system->GetConfig()->channels; ch++) {
-            _read_done[ch] = false;
-            _write_done[ch] = false;
+            if (!_read_done_addr[ch].empty()) _read_done_addr[ch].pop_front();
+            if (!_write_done_addr[ch].empty()) _write_done_addr[ch].pop_front();
         }
         _memory_system->ClockTick();
     }
@@ -171,28 +166,26 @@ public:
     // Query completed requests //
     //////////////////////////////
     bool getReadDone(int channel) const {
-        return _read_done[channel];
+        return !_read_done_addr[channel].empty();
     }
 
     bool getWriteDone(int channel) const {
-        return _write_done[channel];
+        return !_write_done_addr[channel].empty();
     }
 
     addr_t getReadDoneAddr(int channel) const {
-        return _read_done_addr[channel];
+        return _read_done_addr[channel].front();
     }
 
     addr_t getWriteDoneAddr(int channel) const {
-        return _write_done_addr[channel];
+        return _write_done_addr[channel].front();
     }
 
 
 private:
-    std::unique_ptr<MemorySystem>       _memory_system;
-    std::vector<bool>   _read_done;
-    std::vector<addr_t> _read_done_addr;
-    std::vector<bool>   _write_done;
-    std::vector<addr_t> _write_done_addr;
+    std::unique_ptr<MemorySystem>   _memory_system;
+    std::vector<std::deque<addr_t>> _read_done_addr;
+    std::vector<std::deque<addr_t>> _write_done_addr;
 };
 
 


### PR DESCRIPTION
Fixes bug Introduced by the bugfix in #619.

This PR adds a more general solution for multiple reads returning in the same cycle. For the dramsim3 controller, different addresses return in different cycles (I think? I couldn't find any guarantee that this is true), but requests to the same address return twice in the same cycle. The requesters are independent so they each expect a response. So this solution enqueues all reads to an in-order queue, which is drained at the verilog's convenience.

Changes are restricted to bsg_dramsim3.cpp to avoid modifications to dramsim3 code or bsg verilog