### PR TITLE
Update bsg_fsb_node_trace_replay.v

### DIFF
--- a/bsg_fsb/bsg_fsb_node_trace_replay.v
+++ b/bsg_fsb/bsg_fsb_node_trace_replay.v
@@ -171,6 +171,7 @@ module bsg_fsb_node_trace_replay
           end
      end
 
+   // synopsys translate_off
    // non-synthesizeable components
    always @(negedge clk_i)
      begin
@@ -245,5 +246,6 @@ module bsg_fsb_node_trace_replay
              endcase // case (op)
           end // if (instr_completed & ~reset_i & ~done_r)
      end // always @ (negedge clk_i)
+   // synopsys translate_on
 
 endmodule


### PR DESCRIPTION
Pragma for nonsynth region of fsb_node_trace_replay (used in bsg_tag_trace_replay)