### PR TITLE
Adding SURELOG to list of synthesis tools

### DIFF
--- a/bsg_misc/bsg_defines.v
+++ b/bsg_misc/bsg_defines.v
@@ -39,7 +39,7 @@
 `define BSG_INV_PARAM(param) param = -1
 `elsif YOSYS // Bare default parameters are incompatible as of 0.9
 `define BSG_INV_PARAM(param) param = "inv"
-`else // VIVADO, DC, VERILATOR, GENUS
+`else // VIVADO, DC, VERILATOR, GENUS, SURELOG
 `define BSG_INV_PARAM(param) param
 `endif
 
@@ -83,6 +83,8 @@
   `ifdef DC
   `define BSG_VIVADO_SYNTH_FAILS
   `elsif CDS_TOOL_DEFINE
+  `define BSG_VIVADO_SYNTH_FAILS
+  `elsif SURELOG
   `define BSG_VIVADO_SYNTH_FAILS
   `else
   `define BSG_VIVADO_SYNTH_FAILS this_module_is_not_synthesizeable_in_vivado


### PR DESCRIPTION
We could add this flag in preparation for -DSURELOG, or wait for it to be added upstream. Won't break anything in the meantime so I'd suggest merging early.