### PR TITLE
bsg_rom_param

### DIFF
--- a/bsg_test/bsg_rom_param.v
+++ b/bsg_test/bsg_rom_param.v
@@ -1,0 +1,20 @@
+
+`include "bsg_defines.v"
+
+module bsg_rom_param
+ #(parameter `BSG_INV_PARAM(data_width_p)
+   , parameter `BSG_INV_PARAM(data_p)
+   , parameter `BSG_INV_PARAM(width_p)
+   , parameter `BSG_INV_PARAM(els_p)
+
+   , localparam lg_els_lp = `BSG_SAFE_CLOG2(els_p)
+   )
+  (input [lg_els_lp-1:0] addr_i
+   , output logic [width_p-1:0] data_o
+   );
+
+  assign data_o = data_p[addr_i*width_p+:width_p];
+
+endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_rom_param)


### PR DESCRIPTION
This PR adds a ROM module where the contents are set by parameter. This is useful for dynamically generated ROMs where the parameterization is derived from Verilog