### PR TITLE
Update bsg_noc_pkg.v to remove `ifdef

### DIFF
--- a/bsg_noc/bsg_noc_pkg.sv
+++ b/bsg_noc/bsg_noc_pkg.sv
@@ -1,5 +1,3 @@
-`ifndef BSG_NOC_PKG_V
-`define BSG_NOC_PKG_V
 
 // direction type
 package bsg_noc_pkg;
@@ -8,4 +6,3 @@ package bsg_noc_pkg;
   typedef enum logic[2:0] {P=3'd0, W, E, N, S} Dirs;
 endpackage
 
-`endif


### PR DESCRIPTION
header guards are not recommended on packages because they can cause compilation ordering issues