### PR TITLE
bsg_dmc/bsg_dmc_dly_line_v3.sv: Fix missing include

### DIFF
--- a/bsg_dmc/bsg_dmc_dly_line_v3.sv
+++ b/bsg_dmc/bsg_dmc_dly_line_v3.sv
@@ -14,6 +14,8 @@
 // This module should be replaced by the hardened version
 // when being synthesized.
 
+`include "bsg_defines.sv"
+
 module bsg_dmc_dly_line_v3
  #(parameter `BSG_INV_PARAM(num_taps_p)
    )


### PR DESCRIPTION
Add a missing include to bsg_dmc/bsg_dmc_dly_line_v3.sv. Without this line we get errors when trying to run simulation since the file uses some of the macros defined in bsg_misc/bsg_defines.sv.