### PR TITLE
Update bsg_defines.sv for yosys

### DIFF
--- a/bsg_misc/bsg_defines.sv
+++ b/bsg_misc/bsg_defines.sv
@@ -86,6 +86,8 @@
   `define BSG_VIVADO_SYNTH_FAILS
   `elsif SURELOG
   `define BSG_VIVADO_SYNTH_FAILS
+  `elsif YOSYS
+  `define BSG_VIVADO_SYNTH_FAILS
   `else
   `define BSG_VIVADO_SYNTH_FAILS this_module_is_not_synthesizeable_in_vivado
   `endif


### PR DESCRIPTION
YOSYS is not Vivado, so we should identify it as such