### PR TITLE
Harden Xilinx memories

### DIFF
--- a/hard/ultrascale_plus/bsg_mem/bsg_mem_1r1w_sync.sv
+++ b/hard/ultrascale_plus/bsg_mem/bsg_mem_1r1w_sync.sv
@@ -1,0 +1,76 @@
+
+
+`include "bsg_defines.sv"
+
+// From Vivado inference template
+// Simple Dual-Port Block RAM with One Clock
+// File: simple_dual_one_clock.v
+
+module simple_dual_one_clock #(parameter width_p=1,
+								parameter els_p=1,
+								parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p))
+(clk,ena,enb,wea,addra,addrb,dia,dob);
+
+input clk,ena,enb,wea;
+input [addr_width_lp-1:0] addra,addrb;
+input [width_p-1:0] dia;
+output [width_p-1:0] dob;
+reg [width_p-1:0] ram [els_p-1:0];
+reg [width_p-1:0] doa,dob;
+
+always @(posedge clk) begin 
+ if (ena) begin
+    if (wea)
+        ram[addra] <= dia;
+ end
+end
+
+always @(posedge clk) begin 
+  if (enb)
+    dob <= ram[addrb];
+end
+
+endmodule
+
+   module bsg_mem_1r1w_sync
+     #(parameter `BSG_INV_PARAM(width_p)
+       , parameter `BSG_INV_PARAM(els_p)
+       , parameter read_write_same_addr_p=0
+       , parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
+       , parameter harden_p=1
+       , parameter latch_last_read_p=0
+       , parameter disable_collision_warning_p=0
+       , parameter enable_clock_gating_p=0
+     )
+     (
+       input clk_i
+       , input reset_i
+
+       , input w_v_i
+       , input [addr_width_lp-1:0] w_addr_i
+       , input [`BSG_SAFE_MINUS(width_p,1):0] w_data_i
+
+       , input r_v_i
+       , input [addr_width_lp-1:0] r_addr_i
+
+       , output logic [`BSG_SAFE_MINUS(width_p,1):0] r_data_o
+     );
+
+	simple_dual_one_clock #(
+		.width_p(width_p)
+		,.els_p(els_p)
+	) ram (
+		.clk(clk_i)
+		,.ena(w_v_i)
+		,.enb(r_v_i)
+		,.wea(w_v_i)
+		,.addra(w_addr_i)
+		,.addrb(r_addr_i)
+		,.dia(w_data_i)
+		,.dob(r_data_o)
+	);
+
+endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_mem_1r1w_sync)
+

--- a/hard/ultrascale_plus/bsg_mem/bsg_mem_1rw_sync.sv
+++ b/hard/ultrascale_plus/bsg_mem/bsg_mem_1rw_sync.sv
@@ -1,0 +1,67 @@
+
+`include "bsg_defines.sv"
+
+// From Vivado inference template
+// Single-Port Block RAM Write-First Mode (recommended template)
+// File: rams_sp_wf.v
+module rams_sp_wf #(parameter width_p=1,
+                    parameter els_p=1,
+                    parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p))
+(clk, we, en, addr, di, dout);
+input clk; 
+input we; 
+input en;
+input [addr_width_lp-1:0] addr; 
+input [width_p-1:0] di; 
+output [width_p-1:0] dout;
+reg [width_p-1:0] RAM [els_p-1:0];
+reg [width_p-1:0] dout;
+
+always @(posedge clk)
+begin
+  if (en)
+  begin
+    if (we)
+      begin
+        RAM[addr] <= di;
+        dout <= di;
+      end
+   else
+    dout <= RAM[addr];
+  end
+end
+endmodule
+
+ module bsg_mem_1rw_sync #(parameter `BSG_INV_PARAM(width_p)
+                           , parameter `BSG_INV_PARAM(els_p)
+                           , parameter latch_last_read_p=0
+                           , parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
+                           , parameter verbose_if_synth_p=0
+                           , parameter enable_clock_gating_p=0
+                           , parameter harden_p=1
+                           )
+    (input   clk_i
+     , input reset_i
+     , input [`BSG_SAFE_MINUS(width_p,1):0] data_i
+     , input [addr_width_lp-1:0] addr_i
+     , input v_i
+     , input w_i
+     , output logic [`BSG_SAFE_MINUS(width_p,1):0]  data_o
+     );
+
+     rams_sp_wf #(
+         .width_p(width_p)
+         ,.els_p(els_p)
+     ) ram (
+         .clk(clk_i)
+         ,.we(w_i)
+         ,.en(v_i)
+         ,.addr(addr_i)
+         ,.di(data_i)
+         ,.dout(data_o)
+     );
+
+ endmodule
+
+ `BSG_ABSTRACT_MODULE(bsg_mem_1rw_sync)
+

--- a/hard/ultrascale_plus/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
+++ b/hard/ultrascale_plus/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
@@ -1,0 +1,91 @@
+
+`include "bsg_defines.sv"
+
+// From vivado template
+// Single-Port BRAM with Byte-wide Write Enable
+// Read-First mode
+// Single-process description
+// Compact description of the write with a generate-for 
+//   statement
+// Column width and number of columns easily configurable
+//
+// bytewrite_ram_1b.v
+//
+
+module bytewrite_ram_1b (clk, ena, enb, we, addr, di, dout);
+
+parameter SIZE = 1024; 
+parameter ADDR_WIDTH = 10; 
+parameter COL_WIDTH = 8; 
+parameter NB_COL = 4;
+
+input clk;
+input ena;
+input enb;
+input [NB_COL-1:0] we;
+input [ADDR_WIDTH-1:0] addr;
+input [NB_COL*COL_WIDTH-1:0] di;
+output reg [NB_COL*COL_WIDTH-1:0] dout;
+
+reg [NB_COL*COL_WIDTH-1:0] RAM [SIZE-1:0];
+
+always @(posedge clk)
+begin
+    if (ena)
+        dout <= RAM[addr];
+end
+
+generate genvar i;
+for (i = 0; i < NB_COL; i = i+1)
+begin
+always @(posedge clk)
+begin
+    if (enb & we[i])
+        RAM[addr][(i+1)*COL_WIDTH-1:i*COL_WIDTH] <= di[(i+1)*COL_WIDTH-1:i*COL_WIDTH];
+    end 
+end
+endgenerate
+
+endmodule
+
+ module bsg_mem_1rw_sync_mask_write_byte #(parameter `BSG_INV_PARAM(data_width_p)
+                           , parameter `BSG_INV_PARAM(els_p)
+                           , parameter latch_last_read_p=0
+                           , parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
+                           , parameter write_mask_width_lp = data_width_p>>3
+                           , parameter enable_clock_gating_p=0
+                           , parameter harden_p=1
+                           )
+   ( input clk_i
+    ,input reset_i
+
+    ,input v_i
+    ,input w_i
+
+    ,input [addr_width_lp-1:0]       addr_i
+    ,input [`BSG_SAFE_MINUS(data_width_p, 1):0]        data_i
+     // for each bit set in the mask, a byte is written
+    ,input [`BSG_SAFE_MINUS(write_mask_width_lp, 1):0] write_mask_i
+
+    ,output logic [`BSG_SAFE_MINUS(data_width_p, 1):0] data_o
+   );
+
+     bytewrite_ram_1b #(
+         .COL_WIDTH(8)
+		 ,.NB_COL(write_mask_width_lp)
+         ,.SIZE(els_p)
+		 ,.ADDR_WIDTH(addr_width_lp)
+     ) ram (
+		.clk(clk_i)
+        ,.ena(v_i & ~w_i)
+        ,.enb(v_i &  w_i)
+		,.we(write_mask_i)
+		,.addr(addr_i)
+        ,.di(data_i)
+        ,.dout(data_o)
+     );
+
+ endmodule
+
+ `BSG_ABSTRACT_MODULE(bsg_mem_1rw_sync_mask_write_byte)
+


### PR DESCRIPTION
This PR adds xilinx templates for BRAM inference. This is essential for efficient implementation on FPGA. 

TODO: Designate between BRAM and URAM inference for a given width and depth. Currently trusting xilinx

Tested with BP on Vivado 2022.1, correctly infers all 1rw_sync* and 1r1w_sync* RAMs