### PR TITLE
Add tests for bsg_two_fifo

### DIFF
--- a/bsg_dataflow/bsg_two_fifo.sv
+++ b/bsg_dataflow/bsg_two_fifo.sv
@@ -71,7 +71,7 @@ module bsg_two_fifo #(parameter `BSG_INV_PARAM(width_p)
    assign ready_param_o   = ~full_r;
 
    if (ready_THEN_valid_p)
-     assign enq_i = v_i;
+     assign enq_i = v_i & (full_r & deq_i | ~full_r);
    else
      assign enq_i = v_i & ~full_r;
 

--- a/testing/bsg_dataflow/bsg_two_fifo/Makefile
+++ b/testing/bsg_dataflow/bsg_two_fifo/Makefile
@@ -1,0 +1,69 @@
+# This file is public domain, it can be freely copied without restrictions.
+# SPDX-License-Identifier: CC0-1.0
+
+# Cadenv Include
+include /home/projects/ee478.2024spr/cadenv/cadenv_ee.mk
+
+# CAD Tool Paths
+VCS_BIN = $(VCS_HOME)/bin
+VERDI_BIN = $(VERDI_HOME)/bin
+VCS_BIN_DIR = $(VCS_BIN)
+export PATH:=$(PATH):$(VCS_BIN):$(VERDI_BIN)
+
+# VCS Arguments
+EXTRA_ARGS += +v2k -l vcs.log
+EXTRA_ARGS += -debug_pp +vcs+vcdpluson
+EXTRA_ARGS += +lint=all,noSVA-UA,noSVA-NSVU,noVCDE,noNS -assert svaext
+EXTRA_ARGS += -cm line+fsm+branch+cond+tgl
+EXTRA_ARGS += -kdb -debug_access+all
+
+# defaults
+SIM ?= vcs
+TOPLEVEL_LANG ?= verilog
+
+# basejump_stl path
+export BASEJUMP_STL_DIR = $(shell git rev-parse --show-toplevel)/../basejump_stl
+
+# basejump_stl verilog header include path
+EXTRA_ARGS += +incdir+$(BASEJUMP_STL_DIR)/bsg_misc
+
+# basejump_stl verilog filelist
+VERILOG_SOURCES += $(BASEJUMP_STL_DIR)/bsg_dataflow/bsg_two_fifo.sv
+VERILOG_SOURCES += $(BASEJUMP_STL_DIR)/bsg_mem/bsg_mem_1r1w.sv
+VERILOG_SOURCES += $(BASEJUMP_STL_DIR)/bsg_mem/bsg_mem_1r1w_synth.sv
+
+# testbench verilog filelist
+VERILOG_SOURCES += $(PWD)/bsg_two_fifo_wrapper.sv
+VERILOG_SOURCES += $(PWD)/bsg_two_fifo_cov.sv
+
+# TOPLEVEL is the name of the toplevel module in your Verilog or VHDL file
+TOPLEVEL = bsg_two_fifo_wrapper
+
+# MODULE is the basename of the Python test file
+MODULE = bsg_two_fifo_testbench
+
+# include cocotb's make rules to take care of the simulator setup
+include $(shell cocotb-config --makefiles)/Makefile.sim
+
+
+# VERDI open waveform
+ee-verdi:
+	verdi -ssf novas.fsdb &
+
+# VERDI open coverages
+ee-verdi-cov:
+	verdi -cov -covdir sim_build/simv.vdb &
+
+# **DEPRECATED** DVE open waveform
+ee-dve:
+	dve -full64 -vpd vcdplus.vpd &
+
+# **DEPRECATED** DVE open coverages
+ee-dve-cov:
+	dve -full64 -cov -covdir sim_build/simv.vdb &
+
+# Clean simulation files
+ee-clean:
+	make clean
+	rm -rf __pycache__ DVEfiles vcs.log vcdplus.vpd results.xml
+	rm -rf verdiLog vdCovLog novas.conf novas.fsdb novas.rc novas_dump.log

--- a/testing/bsg_dataflow/bsg_two_fifo/bsg_two_fifo_cov.sv
+++ b/testing/bsg_dataflow/bsg_two_fifo/bsg_two_fifo_cov.sv
@@ -1,0 +1,125 @@
+//
+// Eli Orona   05/2024
+//
+// This module defines functional coverages of module bsg_two_fifo
+//
+//
+
+`include "bsg_defines.sv"
+
+module bsg_two_fifo_cov
+
+ #(parameter allow_enq_deq_on_full_p = 0
+  )
+
+  (input clk_i
+  ,input reset_i
+
+  // interface signals
+  ,input v_i
+  ,input yumi_i
+
+  // internal registers
+  ,input full_r
+  ,input empty_r
+  ,input head_r
+  ,input tail_r
+  );
+
+  // reset
+  covergroup cg_reset @(negedge clk_i);
+    coverpoint reset_i;
+  endgroup
+
+  // Partitioning covergroup into smaller ones
+  // empty
+  covergroup cg_empty @ (negedge clk_i iff ~reset_i & empty_r & ~full_r);
+
+    cp_v: coverpoint v_i;
+    // cannot deque when empty
+    cp_yumi: coverpoint yumi_i {illegal_bins ig = {1};}
+    // cannot be full when empty
+    cp_full: coverpoint full_r {illegal_bins ig = {1};}
+    // must be empty by definition
+    cp_empty: coverpoint empty_r {illegal_bins ig = {0};}
+    cp_head: coverpoint head_r;
+    cp_tail: coverpoint tail_r;
+
+    cross_all: cross cp_v, cp_yumi, cp_full, cp_empty, cp_head, cp_tail {
+      // by definition, fifo empty means h/t pointers are the same
+      illegal_bins ig0 = cross_all with (cp_head != cp_tail);
+    }
+
+  endgroup
+
+  // full
+  covergroup cg_full @ (negedge clk_i iff ~reset_i & ~empty_r & full_r);
+
+    cp_v: coverpoint v_i;
+    cp_yumi: coverpoint yumi_i;
+    // must be full by definition
+    cp_full: coverpoint full_r {illegal_bins ig = {0};}
+    // cannot be empty by definition
+    cp_empty: coverpoint empty_r {illegal_bins ig = {1};}
+    cp_head: coverpoint head_r;
+    cp_tail: coverpoint tail_r;
+
+    cross_all: cross cp_v, cp_yumi, cp_full, cp_empty, cp_head, cp_tail {
+      // by definition, fifo full means h/t pointers are the same
+      illegal_bins ig0 = cross_all with (cp_head != cp_tail);
+    }
+
+  endgroup
+
+  // fifo normal
+  covergroup cg_normal @ (negedge clk_i iff ~reset_i & ~empty_r & ~full_r);
+
+    cp_v: coverpoint v_i;
+    cp_yumi: coverpoint yumi_i;
+    // cannot be full
+    cp_full: coverpoint full_r {illegal_bins ig = {1};}
+    // cannot be empty
+    cp_empty: coverpoint empty_r {illegal_bins ig = {1};}
+    cp_head: coverpoint head_r;
+    cp_tail: coverpoint tail_r;
+
+    cross_all: cross cp_v, cp_yumi, cp_full, cp_empty, cp_head, cp_tail {
+      // by definition, normal fifo means h/t pointers cannot be the same
+      illegal_bins ig0 = cross_all with (cp_head == cp_tail);
+    }
+
+  endgroup
+
+  // fifo impossible (fifo cannot be both empty and full at the same time)
+  covergroup cg_impossible @ (negedge clk_i iff ~reset_i);
+    cp_full: coverpoint full_r;
+    cp_empty: coverpoint empty_r;
+
+    cross_all: cross cp_full, cp_empty {
+        illegal_bins igo = cross_all with (cp_full & cp_empty);
+    }
+  endgroup
+
+  // create cover groups
+  cg_reset cov_reset = new;
+  cg_empty cov_empty = new;
+  cg_full cov_full = new;
+  cg_normal cov_normal = new;
+  cg_impossible cov_impossible = new;
+
+  // print coverages when simulation is done
+  final
+  begin
+    $display("");
+    $display("Instance: %m");
+    $display("---------------------- Functional Coverage Results ----------------------");
+    $display("Reset       functional coverage is %f%%", cov_reset.get_coverage());
+    $display("Fifo empty  functional coverage is %f%%", cov_empty.cross_all.get_coverage());
+    $display("Fifo full   functional coverage is %f%%", cov_full.cross_all.get_coverage());
+    $display("Fifo normal functional coverage is %f%%", cov_normal.cross_all.get_coverage());
+    $display("Fifo impossible        coverage is %f%%", cov_impossible.cross_all.get_coverage());
+    $display("-------------------------------------------------------------------------");
+    $display("");
+  end
+
+endmodule

--- a/testing/bsg_dataflow/bsg_two_fifo/bsg_two_fifo_testbench.py
+++ b/testing/bsg_dataflow/bsg_two_fifo/bsg_two_fifo_testbench.py
@@ -1,0 +1,163 @@
+# Import python libraries
+import math
+import time
+import random
+
+# Import cocotb libraries
+import cocotb
+from cocotb.clock import Clock, Timer
+from cocotb.triggers import RisingEdge, FallingEdge, Timer
+
+
+# Data width, matching width_p parameter in DUT
+WIDTH_P = 16
+
+# Testbench iterations
+ITERATION = 350
+
+# Flow control random seed
+# Use different seeds on input and output sides for more randomness
+CTRL_INPUT_SEED  = 1
+CTRL_OUTPUT_SEED = 2
+
+# Testbench clock period
+CLK_PERIOD = 10
+
+
+async def input_side_testbench(dut, seed):
+    """Handle input traffic"""
+
+    # Create local random generator for data generation
+    data_random = random.Random()
+    data_random.seed(seed)
+
+    # Create control random generator for flow control
+    control_random = random.Random()
+    control_random.seed(CTRL_INPUT_SEED)
+
+    # Initialize DUT interface values
+    dut.v_i.value = 0
+    dut.data_i.value = 0
+
+    # Wait for reset deassertion
+    while 1:
+        await RisingEdge(dut.clk_i); await Timer(1, units="ps")
+        if dut.reset_i == 0: break
+
+    # Main iterations
+    i = 0
+    while 1:
+        await RisingEdge(dut.clk_i); await Timer(2, units="ps")
+        # Half chance to send data flit
+        if control_random.random() >= 0.5:
+            # Assert DUT valid signal
+            dut.v_i.setimmediatevalue(1)
+            # Check DUT ready signal OR we are reading (passthrough)
+            if dut.ready_param_o.value == 1 or (dut.yumi_i.value == 1 and dut.v_o.value == 1 and dut.allow_enq_deq_on_full_p.value == 1):
+                # Generate send data
+                value = math.floor(data_random.random()*pow(2, WIDTH_P))
+                # print(f"Sent {value}")
+                dut.data_i.setimmediatevalue(value)
+                # iteration increment
+                i += 1
+                # Check iteration
+                if i == ITERATION:
+                    # Test finished
+                    break
+        else:
+            # Deassert DUT valid signal
+            dut.v_i.setimmediatevalue(0)
+
+    await RisingEdge(dut.clk_i); await Timer(1, units="ps")
+    # Deassert DUT valid signal
+    dut.v_i.value = 0
+
+
+async def output_side_testbench(dut, seed):
+    """Handle input traffic"""
+
+    # Create local random generator for data generation
+    data_random = random.Random()
+    data_random.seed(seed)
+
+    # Create control random generator for flow control
+    control_random = random.Random()
+    control_random.seed(CTRL_OUTPUT_SEED)
+
+    # Initialize DUT interface values
+    dut.yumi_i.value = 0
+
+    # Wait for reset deassertion
+    while 1:
+        await RisingEdge(dut.clk_i); await Timer(1, units="ps")
+        if dut.reset_i == 0: break
+
+    # Main iterations
+    i = 0
+    while 1:
+        await RisingEdge(dut.clk_i); await Timer(1, units="ps")
+        if dut.v_o.value == 1 and control_random.random() >= 0.5:
+            # Assert DUT yumi signal
+            dut.yumi_i.setimmediatevalue(1)
+            # Generate check data and compare with receive data
+            value = math.floor(data_random.random()*pow(2, WIDTH_P))
+            # print(f"Read {value}")
+            assert dut.data_o.value == value, f"data mismatch! Expected: {value}, found: {int(str(dut.data_o.value), 2)}"
+            # iteration increment
+            i += 1
+            # Check iteration
+            if i == ITERATION:
+                # Test finished
+                break
+        else:
+            # Deassert DUT yumi signal
+            dut.yumi_i.setimmediatevalue(0)
+
+    await RisingEdge(dut.clk_i); await Timer(1, units="ps")
+    # Deassert DUT yumi signal
+    dut.yumi_i.value = 0
+
+
+@cocotb.test()
+async def testbench(dut):
+    """Try accessing the design."""
+
+    # Random seed assignment
+    seed = time.time()
+
+    # Create a 10ps period clock on DUT port clk_i
+    clock = Clock(dut.clk_i, CLK_PERIOD, units="ps")
+
+    # Start the clock. Start it low to avoid issues on the first RisingEdge
+    clock_thread = cocotb.start_soon(clock.start(start_high=False))
+
+    # Launch input and output testbench threads
+    input_thread = cocotb.start_soon(input_side_testbench(dut, seed))
+    output_thread = cocotb.start_soon(output_side_testbench(dut, seed))
+
+    # Reset initialization
+    dut.reset_i.value = 1
+
+    # Wait for 5 clock cycles
+    await Timer(CLK_PERIOD*5, units="ps")
+    await RisingEdge(dut.clk_i); await Timer(1, units="ps")
+
+    # Deassert reset
+    dut.reset_i.value = 0
+
+    # Wait for threads to finish
+    await input_thread
+    await output_thread
+
+    # Wait for 5 clock cycles
+    await Timer(CLK_PERIOD*5, units="ps")
+    await RisingEdge(dut.clk_i); await Timer(1, units="ps")
+
+    # Assert reset
+    dut.reset_i.value = 1
+
+    # Wait for 5 clock cycles
+    await Timer(CLK_PERIOD*5, units="ps")
+
+    # Test finished!
+    dut._log.info("Test finished! Current reset_i value = %s", dut.reset_i.value)

--- a/testing/bsg_dataflow/bsg_two_fifo/bsg_two_fifo_wrapper.sv
+++ b/testing/bsg_dataflow/bsg_two_fifo/bsg_two_fifo_wrapper.sv
@@ -1,0 +1,38 @@
+
+module bsg_two_fifo_wrapper #(parameter width_p = 16
+                            , parameter allow_enq_deq_on_full_p = 1 // Makes it harder to test
+                            )
+    ( input clk_i
+    , input reset_i
+
+    // input side
+    , output              ready_param_o // early
+    , input [width_p-1:0] data_i  // late
+    , input               v_i     // late
+
+    // output side
+    , output              v_o     // early
+    , output[width_p-1:0] data_o  // early
+    , input               yumi_i  // late
+    );
+
+    // Instantiate DUT
+    bsg_two_fifo #(.width_p(width_p)
+                  ,.allow_enq_deq_on_full_p(allow_enq_deq_on_full_p)
+                ) fifo
+    (.*);
+
+    // Bind Covergroups
+    bind bsg_two_fifo bsg_two_fifo_cov 
+    #(
+        .allow_enq_deq_on_full_p(allow_enq_deq_on_full_p)
+    )
+        pc_cov
+    (.*);
+
+    // Dump Waveforms
+    initial begin
+        $fsdbDumpvars;
+    end
+
+endmodule


### PR DESCRIPTION
The change in `bsg_two_fifo.sv` might not be necessary, however I found that without it the `head_r` and `tail_r` pointers would no longer be equal, causing an invalid state for the FIFO.
https://github.com/bespoke-silicon-group/basejump_stl/blob/9322a573262d17623dfde4689a2e87de915241cb/bsg_dataflow/bsg_two_fifo.sv#L74

I am also curious how to make the `allow_enq_deq_on_full_p` in `bsg_two_fifo_wrapper potentially.sv` be something that can be properly parameterized, allowing both the normal and passthrough configurations to be tested.