### PR TITLE
Removed all synopsys translate_off/on pragmas

### DIFF
--- a/bsg_async/bsg_async_credit_counter.sv
+++ b/bsg_async/bsg_async_credit_counter.sv
@@ -130,7 +130,7 @@ module bsg_async_credit_counter #(parameter `BSG_INV_PARAM(max_tokens_p )
    //
 
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
    bsg_gray_to_binary #(.width_p(w_counter_width_lp)) bsg_g2b
      (.gray_i(w_counter_gray_r_rsync)

--- a/bsg_async/bsg_async_credit_counter.sv
+++ b/bsg_async/bsg_async_credit_counter.sv
@@ -130,7 +130,7 @@ module bsg_async_credit_counter #(parameter `BSG_INV_PARAM(max_tokens_p )
    //
 
 
-   // synopsys translate_off
+`ifndef SYNTHESIS
 
    bsg_gray_to_binary #(.width_p(w_counter_width_lp)) bsg_g2b
      (.gray_i(w_counter_gray_r_rsync)
@@ -160,7 +160,7 @@ module bsg_async_credit_counter #(parameter `BSG_INV_PARAM(max_tokens_p )
        assert (!(r_dec_credit_i===1 && r_credits_avail_o===0))
               else $error("decrementing empty credit counter");
 
-   // synopsys translate_on
+`endif
 
    //
    // end debug

--- a/bsg_async/bsg_async_fifo.sv
+++ b/bsg_async/bsg_async_fifo.sv
@@ -138,14 +138,14 @@ module bsg_async_fifo #(parameter `BSG_INV_PARAM(  lg_size_p )
                                          , r_ptr_gray_r_wsync[0+:lg_size_p-1] });
 
 
-   // synopsys translate_off
+`ifndef SYNTHESIS
    always @(negedge w_clk_i)
      assert(!(w_full_o===1 && w_enq_i===1))   else $error("enqueing data on bsg_async_fifo when full");
 
    always @(negedge r_clk_i)
      assert(!(r_valid_o_tmp===0 && r_deq_i===1)) else $error("dequeing data on bsg_async_fifo when empty");
 
-   // synopsys translate_on
+`endif
 
 endmodule // bsg_async_fifo
 

--- a/bsg_async/bsg_async_fifo.sv
+++ b/bsg_async/bsg_async_fifo.sv
@@ -138,7 +138,7 @@ module bsg_async_fifo #(parameter `BSG_INV_PARAM(  lg_size_p )
                                          , r_ptr_gray_r_wsync[0+:lg_size_p-1] });
 
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
    always @(negedge w_clk_i)
      assert(!(w_full_o===1 && w_enq_i===1))   else $error("enqueing data on bsg_async_fifo when full");
 

--- a/bsg_async/bsg_launch_sync_sync.sv
+++ b/bsg_async/bsg_launch_sync_sync.sv
@@ -229,7 +229,7 @@ module bsg_launch_sync_sync #(parameter `BSG_INV_PARAM(width_p)
     , output [width_p-1:0] oclk_data_o // after sync flops
     );
 
-// synopsys translate_off
+`ifndef SYNTHESIS
 
 /*   initial
      begin
@@ -246,7 +246,7 @@ module bsg_launch_sync_sync #(parameter `BSG_INV_PARAM(width_p)
           $finish();
        end
 `endif
-// synopsys translate_on
+`endif
 
    genvar i;
 

--- a/bsg_async/bsg_launch_sync_sync.sv
+++ b/bsg_async/bsg_launch_sync_sync.sv
@@ -229,7 +229,7 @@ module bsg_launch_sync_sync #(parameter `BSG_INV_PARAM(width_p)
     , output [width_p-1:0] oclk_data_o // after sync flops
     );
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
 /*   initial
      begin

--- a/bsg_async/bsg_sync_sync.sv
+++ b/bsg_async/bsg_sync_sync.sv
@@ -89,14 +89,14 @@ module bsg_sync_sync #(parameter `BSG_INV_PARAM(width_p ))
 
    genvar   i;
 
-   // synopsys translate_off
+`ifndef SYNTHESIS
  /*
    initial
      begin
         $display("%m: instantiating bss of size %d",width_p);
      end
   */
-   // synopsys translate_on
+`endif
 
    for (i = 0; i < (width_p/`bss_max_block); i = i + 1)
      begin : maxb

--- a/bsg_async/bsg_sync_sync.sv
+++ b/bsg_async/bsg_sync_sync.sv
@@ -89,7 +89,7 @@ module bsg_sync_sync #(parameter `BSG_INV_PARAM(width_p ))
 
    genvar   i;
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
  /*
    initial
      begin

--- a/bsg_cache/bsg_cache.sv
+++ b/bsg_cache/bsg_cache.sv
@@ -1183,7 +1183,7 @@ end
   assign tbuf_bypass_v_li = (decode_tl_r.ld_op | decode_tl_r.atomic_op | partial_st_tl) & v_tl_r & v_we;
 
 
-  // synopsys translate_off
+`ifndef SYNTHESIS
 
   always_ff @ (negedge clk_i) begin
     if (~reset_i) begin
@@ -1234,7 +1234,7 @@ end
     end
   end
 
-  // synopsys translate_on
+`endif
 
 
 endmodule

--- a/bsg_cache/bsg_cache.sv
+++ b/bsg_cache/bsg_cache.sv
@@ -1183,7 +1183,7 @@ end
   assign tbuf_bypass_v_li = (decode_tl_r.ld_op | decode_tl_r.atomic_op | partial_st_tl) & v_tl_r & v_we;
 
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
   always_ff @ (negedge clk_i) begin
     if (~reset_i) begin

--- a/bsg_cache/bsg_cache_buffer_queue.sv
+++ b/bsg_cache/bsg_cache_buffer_queue.sv
@@ -125,13 +125,13 @@ module bsg_cache_buffer_queue
 
 
 
-  // synopsys translate_off
+`ifndef SYNTHESIS
   always_ff @ (negedge clk_i) begin
     if (~reset_i & num_els_r !== 2'bx) 
       assert(num_els_r != 3) else $error("bsg_cache_buffer_queue cannot hold more than 2 entries.");
 
   end
-  // synopsys translate_on
+`endif
 
 
 endmodule

--- a/bsg_cache/bsg_cache_buffer_queue.sv
+++ b/bsg_cache/bsg_cache_buffer_queue.sv
@@ -125,7 +125,7 @@ module bsg_cache_buffer_queue
 
 
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
   always_ff @ (negedge clk_i) begin
     if (~reset_i & num_els_r !== 2'bx) 
       assert(num_els_r != 3) else $error("bsg_cache_buffer_queue cannot hold more than 2 entries.");

--- a/bsg_cache/bsg_cache_dma.sv
+++ b/bsg_cache/bsg_cache_dma.sv
@@ -420,7 +420,7 @@ module bsg_cache_dma
     end
   end
 
-  // synopsys translate_off
+`ifndef SYNTHESIS
   
   always_ff @ (posedge clk_i) begin
     if (debug_p) begin
@@ -430,7 +430,7 @@ module bsg_cache_dma
       end
     end
   end
-  // synopsys translate_on
+`endif
 
 endmodule
 

--- a/bsg_cache/bsg_cache_dma.sv
+++ b/bsg_cache/bsg_cache_dma.sv
@@ -420,7 +420,7 @@ module bsg_cache_dma
     end
   end
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
   
   always_ff @ (posedge clk_i) begin
     if (debug_p) begin

--- a/bsg_cache/bsg_cache_dma_to_wormhole.sv
+++ b/bsg_cache/bsg_cache_dma_to_wormhole.sv
@@ -329,14 +329,14 @@ module bsg_cache_dma_to_wormhole
     end
   end
 
-  //synopsys translate_off
+`ifndef SYNTHESIS
   if (wh_flit_width_p != dma_data_width_lp)
     $error("WH flit width must be equal to DMA data width");
   if (wh_flit_width_p < dma_addr_width_p)
     $error("WH flit width must be larger than address width");
   if (wh_len_width_p < `BSG_WIDTH(dma_burst_len_p+1))
     $error("WH len width %d must be large enough to hold the dma transfer size %d", wh_len_width_p, `BSG_WIDTH(dma_burst_len_p+1));
-  //synopsys translate_on
+`endif
 
 endmodule
 

--- a/bsg_cache/bsg_cache_dma_to_wormhole.sv
+++ b/bsg_cache/bsg_cache_dma_to_wormhole.sv
@@ -329,7 +329,7 @@ module bsg_cache_dma_to_wormhole
     end
   end
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
   if (wh_flit_width_p != dma_data_width_lp)
     $error("WH flit width must be equal to DMA data width");
   if (wh_flit_width_p < dma_addr_width_p)

--- a/bsg_cache/bsg_cache_non_blocking_mhu.sv
+++ b/bsg_cache/bsg_cache_non_blocking_mhu.sv
@@ -812,7 +812,7 @@ module bsg_cache_non_blocking_mhu
     end
   end
 
-  // synopsys translate_off
+`ifndef SYNTHESIS
 
   always_ff @ (negedge clk_i) begin
     if (~reset_i) begin
@@ -827,7 +827,7 @@ module bsg_cache_non_blocking_mhu
     end
   end
 
-  // synopsys translate_on
+`endif
 
 
 endmodule

--- a/bsg_cache/bsg_cache_non_blocking_mhu.sv
+++ b/bsg_cache/bsg_cache_non_blocking_mhu.sv
@@ -812,7 +812,7 @@ module bsg_cache_non_blocking_mhu
     end
   end
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
   always_ff @ (negedge clk_i) begin
     if (~reset_i) begin

--- a/bsg_cache/bsg_cache_non_blocking_miss_fifo.sv
+++ b/bsg_cache/bsg_cache_non_blocking_miss_fifo.sv
@@ -367,7 +367,7 @@ module bsg_cache_non_blocking_miss_fifo
 
 
 
-  // synopsys translate_off
+`ifndef SYNTHESIS
 
   always_ff @ (negedge clk_i) begin
     if (~reset_i) begin
@@ -375,7 +375,7 @@ module bsg_cache_non_blocking_miss_fifo
     end
   end
 
-  // synopsys translate_on
+`endif
 
 endmodule
 

--- a/bsg_cache/bsg_cache_non_blocking_miss_fifo.sv
+++ b/bsg_cache/bsg_cache_non_blocking_miss_fifo.sv
@@ -367,7 +367,7 @@ module bsg_cache_non_blocking_miss_fifo
 
 
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
   always_ff @ (negedge clk_i) begin
     if (~reset_i) begin

--- a/bsg_cache/bsg_cache_non_blocking_tag_mem.sv
+++ b/bsg_cache/bsg_cache_non_blocking_tag_mem.sv
@@ -199,7 +199,7 @@ module bsg_cache_non_blocking_tag_mem
   end
 
 
-  // synopsys translate_off
+`ifndef SYNTHESIS
   always_ff @ (negedge clk_i) begin
 
     if (v_i & debug_p)
@@ -208,7 +208,7 @@ module bsg_cache_non_blocking_tag_mem
   end
 
 
-  // synopsys translate_on
+`endif
 
 endmodule
 

--- a/bsg_cache/bsg_cache_non_blocking_tag_mem.sv
+++ b/bsg_cache/bsg_cache_non_blocking_tag_mem.sv
@@ -199,7 +199,7 @@ module bsg_cache_non_blocking_tag_mem
   end
 
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
   always_ff @ (negedge clk_i) begin
 
     if (v_i & debug_p)

--- a/bsg_cache/bsg_cache_non_blocking_tl_stage.sv
+++ b/bsg_cache/bsg_cache_non_blocking_tl_stage.sv
@@ -457,7 +457,7 @@ module bsg_cache_non_blocking_tl_stage
   end
 
 
-  // synopsys translate_off
+`ifndef SYNTHESIS
   always_ff @ (negedge clk_i) begin
     if (~reset_i & v_tl_r) begin
       assert($countones(tag_hit) <= 1) 
@@ -468,7 +468,7 @@ module bsg_cache_non_blocking_tl_stage
         else $error("[BSG_ERROR] %m. t=%t. There needs to be at least 2 unlocked ways.]", $time);
     end
   end
-  // synopsys translate_on
+`endif
 
 
 

--- a/bsg_cache/bsg_cache_non_blocking_tl_stage.sv
+++ b/bsg_cache/bsg_cache_non_blocking_tl_stage.sv
@@ -457,7 +457,7 @@ module bsg_cache_non_blocking_tl_stage
   end
 
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
   always_ff @ (negedge clk_i) begin
     if (~reset_i & v_tl_r) begin
       assert($countones(tag_hit) <= 1) 

--- a/bsg_cache/bsg_cache_to_axi.sv
+++ b/bsg_cache/bsg_cache_to_axi.sv
@@ -338,12 +338,12 @@ module bsg_cache_to_axi
 
   // assertions
   //
-  // synopsys translate_off
+`ifndef SYNTHESIS
   initial begin
     assert(data_width_p*block_size_in_words_p == axi_data_width_p*axi_burst_len_p)
       else $error("cache block size and axi transfer size do not match.");
   end
-  // synopsys translate_on
+`endif
 
 endmodule
 

--- a/bsg_cache/bsg_cache_to_axi.sv
+++ b/bsg_cache/bsg_cache_to_axi.sv
@@ -338,7 +338,7 @@ module bsg_cache_to_axi
 
   // assertions
   //
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
   initial begin
     assert(data_width_p*block_size_in_words_p == axi_data_width_p*axi_burst_len_p)
       else $error("cache block size and axi transfer size do not match.");

--- a/bsg_cache/bsg_cache_to_test_dram_rx.sv
+++ b/bsg_cache/bsg_cache_to_test_dram_rx.sv
@@ -137,7 +137,7 @@ module bsg_cache_to_test_dram_rx
   assign ch_addr_afifo_deq = ch_addr_v_lo & dram_data_v_lo;
 
 
-  // synopsys translate_off
+`ifndef SYNTHESIS
   
   always_ff @ (negedge dram_clk_i) begin
     if (~dram_reset_i & dram_data_v_i) begin
@@ -146,7 +146,7 @@ module bsg_cache_to_test_dram_rx
     end
   end
 
-  // synopsys translate_on
+`endif
 
 
 endmodule

--- a/bsg_cache/bsg_cache_to_test_dram_rx.sv
+++ b/bsg_cache/bsg_cache_to_test_dram_rx.sv
@@ -137,7 +137,7 @@ module bsg_cache_to_test_dram_rx
   assign ch_addr_afifo_deq = ch_addr_v_lo & dram_data_v_lo;
 
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
   
   always_ff @ (negedge dram_clk_i) begin
     if (~dram_reset_i & dram_data_v_i) begin

--- a/bsg_cache/bsg_cache_to_test_dram_rx_reorder.sv
+++ b/bsg_cache/bsg_cache_to_test_dram_rx_reorder.sv
@@ -62,7 +62,7 @@ module bsg_cache_to_test_dram_rx_reorder
     assign piso_v_li = dram_v_i;
     wire unused = |dram_ch_addr_i; 
 
-`ifndef SYNTHESIS 
+`ifndef BSG_HIDE_FROM_SYNTHESIS 
     always_ff @ (negedge core_clk_i) begin
       if (~core_reset_i & dram_v_i) begin
         assert(piso_ready_lo) else $fatal(1, "piso is not ready!");

--- a/bsg_cache/bsg_cache_to_test_dram_rx_reorder.sv
+++ b/bsg_cache/bsg_cache_to_test_dram_rx_reorder.sv
@@ -62,13 +62,13 @@ module bsg_cache_to_test_dram_rx_reorder
     assign piso_v_li = dram_v_i;
     wire unused = |dram_ch_addr_i; 
 
-    // synopsys translate_off 
+`ifndef SYNTHESIS 
     always_ff @ (negedge core_clk_i) begin
       if (~core_reset_i & dram_v_i) begin
         assert(piso_ready_lo) else $fatal(1, "piso is not ready!");
       end
     end
-    // synopsys translate_on
+`endif
 
   end
   else begin: reqn

--- a/bsg_cache/bsg_nonsynth_cache_axe_tracer.sv
+++ b/bsg_cache/bsg_nonsynth_cache_axe_tracer.sv
@@ -34,7 +34,7 @@ module bsg_nonsynth_cache_axe_tracer
   assign sbuf_entry = sbuf_entry_li;
 
 
-  // synopsys translate_off
+`ifndef SYNTHESIS
   
   localparam logfile_lp = "bsg_cache.axe";
 
@@ -58,7 +58,7 @@ module bsg_nonsynth_cache_axe_tracer
       end
     end 
   end   
-// synopsys translate_on
+`endif
 
 
 endmodule

--- a/bsg_cache/bsg_nonsynth_cache_axe_tracer.sv
+++ b/bsg_cache/bsg_nonsynth_cache_axe_tracer.sv
@@ -34,7 +34,7 @@ module bsg_nonsynth_cache_axe_tracer
   assign sbuf_entry = sbuf_entry_li;
 
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
   
   localparam logfile_lp = "bsg_cache.axe";
 

--- a/bsg_cache/bsg_wormhole_to_cache_dma_fanout.sv
+++ b/bsg_cache/bsg_wormhole_to_cache_dma_fanout.sv
@@ -405,14 +405,14 @@ module bsg_wormhole_to_cache_dma_fanout
     end
   end
 
-  //synopsys translate_off
+`ifndef SYNTHESIS
   if (wh_flit_width_p != dma_data_width_p)
     $error("WH flit width must be equal to DMA data width");
   if (wh_flit_width_p < dma_addr_width_p)
     $error("WH flit width must be larger than address width");
   if (wh_len_width_p < `BSG_WIDTH(dma_burst_len_p+1))
     $error("WH len width %d must be large enough to hold the dma transfer size %d", wh_len_width_p, `BSG_WIDTH(dma_burst_len_p+1));
-  //synopsys translate_on
+`endif
 
 endmodule
 

--- a/bsg_cache/bsg_wormhole_to_cache_dma_fanout.sv
+++ b/bsg_cache/bsg_wormhole_to_cache_dma_fanout.sv
@@ -405,7 +405,7 @@ module bsg_wormhole_to_cache_dma_fanout
     end
   end
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
   if (wh_flit_width_p != dma_data_width_p)
     $error("WH flit width must be equal to DMA data width");
   if (wh_flit_width_p < dma_addr_width_p)

--- a/bsg_cache/bsg_wormhole_to_cache_dma_inorder.sv
+++ b/bsg_cache/bsg_wormhole_to_cache_dma_inorder.sv
@@ -361,14 +361,14 @@ module bsg_wormhole_to_cache_dma_inorder
     end
   end
 
-  //synopsys translate_off
+`ifndef SYNTHESIS
   if (wh_flit_width_p != dma_data_width_p)
     $error("WH flit width must be equal to DMA data width");
   if (wh_flit_width_p < dma_addr_width_p)
     $error("WH flit width must be larger than address width");
   if (wh_len_width_p < `BSG_WIDTH(dma_burst_len_p+1))
     $error("WH len width %d must be large enough to hold the dma transfer size %d", wh_len_width_p, `BSG_WIDTH(dma_burst_len_p+1));
-  //synopsys translate_on
+`endif
 
 endmodule
 

--- a/bsg_cache/bsg_wormhole_to_cache_dma_inorder.sv
+++ b/bsg_cache/bsg_wormhole_to_cache_dma_inorder.sv
@@ -361,7 +361,7 @@ module bsg_wormhole_to_cache_dma_inorder
     end
   end
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
   if (wh_flit_width_p != dma_data_width_p)
     $error("WH flit width must be equal to DMA data width");
   if (wh_flit_width_p < dma_addr_width_p)

--- a/bsg_comm_link/bsg_comm_link.sv
+++ b/bsg_comm_link/bsg_comm_link.sv
@@ -554,7 +554,7 @@ module bsg_comm_link
              assign io_trigger_mode_alt_en [i]     = 1'b0;
              assign core_loopback_en       [i]     = 1'b0;
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
              // activate the channel if all of the "real" tests passed
              // MBT: we use triple equals because this handles the X case in simulation
              //      DC of course does not like ===

--- a/bsg_comm_link/bsg_source_sync_channel_control_slave.sv
+++ b/bsg_comm_link/bsg_source_sync_channel_control_slave.sv
@@ -208,7 +208,7 @@ module  bsg_source_sync_channel_control_slave #( parameter `BSG_INV_PARAM(width_
           out_rot_r                 <= out_rot_n;
      end
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
    always @(out_state_r)
      begin

--- a/bsg_comm_link/bsg_source_sync_channel_control_slave.sv
+++ b/bsg_comm_link/bsg_source_sync_channel_control_slave.sv
@@ -208,7 +208,7 @@ module  bsg_source_sync_channel_control_slave #( parameter `BSG_INV_PARAM(width_
           out_rot_r                 <= out_rot_n;
      end
 
-   // synopsys translate_off
+`ifndef SYNTHESIS
 
    always @(out_state_r)
      begin
@@ -220,7 +220,7 @@ module  bsg_source_sync_channel_control_slave #( parameter `BSG_INV_PARAM(width_
      assert (width_p > 2)
        else $error("width_p currently must be >= 3 because of calibration codes");
 
-   // synopsys translate_on
+`endif
 
    assign  out_channel_active_o  = (out_state_r == sActive);
    wire  out_loopback_en         = (out_state_r == sPhase3)

--- a/bsg_comm_link/bsg_source_sync_input.sv
+++ b/bsg_comm_link/bsg_source_sync_input.sv
@@ -213,7 +213,7 @@ module bsg_source_sync_input #(parameter lg_fifo_depth_p=5
                ? io_trigger_mode_active             // enque if we in trigger mode
                : (io_valid_0_r | io_valid_1_r);     // enque if either valid bit set
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
    always @(negedge io_clk_i)
      assert(!(io_async_fifo_full===1 && io_async_fifo_enq===1))

--- a/bsg_comm_link/bsg_source_sync_input.sv
+++ b/bsg_comm_link/bsg_source_sync_input.sv
@@ -213,13 +213,13 @@ module bsg_source_sync_input #(parameter lg_fifo_depth_p=5
                ? io_trigger_mode_active             // enque if we in trigger mode
                : (io_valid_0_r | io_valid_1_r);     // enque if either valid bit set
 
-   // synopsys translate_off
+`ifndef SYNTHESIS
 
    always @(negedge io_clk_i)
      assert(!(io_async_fifo_full===1 && io_async_fifo_enq===1))
        else $error("attempt to enque on full async fifo");
 
-   // synopsys translate_on
+`endif
 
 
    wire   core_actual_deque;

--- a/bsg_comm_link/bsg_source_sync_output.sv
+++ b/bsg_comm_link/bsg_source_sync_output.sv
@@ -185,13 +185,13 @@ module bsg_source_sync_output
     );
     */
    
-   // synopsys translate_off
+`ifndef SYNTHESIS
    always @(posedge io_master_clk_i)
    begin
       if (io_clk_init_i === 1)
 	$display("## %m Reset DDR clock");
    end
-   // synopsys translate_on
+`endif
 
    assign io_clk_n = ~io_clk_r_o;
 

--- a/bsg_comm_link/bsg_source_sync_output.sv
+++ b/bsg_comm_link/bsg_source_sync_output.sv
@@ -185,7 +185,7 @@ module bsg_source_sync_output
     );
     */
    
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
    always @(posedge io_master_clk_i)
    begin
       if (io_clk_init_i === 1)

--- a/bsg_dataflow/bsg_8b10b_shift_decoder.sv
+++ b/bsg_dataflow/bsg_8b10b_shift_decoder.sv
@@ -100,7 +100,7 @@ module bsg_8b10b_shift_decoder
   // Display an error if we ever see a K.28.7 code. This code is not allowed
   // with the given comma code detection logic.
 
-  // synopsys translate_off
+`ifndef SYNTHESIS
   always_ff @(negedge clk_i)
     begin
       if  (shift_reg_r !== 10'b0001_111100 && shift_reg_r !== 10'b1110_000011)
@@ -108,7 +108,7 @@ module bsg_8b10b_shift_decoder
       else
         $display("## decoding Error (%M) - K.28.7 Code Detected!");
     end
-  // synopsys translate_on
+`endif
 
 endmodule
 

--- a/bsg_dataflow/bsg_8b10b_shift_decoder.sv
+++ b/bsg_dataflow/bsg_8b10b_shift_decoder.sv
@@ -100,7 +100,7 @@ module bsg_8b10b_shift_decoder
   // Display an error if we ever see a K.28.7 code. This code is not allowed
   // with the given comma code detection logic.
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
   always_ff @(negedge clk_i)
     begin
       if  (shift_reg_r !== 10'b0001_111100 && shift_reg_r !== 10'b1110_000011)

--- a/bsg_dataflow/bsg_channel_narrow.sv
+++ b/bsg_dataflow/bsg_channel_narrow.sv
@@ -36,7 +36,7 @@ module bsg_channel_narrow #( parameter `BSG_INV_PARAM(width_in_p   )
 
   localparam padding_p    = width_in_p % width_out_p;
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
    initial
     assert (width_in_p % width_out_p == 0)
       else $display ("zero is padded to the left (in=%d) vs (out=%d)", width_in_p, width_out_p);

--- a/bsg_dataflow/bsg_channel_narrow.sv
+++ b/bsg_dataflow/bsg_channel_narrow.sv
@@ -36,11 +36,11 @@ module bsg_channel_narrow #( parameter `BSG_INV_PARAM(width_in_p   )
 
   localparam padding_p    = width_in_p % width_out_p;
 
-  //synopsys translate_off
+`ifndef SYNTHESIS
    initial
     assert (width_in_p % width_out_p == 0)
       else $display ("zero is padded to the left (in=%d) vs (out=%d)", width_in_p, width_out_p);
-  //synopsys translate_on
+`endif
 
   logic [width_out_p - 1: 0] data [divisions_lp - 1: 0];
   // in case of 2 divisions, it would be only 1 bit counter

--- a/bsg_dataflow/bsg_channel_tunnel.sv
+++ b/bsg_dataflow/bsg_channel_tunnel.sv
@@ -96,7 +96,7 @@ module bsg_channel_tunnel #(parameter width_p        = 1
     , input  [num_in_p-1:0]              yumi_i
     );
 
-   // synopsys translate_off
+`ifndef SYNTHESIS
    initial
      assert(lg_credit_decimation_p <= lg_remote_credits_lp)
        else
@@ -114,7 +114,7 @@ module bsg_channel_tunnel #(parameter width_p        = 1
                    ,num_in_p*lg_remote_credits_lp);
             $finish;
          end
-   // synopsys translate_on
+`endif
 
    wire [num_in_p-1:0][lg_remote_credits_lp-1:0] credit_local_return_data_oi;
    wire                                          credit_local_return_v_oi;

--- a/bsg_dataflow/bsg_channel_tunnel.sv
+++ b/bsg_dataflow/bsg_channel_tunnel.sv
@@ -96,7 +96,7 @@ module bsg_channel_tunnel #(parameter width_p        = 1
     , input  [num_in_p-1:0]              yumi_i
     );
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
    initial
      assert(lg_credit_decimation_p <= lg_remote_credits_lp)
        else

--- a/bsg_dataflow/bsg_channel_tunnel_out.sv
+++ b/bsg_dataflow/bsg_channel_tunnel_out.sv
@@ -47,13 +47,13 @@ module bsg_channel_tunnel_out #(
     , output credit_remote_return_yumi_o
     );
 
-   // synopsys translate_off
+`ifndef SYNTHESIS
    initial
      begin
         assert(remote_credits_p >= (1 << lg_credit_decimation_p))
           else $error("%m remote_credits_p is smaller than credit decimation factor!");
      end
-   // synopsys translate_on
+`endif
 
    genvar i;
 
@@ -64,11 +64,11 @@ module bsg_channel_tunnel_out #(
    // that transmit sections of the remote credits
    // but we'll wait until we run into that problem before we build it out
 
-   // synopsys translate_off
+`ifndef SYNTHESIS
    initial
       assert (width_p >= num_in_p*lg_remote_credits_lp)
         else $error("%m not enough room in packet to transmit all credit counters");
-   // synopsys translate_on
+`endif
 
    for (i = 0; i < num_in_p; i=i+1)
      begin: rof

--- a/bsg_dataflow/bsg_channel_tunnel_out.sv
+++ b/bsg_dataflow/bsg_channel_tunnel_out.sv
@@ -47,7 +47,7 @@ module bsg_channel_tunnel_out #(
     , output credit_remote_return_yumi_o
     );
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
    initial
      begin
         assert(remote_credits_p >= (1 << lg_credit_decimation_p))
@@ -64,7 +64,7 @@ module bsg_channel_tunnel_out #(
    // that transmit sections of the remote credits
    // but we'll wait until we run into that problem before we build it out
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
    initial
       assert (width_p >= num_in_p*lg_remote_credits_lp)
         else $error("%m not enough room in packet to transmit all credit counters");

--- a/bsg_dataflow/bsg_channel_tunnel_wormhole.sv
+++ b/bsg_dataflow/bsg_channel_tunnel_wormhole.sv
@@ -625,7 +625,7 @@ module  bsg_channel_tunnel_wormhole
   
 /*************************** Debugging Information ****************************/
   
-  // synopsys translate_off
+`ifndef SYNTHESIS
   initial 
   begin
   
@@ -637,7 +637,7 @@ module  bsg_channel_tunnel_wormhole
       end
 
   end
-  // synopsys translate_on
+`endif
 
 endmodule
 

--- a/bsg_dataflow/bsg_channel_tunnel_wormhole.sv
+++ b/bsg_dataflow/bsg_channel_tunnel_wormhole.sv
@@ -625,7 +625,7 @@ module  bsg_channel_tunnel_wormhole
   
 /*************************** Debugging Information ****************************/
   
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
   initial 
   begin
   

--- a/bsg_dataflow/bsg_fifo_1r1w_large.sv
+++ b/bsg_dataflow/bsg_fifo_1r1w_large.sv
@@ -125,10 +125,10 @@ module bsg_fifo_1r1w_large #(parameter `BSG_INV_PARAM(width_p)
     , input                yumi_i
     );
 
-   // synopsys translate_off
+`ifndef SYNTHESIS
    initial assert ((els_p & 1) == 0) else
      $error("odd number of elements for two port fifo not handled.");
-   // synopsys translate_on
+`endif
 
    wire [width_p*2-1:0] data_sipo;
    wire [1:0]          valid_sipo;
@@ -292,7 +292,7 @@ module bsg_fifo_1r1w_large #(parameter `BSG_INV_PARAM(width_p)
       ,.yumi_i (yumi_i    )
       );
 
-   // synopsys translate_off
+`ifndef SYNTHESIS
 
    // this sums up all of the storage in this fifo
    wire [31:0] num_elements_debug
@@ -301,7 +301,7 @@ module bsg_fifo_1r1w_large #(parameter `BSG_INV_PARAM(width_p)
                + sipo.valid_r[0] + sipo.valid_r[1]
                + !little_ready_rot[0] + !little_ready_rot[1];
 
-   // synopsys translate_on
+`endif
 
 
 endmodule

--- a/bsg_dataflow/bsg_fifo_1r1w_large.sv
+++ b/bsg_dataflow/bsg_fifo_1r1w_large.sv
@@ -125,7 +125,7 @@ module bsg_fifo_1r1w_large #(parameter `BSG_INV_PARAM(width_p)
     , input                yumi_i
     );
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
    initial assert ((els_p & 1) == 0) else
      $error("odd number of elements for two port fifo not handled.");
 `endif
@@ -292,7 +292,7 @@ module bsg_fifo_1r1w_large #(parameter `BSG_INV_PARAM(width_p)
       ,.yumi_i (yumi_i    )
       );
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
    // this sums up all of the storage in this fifo
    wire [31:0] num_elements_debug

--- a/bsg_dataflow/bsg_fifo_1r1w_pseudo_large.sv
+++ b/bsg_dataflow/bsg_fifo_1r1w_pseudo_large.sv
@@ -157,7 +157,7 @@ module bsg_fifo_1r1w_pseudo_large #(parameter `BSG_INV_PARAM(width_p )
 
    // ***** DEBUG ******
    // for debugging; whether we are bypassing the big fifo
-   // synopsys translate_off
+`ifndef SYNTHESIS
 
    wire bypass_mode = v_i & ~ big_enq;
 
@@ -176,7 +176,7 @@ module bsg_fifo_1r1w_pseudo_large #(parameter `BSG_INV_PARAM(width_p )
      if (verbose_p & (reset_i === 0) & (~big_enq_r & big_enq))
        $display("## %L: overflowing into big fifo for the first time (%m)");
 
-   // synopsys translate_on
+`endif
 
    //
    // ***** END DEBUG ******

--- a/bsg_dataflow/bsg_fifo_1r1w_pseudo_large.sv
+++ b/bsg_dataflow/bsg_fifo_1r1w_pseudo_large.sv
@@ -157,7 +157,7 @@ module bsg_fifo_1r1w_pseudo_large #(parameter `BSG_INV_PARAM(width_p )
 
    // ***** DEBUG ******
    // for debugging; whether we are bypassing the big fifo
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
    wire bypass_mode = v_i & ~ big_enq;
 

--- a/bsg_dataflow/bsg_fifo_1r1w_small_hardened.sv
+++ b/bsg_dataflow/bsg_fifo_1r1w_small_hardened.sv
@@ -126,7 +126,7 @@ module bsg_fifo_1r1w_small_hardened #(parameter `BSG_INV_PARAM(width_p)
    assign ready_param_o = ready_param_lo;
    assign v_o_tmp = ~empty;
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
    always_ff @ (negedge clk_i)
      begin
         if (ready_THEN_valid_p & full  & v_i    & ~reset_i)

--- a/bsg_dataflow/bsg_fifo_1r1w_small_hardened.sv
+++ b/bsg_dataflow/bsg_fifo_1r1w_small_hardened.sv
@@ -126,7 +126,7 @@ module bsg_fifo_1r1w_small_hardened #(parameter `BSG_INV_PARAM(width_p)
    assign ready_param_o = ready_param_lo;
    assign v_o_tmp = ~empty;
 
-   //synopsys translate_off
+`ifndef SYNTHESIS
    always_ff @ (negedge clk_i)
      begin
         if (ready_THEN_valid_p & full  & v_i    & ~reset_i)
@@ -134,7 +134,7 @@ module bsg_fifo_1r1w_small_hardened #(parameter `BSG_INV_PARAM(width_p)
         if (empty & yumi_i & ~reset_i)
           $display("%m error: deque empty fifo at time %t", $time);
      end
-   //synopsys translate_on
+`endif
 
 endmodule
 

--- a/bsg_dataflow/bsg_fifo_1r1w_small_unhardened.sv
+++ b/bsg_dataflow/bsg_fifo_1r1w_small_unhardened.sv
@@ -94,7 +94,7 @@ module bsg_fifo_1r1w_small_unhardened #( parameter `BSG_INV_PARAM(width_p      )
    assign ready_param_o = ready_param_lo;
    assign v_o_tmp = ~empty;
 
-   //synopsys translate_off
+`ifndef SYNTHESIS
    always_ff @ (negedge clk_i)
      begin
         if (ready_THEN_valid_p & full  & v_i    & ~reset_i)
@@ -102,7 +102,7 @@ module bsg_fifo_1r1w_small_unhardened #( parameter `BSG_INV_PARAM(width_p      )
         if (empty & yumi_i & ~reset_i)
           $display("%m error: deque empty fifo at time %t", $time);
      end
-   //synopsys translate_on
+`endif
 
 /*
    always_ff @(negedge clk_i)

--- a/bsg_dataflow/bsg_fifo_1r1w_small_unhardened.sv
+++ b/bsg_dataflow/bsg_fifo_1r1w_small_unhardened.sv
@@ -94,7 +94,7 @@ module bsg_fifo_1r1w_small_unhardened #( parameter `BSG_INV_PARAM(width_p      )
    assign ready_param_o = ready_param_lo;
    assign v_o_tmp = ~empty;
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
    always_ff @ (negedge clk_i)
      begin
         if (ready_THEN_valid_p & full  & v_i    & ~reset_i)

--- a/bsg_dataflow/bsg_fifo_1rw_large.sv
+++ b/bsg_dataflow/bsg_fifo_1rw_large.sv
@@ -55,7 +55,7 @@ module bsg_fifo_1rw_large #(parameter `BSG_INV_PARAM(width_p         )
    assign full_o  = fifo_full;
    assign empty_o = fifo_empty;
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
    always_ff @(posedge clk_i)
      assert (reset_i

--- a/bsg_dataflow/bsg_fifo_1rw_large.sv
+++ b/bsg_dataflow/bsg_fifo_1rw_large.sv
@@ -55,7 +55,7 @@ module bsg_fifo_1rw_large #(parameter `BSG_INV_PARAM(width_p         )
    assign full_o  = fifo_full;
    assign empty_o = fifo_empty;
 
-   // synopsys translate_off
+`ifndef SYNTHESIS
 
    always_ff @(posedge clk_i)
      assert (reset_i
@@ -86,7 +86,7 @@ module bsg_fifo_1rw_large #(parameter `BSG_INV_PARAM(width_p         )
                                            ? (wr_ptr - rd_ptr)
                                            : (els_p - (rd_ptr - wr_ptr)))));
 
-   // synopsys translate_on
+`endif
 
    bsg_circular_ptr #(.slots_p(els_p)
                       ,.max_add_p(1)

--- a/bsg_dataflow/bsg_fifo_reorder.sv
+++ b/bsg_dataflow/bsg_fifo_reorder.sv
@@ -130,7 +130,7 @@ module bsg_fifo_reorder
   assign fifo_deq_id_o = rptr_r;
 
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
   always_ff @ (negedge clk_i) begin
     if (~reset_i) begin

--- a/bsg_dataflow/bsg_fifo_reorder.sv
+++ b/bsg_dataflow/bsg_fifo_reorder.sv
@@ -130,7 +130,7 @@ module bsg_fifo_reorder
   assign fifo_deq_id_o = rptr_r;
 
 
-  // synopsys translate_off
+`ifndef SYNTHESIS
 
   always_ff @ (negedge clk_i) begin
     if (~reset_i) begin
@@ -147,7 +147,7 @@ module bsg_fifo_reorder
     end    
   end
 
-  // synopsys translate_on
+`endif
 
 
 endmodule

--- a/bsg_dataflow/bsg_parallel_in_serial_out_passthrough.sv
+++ b/bsg_dataflow/bsg_parallel_in_serial_out_passthrough.sv
@@ -80,7 +80,7 @@ module bsg_parallel_in_serial_out_passthrough #( parameter `BSG_INV_PARAM(width_
      );
   assign v_o = v_i;
 
-  //synopsys translate_off
+`ifndef SYNTHESIS
   logic [els_p-1:0][width_p-1:0] initial_data_r;
   bsg_dff_en
    #(.width_p(width_p*els_p))
@@ -102,7 +102,7 @@ module bsg_parallel_in_serial_out_passthrough #( parameter `BSG_INV_PARAM(width_
             else $error("data_i must be held constant during the entire PISO transaction");
         end
     end
-  //synopsys translate_on
+`endif
 
 endmodule
 

--- a/bsg_dataflow/bsg_parallel_in_serial_out_passthrough.sv
+++ b/bsg_dataflow/bsg_parallel_in_serial_out_passthrough.sv
@@ -80,7 +80,7 @@ module bsg_parallel_in_serial_out_passthrough #( parameter `BSG_INV_PARAM(width_
      );
   assign v_o = v_i;
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
   logic [els_p-1:0][width_p-1:0] initial_data_r;
   bsg_dff_en
    #(.width_p(width_p*els_p))

--- a/bsg_dataflow/bsg_scatter_gather.py
+++ b/bsg_dataflow/bsg_scatter_gather.py
@@ -202,9 +202,9 @@ module bsg_scatter_gather #(`BSG_INV_PARAM(vec_size_lp))
 for x in channels :
     generate_code_for_channel(x)
 
-print "// synopsys translate_off";
+print "`ifndef SYNTHESIS";
 print "initial assert (vec_size_lp < ",max_channel,") else $error(\"bsg_scatter_gather: vec_size_lp too large %d\", vec_size_lp);";
-print "// synopsys translate_on";
+print "`endif";
 
 print "endmodule";
 

--- a/bsg_dataflow/bsg_scatter_gather.py
+++ b/bsg_dataflow/bsg_scatter_gather.py
@@ -202,7 +202,7 @@ module bsg_scatter_gather #(`BSG_INV_PARAM(vec_size_lp))
 for x in channels :
     generate_code_for_channel(x)
 
-print "`ifndef SYNTHESIS";
+print "`ifndef BSG_HIDE_FROM_SYNTHESIS";
 print "initial assert (vec_size_lp < ",max_channel,") else $error(\"bsg_scatter_gather: vec_size_lp too large %d\", vec_size_lp);";
 print "`endif";
 

--- a/bsg_dataflow/bsg_scatter_gather.sv
+++ b/bsg_dataflow/bsg_scatter_gather.sv
@@ -16709,7 +16709,7 @@ if (vec_size_lp == 11)
         default: fwd_datapath_o= 'X;
     endcase
   end
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 initial assert (vec_size_lp <  12 ) else $error("bsg_scatter_gather: vec_size_lp too large %d", vec_size_lp);
 `endif
 endmodule

--- a/bsg_dataflow/bsg_scatter_gather.sv
+++ b/bsg_dataflow/bsg_scatter_gather.sv
@@ -16709,9 +16709,9 @@ if (vec_size_lp == 11)
         default: fwd_datapath_o= 'X;
     endcase
   end
-// synopsys translate_off
+`ifndef SYNTHESIS
 initial assert (vec_size_lp <  12 ) else $error("bsg_scatter_gather: vec_size_lp too large %d", vec_size_lp);
-// synopsys translate_on
+`endif
 endmodule
 
 `BSG_ABSTRACT_MODULE(bsg_scatter_gather)

--- a/bsg_dataflow/bsg_two_buncher.sv
+++ b/bsg_dataflow/bsg_two_buncher.sv
@@ -37,7 +37,7 @@ module bsg_two_buncher #(parameter `BSG_INV_PARAM(width_p))
    logic [width_p-1:0] data_r,   data_n;
    logic              data_v_r, data_v_n, data_en;
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
    always @(posedge clk_i)
      assert (  (ready_and_i[1] !== 1'b1) | ready_and_i[0])
        else $error("potentially invalid ready pattern\n");

--- a/bsg_dataflow/bsg_two_buncher.sv
+++ b/bsg_dataflow/bsg_two_buncher.sv
@@ -37,7 +37,7 @@ module bsg_two_buncher #(parameter `BSG_INV_PARAM(width_p))
    logic [width_p-1:0] data_r,   data_n;
    logic              data_v_r, data_v_n, data_en;
 
-   // synopsys translate_off
+`ifndef SYNTHESIS
    always @(posedge clk_i)
      assert (  (ready_and_i[1] !== 1'b1) | ready_and_i[0])
        else $error("potentially invalid ready pattern\n");
@@ -46,7 +46,7 @@ module bsg_two_buncher #(parameter `BSG_INV_PARAM(width_p))
      assert ( (v_o[1] !== 1'b1) | v_o[0])
        else $error("invalide valid output pattern\n");
 
-   // synopsys translate_on
+`endif
 
    always_ff @(posedge clk_i)
      if (reset_i)

--- a/bsg_dataflow/bsg_two_fifo.sv
+++ b/bsg_dataflow/bsg_two_fifo.sv
@@ -105,7 +105,7 @@ module bsg_two_fifo #(parameter `BSG_INV_PARAM(width_p)
           end // else: !if(reset_i)
      end // always_ff @
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
    always_ff @(posedge clk_i)
      begin
         if (~reset_i)

--- a/bsg_dataflow/bsg_two_fifo.sv
+++ b/bsg_dataflow/bsg_two_fifo.sv
@@ -105,7 +105,7 @@ module bsg_two_fifo #(parameter `BSG_INV_PARAM(width_p)
           end // else: !if(reset_i)
      end // always_ff @
 
-   // synopsys translate_off
+`ifndef SYNTHESIS
    always_ff @(posedge clk_i)
      begin
         if (~reset_i)
@@ -140,7 +140,7 @@ module bsg_two_fifo #(parameter `BSG_INV_PARAM(width_p)
    // for debugging
    wire [31:0] num_elements_debug = full_r + (empty_r==0);
 
-   // synopsys translate_on
+`endif
 
 endmodule
 

--- a/bsg_legacy/bsg_fsb/bsg_fsb.v
+++ b/bsg_legacy/bsg_fsb/bsg_fsb.v
@@ -181,7 +181,7 @@ module bsg_fsb #(parameter `BSG_INV_PARAM( width_p )
         assign node_data_o[i] = node_data_o_int;
         assign node_en_r_o[i] = node_en_r_int;
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
         always @(negedge node_reset_r_o[i])
           begin
              $display("   __         _                                    _");
@@ -362,7 +362,7 @@ module bsg_fsb #(parameter `BSG_INV_PARAM( width_p )
         assign node_data_o[i] = node_data_o_int;
         assign node_en_r_o[i] = node_en_r_int;
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
         always @(negedge node_reset_r_o[i])
           begin
              $display("   __         _                                    _");

--- a/bsg_legacy/bsg_fsb/bsg_fsb.v
+++ b/bsg_legacy/bsg_fsb/bsg_fsb.v
@@ -181,7 +181,7 @@ module bsg_fsb #(parameter `BSG_INV_PARAM( width_p )
         assign node_data_o[i] = node_data_o_int;
         assign node_en_r_o[i] = node_en_r_int;
 
-        // synopsys translate_off
+`ifndef SYNTHESIS
         always @(negedge node_reset_r_o[i])
           begin
              $display("   __         _                                    _");
@@ -202,7 +202,7 @@ module bsg_fsb #(parameter `BSG_INV_PARAM( width_p )
              $display(" |_|   |___/ |_.__/     \\___| |_| |_|  \\__,_| |_.__/  |_|  \\___|  ");
              $display("## enable high on FSB in module %m, node %2d, time = ",i, $stime);
           end
-        // synopsys translate_on
+`endif
      end
 
 endmodule
@@ -362,7 +362,7 @@ module bsg_fsb #(parameter `BSG_INV_PARAM( width_p )
         assign node_data_o[i] = node_data_o_int;
         assign node_en_r_o[i] = node_en_r_int;
 
-        // synopsys translate_off
+`ifndef SYNTHESIS
         always @(negedge node_reset_r_o[i])
           begin
              $display("   __         _                                    _");
@@ -383,7 +383,7 @@ module bsg_fsb #(parameter `BSG_INV_PARAM( width_p )
              $display(" |_|   |___/ |_.__/     \\___| |_| |_|  \\__,_| |_.__/  |_|  \\___|  ");
              $display("## enable high on FSB in module %m, node %2d, time = ",i, $stime);
           end
-        // synopsys translate_on
+`endif
      end
 
 endmodule

--- a/bsg_legacy/bsg_fsb/bsg_fsb_node_trace_replay.v
+++ b/bsg_legacy/bsg_fsb/bsg_fsb_node_trace_replay.v
@@ -171,7 +171,7 @@ module bsg_fsb_node_trace_replay
           end
      end
 
-   // synopsys translate_off
+`ifndef SYNTHESIS
    // non-synthesizeable components
    always @(negedge clk_i)
      begin
@@ -246,6 +246,6 @@ module bsg_fsb_node_trace_replay
              endcase // case (op)
           end // if (instr_completed & ~reset_i & ~done_r)
      end // always @ (negedge clk_i)
-   // synopsys translate_on
+`endif
 
 endmodule

--- a/bsg_legacy/bsg_fsb/bsg_fsb_node_trace_replay.v
+++ b/bsg_legacy/bsg_fsb/bsg_fsb_node_trace_replay.v
@@ -171,7 +171,7 @@ module bsg_fsb_node_trace_replay
           end
      end
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
    // non-synthesizeable components
    always @(negedge clk_i)
      begin

--- a/bsg_legacy/bsg_tag/config_net/src/config_node.v
+++ b/bsg_legacy/bsg_tag/config_net/src/config_node.v
@@ -118,7 +118,7 @@ module config_node
   assign shift_n = {config_i.cfg_bit, shift_r[1 +: shift_width_lp - 1]};
 
 
-  // synopsys translate_off
+`ifndef SYNTHESIS
 
    // non-synthesizeable helper message
   always @(negedge config_i.cfg_clk)
@@ -127,7 +127,7 @@ module config_node
          $display("## I: CONFIG NODE (id=%-d,default=%-d'b%-b,packet_size=%-d) received reset packet (%m)",id_p,data_bits_p,default_p,$bits(node_packet_s));
     end
 
-  // synopsys translate_on
+`endif
 
    // we break up the config register into three parts because it is too tall
 

--- a/bsg_legacy/bsg_tag/config_net/src/config_node.v
+++ b/bsg_legacy/bsg_tag/config_net/src/config_node.v
@@ -118,7 +118,7 @@ module config_node
   assign shift_n = {config_i.cfg_bit, shift_r[1 +: shift_width_lp - 1]};
 
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
    // non-synthesizeable helper message
   always @(negedge config_i.cfg_clk)

--- a/bsg_link/bsg_link_ddr_downstream.sv
+++ b/bsg_link/bsg_link_ddr_downstream.sv
@@ -198,7 +198,7 @@ module bsg_link_ddr_downstream
     );
   end
   
-  // synopsys translate_off
+`ifndef SYNTHESIS
   initial 
   begin
     assert (sipo_ratio_lp > 0)
@@ -215,7 +215,7 @@ module bsg_link_ddr_downstream
         $finish;
       end
   end
-  // synopsys translate_on
+`endif
 
 endmodule
 `BSG_ABSTRACT_MODULE(bsg_link_ddr_downstream)

--- a/bsg_link/bsg_link_ddr_downstream.sv
+++ b/bsg_link/bsg_link_ddr_downstream.sv
@@ -198,7 +198,7 @@ module bsg_link_ddr_downstream
     );
   end
   
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
   initial 
   begin
     assert (sipo_ratio_lp > 0)

--- a/bsg_link/bsg_link_ddr_upstream.sv
+++ b/bsg_link/bsg_link_ddr_upstream.sv
@@ -215,7 +215,7 @@ module bsg_link_ddr_upstream
   
   end
   
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
   initial 
   begin
     assert (piso_ratio_lp > 0)

--- a/bsg_link/bsg_link_ddr_upstream.sv
+++ b/bsg_link/bsg_link_ddr_upstream.sv
@@ -215,7 +215,7 @@ module bsg_link_ddr_upstream
   
   end
   
-  // synopsys translate_off
+`ifndef SYNTHESIS
   initial 
   begin
     assert (piso_ratio_lp > 0)
@@ -232,7 +232,7 @@ module bsg_link_ddr_upstream
         $finish;
       end
   end
-  // synopsys translate_on
+`endif
 
 endmodule
 `BSG_ABSTRACT_MODULE(bsg_link_ddr_upstream)

--- a/bsg_link/bsg_link_osdr_phy_phase_align.sv
+++ b/bsg_link/bsg_link_osdr_phy_phase_align.sv
@@ -55,7 +55,7 @@ module bsg_link_osdr_phy_phase_align
   bsg_dff_reset #(.width_p(1),.reset_val_p(0)) clk_ff_n
   (.clk_i(~clk_i),.reset_i(reset_i),.data_i(~clk_r_n),.data_o(clk_r_n));
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
   initial
   begin
     $display("## %L: instantiating unhardened bsg_link_osdr_phase_align (%m)");

--- a/bsg_link/bsg_link_osdr_phy_phase_align.sv
+++ b/bsg_link/bsg_link_osdr_phy_phase_align.sv
@@ -55,11 +55,11 @@ module bsg_link_osdr_phy_phase_align
   bsg_dff_reset #(.width_p(1),.reset_val_p(0)) clk_ff_n
   (.clk_i(~clk_i),.reset_i(reset_i),.data_i(~clk_r_n),.data_o(clk_r_n));
 
-  // synopsys translate_off
+`ifndef SYNTHESIS
   initial
   begin
     $display("## %L: instantiating unhardened bsg_link_osdr_phase_align (%m)");
   end
-  // synopsys translate_on
+`endif
 
 endmodule

--- a/bsg_link/bsg_link_source_sync_downstream.sv
+++ b/bsg_link/bsg_link_source_sync_downstream.sv
@@ -84,7 +84,7 @@ module bsg_link_source_sync_downstream
    logic io_fifo_valid_lo, io_fifo_ready_lo;
    logic [channel_width_p-1:0] io_async_fifo_data;
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
    always_ff @(negedge io_clk_i)
      assert(!(io_fifo_ready_lo===0 && io_valid_i===1))

--- a/bsg_link/bsg_link_source_sync_downstream.sv
+++ b/bsg_link/bsg_link_source_sync_downstream.sv
@@ -84,13 +84,13 @@ module bsg_link_source_sync_downstream
    logic io_fifo_valid_lo, io_fifo_ready_lo;
    logic [channel_width_p-1:0] io_async_fifo_data;
 
-   // synopsys translate_off
+`ifndef SYNTHESIS
 
    always_ff @(negedge io_clk_i)
      assert(!(io_fifo_ready_lo===0 && io_valid_i===1))
        else $error("attempt to enque on full async fifo");
 
-   // synopsys translate_on
+`endif
 
   if (use_hardened_fifo_p == 0)
   begin

--- a/bsg_mem/bsg_cam_1r1w_tag_array.sv
+++ b/bsg_mem/bsg_cam_1r1w_tag_array.sv
@@ -73,7 +73,7 @@ module bsg_cam_1r1w_tag_array
     end
       end
 
-  //synopsys translate_off
+`ifndef SYNTHESIS
   always_ff @(negedge clk_i) begin
     assert(multiple_entries_p || reset_i || $countones(r_match_o) <= 1)
       else $error("Multiple similar entries are found in match_array\
@@ -83,7 +83,7 @@ module bsg_cam_1r1w_tag_array
 	assert(reset_i || $countones(w_v_i & {safe_els_lp{w_set_not_clear_i}}) <= 1)
       else $error("Inv_r one-hot write address %b\n", w_v_i);
   end 
-  //synopsys translate_on
+`endif
 
 endmodule
 

--- a/bsg_mem/bsg_cam_1r1w_tag_array.sv
+++ b/bsg_mem/bsg_cam_1r1w_tag_array.sv
@@ -73,7 +73,7 @@ module bsg_cam_1r1w_tag_array
     end
       end
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
   always_ff @(negedge clk_i) begin
     assert(multiple_entries_p || reset_i || $countones(r_match_o) <= 1)
       else $error("Multiple similar entries are found in match_array\

--- a/bsg_mem/bsg_mem_1r1w.sv
+++ b/bsg_mem/bsg_mem_1r1w.sv
@@ -34,7 +34,7 @@ module bsg_mem_1r1w #(parameter `BSG_INV_PARAM(width_p)
        ) synth
        (.*);
 
-   //synopsys translate_off
+`ifndef SYNTHESIS
 
    initial
      begin
@@ -52,7 +52,7 @@ module bsg_mem_1r1w #(parameter `BSG_INV_PARAM(width_p)
             else $error("%m: Attempt to read and write same address %x (w_v_i = %b, w_reset_i = %b)",w_addr_i,w_v_i,w_reset_i);
        end
 
-   //synopsys translate_on
+`endif
 
 endmodule
 

--- a/bsg_mem/bsg_mem_1r1w.sv
+++ b/bsg_mem/bsg_mem_1r1w.sv
@@ -34,7 +34,7 @@ module bsg_mem_1r1w #(parameter `BSG_INV_PARAM(width_p)
        ) synth
        (.*);
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
    initial
      begin

--- a/bsg_mem/bsg_mem_1r1w_one_hot.sv
+++ b/bsg_mem/bsg_mem_1r1w_one_hot.sv
@@ -52,7 +52,7 @@ module bsg_mem_1r1w_one_hot #(parameter `BSG_INV_PARAM(width_p)
      ,.data_o(r_data_o)
      );
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
    initial
      begin

--- a/bsg_mem/bsg_mem_1r1w_one_hot.sv
+++ b/bsg_mem/bsg_mem_1r1w_one_hot.sv
@@ -52,7 +52,7 @@ module bsg_mem_1r1w_one_hot #(parameter `BSG_INV_PARAM(width_p)
      ,.data_o(r_data_o)
      );
 
-   //synopsys translate_off
+`ifndef SYNTHESIS
 
    initial
      begin
@@ -69,7 +69,7 @@ module bsg_mem_1r1w_one_hot #(parameter `BSG_INV_PARAM(width_p)
          else $error("Invalid read address %b to %m is not onehot (w_reset_i=%b)\n", r_v_i, w_reset_i);
      end
 
-   //synopsys translate_on
+`endif
 
 endmodule
 

--- a/bsg_mem/bsg_mem_1r1w_sync.sv
+++ b/bsg_mem/bsg_mem_1r1w_sync.sv
@@ -70,7 +70,7 @@ module bsg_mem_1r1w_sync #(parameter `BSG_INV_PARAM(width_p)
        ,.r_data_o
        );
 
-   //synopsys translate_off
+`ifndef SYNTHESIS
    initial
      begin
 	// we warn if els_p >= 16 because it is a good candidate for hardening
@@ -94,7 +94,7 @@ module bsg_mem_1r1w_sync #(parameter `BSG_INV_PARAM(width_p)
                  $error("X'ing matched read address %x (%m)",r_addr_i);
               end
        end
-   //synopsys translate_on
+`endif
 
 endmodule
 

--- a/bsg_mem/bsg_mem_1r1w_sync.sv
+++ b/bsg_mem/bsg_mem_1r1w_sync.sv
@@ -70,7 +70,7 @@ module bsg_mem_1r1w_sync #(parameter `BSG_INV_PARAM(width_p)
        ,.r_data_o
        );
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
    initial
      begin
 	// we warn if els_p >= 16 because it is a good candidate for hardening

--- a/bsg_mem/bsg_mem_1r1w_sync_banked.sv
+++ b/bsg_mem/bsg_mem_1r1w_sync_banked.sv
@@ -154,7 +154,7 @@ module bsg_mem_1r1w_sync_banked
   end
 
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
   initial begin
     assert(els_p % num_depth_bank_p == 0)

--- a/bsg_mem/bsg_mem_1r1w_sync_banked.sv
+++ b/bsg_mem/bsg_mem_1r1w_sync_banked.sv
@@ -154,7 +154,7 @@ module bsg_mem_1r1w_sync_banked
   end
 
 
-  // synopsys translate_off
+`ifndef SYNTHESIS
 
   initial begin
     assert(els_p % num_depth_bank_p == 0)
@@ -164,7 +164,7 @@ module bsg_mem_1r1w_sync_banked
       else $error("[BSG_ERROR] num_width_bank_p does not divide even with width_p. %m");
   end
   
-  // synopsys translate_on
+`endif
   
 
 

--- a/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit.sv
+++ b/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit.sv
@@ -67,7 +67,7 @@ module bsg_mem_1r1w_sync_mask_write_bit #(parameter `BSG_INV_PARAM(width_p)
        ,.r_data_o
        );
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
 /*
    always_ff @(negedge clk_lo)

--- a/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit.sv
+++ b/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit.sv
@@ -67,7 +67,7 @@ module bsg_mem_1r1w_sync_mask_write_bit #(parameter `BSG_INV_PARAM(width_p)
        ,.r_data_o
        );
 
-   //synopsys translate_off
+`ifndef SYNTHESIS
 
 /*
    always_ff @(negedge clk_lo)
@@ -99,7 +99,7 @@ module bsg_mem_1r1w_sync_mask_write_bit #(parameter `BSG_INV_PARAM(width_p)
           $display("## %m %L: disable_collision_warning_p is set; you should not have this on unless you have broken code. fix it!\n");
      end
 
-   //synopsys translate_on
+`endif
 
    
 endmodule

--- a/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit_synth.sv
+++ b/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit_synth.sv
@@ -76,7 +76,7 @@ module bsg_mem_1r1w_sync_mask_write_bit_synth #(parameter `BSG_INV_PARAM(width_p
         if (r_v_i)
           r_addr_r <= r_addr_i;
 
-        // synopsys translate_off
+`ifndef SYNTHESIS
         else
           r_addr_r <= 'X;
 
@@ -90,7 +90,7 @@ module bsg_mem_1r1w_sync_mask_write_bit_synth #(parameter `BSG_INV_PARAM(width_p
                end
              r_addr_r <= 'X;
           end
-        // synopsys translate_on
+`endif
 
      end
 

--- a/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit_synth.sv
+++ b/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit_synth.sv
@@ -76,7 +76,7 @@ module bsg_mem_1r1w_sync_mask_write_bit_synth #(parameter `BSG_INV_PARAM(width_p
         if (r_v_i)
           r_addr_r <= r_addr_i;
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
         else
           r_addr_r <= 'X;
 

--- a/bsg_mem/bsg_mem_1r1w_sync_mask_write_byte.sv
+++ b/bsg_mem/bsg_mem_1r1w_sync_mask_write_byte.sv
@@ -70,7 +70,7 @@ module bsg_mem_1r1w_sync_mask_write_byte #(parameter `BSG_INV_PARAM(width_p)
        ,.r_data_o
        );
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
 /*
    always_ff @(negedge clk_lo)

--- a/bsg_mem/bsg_mem_1r1w_sync_mask_write_byte.sv
+++ b/bsg_mem/bsg_mem_1r1w_sync_mask_write_byte.sv
@@ -70,7 +70,7 @@ module bsg_mem_1r1w_sync_mask_write_byte #(parameter `BSG_INV_PARAM(width_p)
        ,.r_data_o
        );
 
-   //synopsys translate_off
+`ifndef SYNTHESIS
 
 /*
    always_ff @(negedge clk_lo)
@@ -102,7 +102,7 @@ module bsg_mem_1r1w_sync_mask_write_byte #(parameter `BSG_INV_PARAM(width_p)
           $display("## %m %L: disable_collision_warning_p is set; you should not have this on unless you have broken code. fix it!\n");
      end
 
-   //synopsys translate_on
+`endif
 
    
 endmodule

--- a/bsg_mem/bsg_mem_1r1w_sync_synth.sv
+++ b/bsg_mem/bsg_mem_1r1w_sync_synth.sv
@@ -113,13 +113,13 @@ module bsg_mem_1r1w_sync_synth #(parameter `BSG_INV_PARAM(width_p)
 
    end
 
-   // synopsys translate_off
+`ifndef SYNTHESIS
    initial
      begin
         if (verbose_p)
       $display("## %L: instantiating width_p=%d, els_p=%d (%m)",width_p,els_p);
      end
-   // synopsys translate_on
+`endif
 
 endmodule
 

--- a/bsg_mem/bsg_mem_1r1w_sync_synth.sv
+++ b/bsg_mem/bsg_mem_1r1w_sync_synth.sv
@@ -113,7 +113,7 @@ module bsg_mem_1r1w_sync_synth #(parameter `BSG_INV_PARAM(width_p)
 
    end
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
    initial
      begin
         if (verbose_p)

--- a/bsg_mem/bsg_mem_1rw_sync_banked.sv
+++ b/bsg_mem/bsg_mem_1rw_sync_banked.sv
@@ -134,7 +134,7 @@ module bsg_mem_1rw_sync_banked
   end
 
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
   initial begin
     assert(els_p % num_depth_bank_p == 0)

--- a/bsg_mem/bsg_mem_1rw_sync_banked.sv
+++ b/bsg_mem/bsg_mem_1rw_sync_banked.sv
@@ -134,7 +134,7 @@ module bsg_mem_1rw_sync_banked
   end
 
 
-  // synopsys translate_off
+`ifndef SYNTHESIS
 
   initial begin
     assert(els_p % num_depth_bank_p == 0)
@@ -144,7 +144,7 @@ module bsg_mem_1rw_sync_banked
       else $error("[BSG_ERROR] num_width_bank_p does not divide even with width_p. %m");
   end
   
-  // synopsys translate_on
+`endif
   
 
 

--- a/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.sv
+++ b/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.sv
@@ -53,7 +53,7 @@ module bsg_mem_1rw_sync_mask_write_bit #(
        );
 
 
-   // synopsys translate_off
+`ifndef SYNTHESIS
    always_ff @(negedge clk_lo)
    if (((els_p > 1) && (v_i === 1)))
      assert (((reset_i === 'X) || (reset_i === 1'b1) || (els_p <= 1) || (addr_i < els_p)))
@@ -62,7 +62,7 @@ module bsg_mem_1rw_sync_mask_write_bit #(
      begin
         $display("## %L: instantiating width_p=%d, els_p=%d (%m)",width_p,els_p);
      end
-  // synopsys translate_on
+`endif
 
    
 endmodule

--- a/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.sv
+++ b/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.sv
@@ -53,7 +53,7 @@ module bsg_mem_1rw_sync_mask_write_bit #(
        );
 
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
    always_ff @(negedge clk_lo)
    if (((els_p > 1) && (v_i === 1)))
      assert (((reset_i === 'X) || (reset_i === 1'b1) || (els_p <= 1) || (addr_i < els_p)))

--- a/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_banked.sv
+++ b/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_banked.sv
@@ -136,7 +136,7 @@ module bsg_mem_1rw_sync_mask_write_bit_banked
   end
 
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
   initial begin
     assert(els_p % num_depth_bank_p == 0)

--- a/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_banked.sv
+++ b/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_banked.sv
@@ -136,7 +136,7 @@ module bsg_mem_1rw_sync_mask_write_bit_banked
   end
 
 
-  // synopsys translate_off
+`ifndef SYNTHESIS
 
   initial begin
     assert(els_p % num_depth_bank_p == 0)
@@ -146,7 +146,7 @@ module bsg_mem_1rw_sync_mask_write_bit_banked
       else $error("[BSG_ERROR] num_width_bank_p does not divide even with width_p. %m");
   end
   
-  // synopsys translate_on
+`endif
 
 
 endmodule

--- a/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_from_1r1w.sv
+++ b/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_from_1r1w.sv
@@ -45,7 +45,7 @@ module bsg_mem_1rw_sync_mask_write_bit_from_1r1w #(
   , output [width_m1_lp:0]       data_o
 );
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
   always @(negedge clk_i)
     assert((int'(addr_i) < els_p) || (els_p <= 1)) else $warning("%m Accessing uninitialized address!");
 `endif
@@ -132,7 +132,7 @@ module bsg_mem_1rw_sync_mask_write_bit_from_1r1w #(
 
   wire [width_m1_lp:0] data_o_latchable = bypass_r ? bypass_data_r : mem_data_lo;
   
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
   always_ff @(posedge clk_i)
     if(verbose_p==1)
       $display("w_en %b | r_en %b | w_data_li %b | mem_data_lo %b | w_addr_r %06h"

--- a/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_from_1r1w.sv
+++ b/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_from_1r1w.sv
@@ -45,10 +45,10 @@ module bsg_mem_1rw_sync_mask_write_bit_from_1r1w #(
   , output [width_m1_lp:0]       data_o
 );
 
-  // synopsys translate_off
+`ifndef SYNTHESIS
   always @(negedge clk_i)
     assert((int'(addr_i) < els_p) || (els_p <= 1)) else $warning("%m Accessing uninitialized address!");
-  // synopsys translate_on
+`endif
 
   wire                      v_and_w_n = v_i & w_i;
   wire                      v_and_w_r;
@@ -132,14 +132,14 @@ module bsg_mem_1rw_sync_mask_write_bit_from_1r1w #(
 
   wire [width_m1_lp:0] data_o_latchable = bypass_r ? bypass_data_r : mem_data_lo;
   
-  // synopsys translate_off
+`ifndef SYNTHESIS
   always_ff @(posedge clk_i)
     if(verbose_p==1)
       $display("w_en %b | r_en %b | w_data_li %b | mem_data_lo %b | w_addr_r %06h"
               , w_en_li, r_en_li, w_data_li, mem_data_lo, w_addr_r
               , "| bypass_data_r %b | bypass_r %b|"
               , bypass_data_r, bypass_r);
-  // synopsys translate_on
+`endif
 
   if (latch_last_read_p)
     begin: llr

--- a/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
+++ b/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
@@ -51,7 +51,7 @@ module bsg_mem_1rw_sync_mask_write_byte #(parameter `BSG_INV_PARAM(els_p)
    ,.data_o
    );
 
-  // synopsys translate_off
+`ifndef SYNTHESIS
 
   always_comb
     assert (data_width_p % 8 == 0)
@@ -62,7 +62,7 @@ module bsg_mem_1rw_sync_mask_write_byte #(parameter `BSG_INV_PARAM(els_p)
         $display("## %L: instantiating data_width_p=%d, els_p=%d (%m)",data_width_p,els_p);
      end
 
-  // synopsys translate_on
+`endif
 
    
 endmodule

--- a/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
+++ b/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
@@ -51,7 +51,7 @@ module bsg_mem_1rw_sync_mask_write_byte #(parameter `BSG_INV_PARAM(els_p)
    ,.data_o
    );
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
   always_comb
     assert (data_width_p % 8 == 0)

--- a/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_banked.sv
+++ b/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_banked.sv
@@ -138,7 +138,7 @@ module bsg_mem_1rw_sync_mask_write_byte_banked
   end
 
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
   initial begin
 

--- a/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_banked.sv
+++ b/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_banked.sv
@@ -138,7 +138,7 @@ module bsg_mem_1rw_sync_mask_write_byte_banked
   end
 
 
-  // synopsys translate_off
+`ifndef SYNTHESIS
 
   initial begin
 
@@ -153,7 +153,7 @@ module bsg_mem_1rw_sync_mask_write_byte_banked
 
   end
   
-  // synopsys translate_on
+`endif
 
 
 endmodule

--- a/bsg_mem/bsg_mem_1rw_sync_synth.sv
+++ b/bsg_mem/bsg_mem_1rw_sync_synth.sv
@@ -81,7 +81,7 @@ module bsg_mem_1rw_sync_synth
       if (v_i & w_i) 
         mem[addr_li] <= data_i;
    end // non_zero_width
-   // synopsys translate_off
+`ifndef SYNTHESIS
    initial
      begin
         if (verbose_p)
@@ -93,7 +93,7 @@ module bsg_mem_1rw_sync_synth
      if (v_i)
        assert ( (v_i !== 1'b1) || (reset_i === 'X) || (reset_i === 1'b1) || (addr_i < els_p) || (els_p <= 1))
          else $error("Invalid address %x to %m of size %x (reset_i = %b, v_i = %b, clk_i = %b)\n", addr_i, els_p, reset_i, v_i, clk_i);
-   // synopsys translate_on
+`endif
 
 endmodule
 

--- a/bsg_mem/bsg_mem_1rw_sync_synth.sv
+++ b/bsg_mem/bsg_mem_1rw_sync_synth.sv
@@ -81,7 +81,7 @@ module bsg_mem_1rw_sync_synth
       if (v_i & w_i) 
         mem[addr_li] <= data_i;
    end // non_zero_width
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
    initial
      begin
         if (verbose_p)

--- a/bsg_mem/bsg_mem_2r1w.sv
+++ b/bsg_mem/bsg_mem_2r1w.sv
@@ -36,7 +36,7 @@ module bsg_mem_2r1w #(parameter `BSG_INV_PARAM(width_p)
        ) synth
        (.*);
 
-// synopsys translate_off
+`ifndef SYNTHESIS
 
    always_ff @(negedge w_clk_i)
      if (w_v_i)
@@ -56,7 +56,7 @@ module bsg_mem_2r1w #(parameter `BSG_INV_PARAM(width_p)
         $display("## %L: instantiating width_p=%d, els_p=%d, read_write_same_addr_p=%d (%m)",width_p,els_p,read_write_same_addr_p);
      end
 
-// synopsys translate_on
+`endif
 
 endmodule
 

--- a/bsg_mem/bsg_mem_2r1w.sv
+++ b/bsg_mem/bsg_mem_2r1w.sv
@@ -36,7 +36,7 @@ module bsg_mem_2r1w #(parameter `BSG_INV_PARAM(width_p)
        ) synth
        (.*);
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
    always_ff @(negedge w_clk_i)
      if (w_v_i)

--- a/bsg_mem/bsg_mem_2r1w_sync.sv
+++ b/bsg_mem/bsg_mem_2r1w_sync.sv
@@ -71,7 +71,7 @@ module bsg_mem_2r1w_sync #(parameter `BSG_INV_PARAM(width_p)
     );
 
 
-//synopsys translate_off
+`ifndef SYNTHESIS
 
    always_ff @(negedge clk_lo)
      if (w_v_i)
@@ -92,7 +92,7 @@ module bsg_mem_2r1w_sync #(parameter `BSG_INV_PARAM(width_p)
 		 ,width_p,els_p,read_write_same_addr_p,harden_p);
      end
 
-//synopsys translate_on
+`endif
    
 endmodule
 

--- a/bsg_mem/bsg_mem_2r1w_sync.sv
+++ b/bsg_mem/bsg_mem_2r1w_sync.sv
@@ -71,7 +71,7 @@ module bsg_mem_2r1w_sync #(parameter `BSG_INV_PARAM(width_p)
     );
 
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
    always_ff @(negedge clk_lo)
      if (w_v_i)

--- a/bsg_mem/bsg_mem_2rw_sync.sv
+++ b/bsg_mem/bsg_mem_2rw_sync.sv
@@ -62,7 +62,7 @@ module bsg_mem_2rw_sync #( parameter `BSG_INV_PARAM(width_p )
        ,.b_data_o
        );
 
-   // synopsys translate_off
+`ifndef SYNTHESIS
 
    always_ff @(negedge clk_lo)
    begin
@@ -89,7 +89,7 @@ module bsg_mem_2rw_sync #( parameter `BSG_INV_PARAM(width_p )
           $display("## %m %L: disable_collision_warning_p is set; you should not have this on unless you have broken code. fix it!\n");
      end
 
-  // synopsys translate_on
+`endif
 
    
 endmodule

--- a/bsg_mem/bsg_mem_2rw_sync.sv
+++ b/bsg_mem/bsg_mem_2rw_sync.sv
@@ -62,7 +62,7 @@ module bsg_mem_2rw_sync #( parameter `BSG_INV_PARAM(width_p )
        ,.b_data_o
        );
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
    always_ff @(negedge clk_lo)
    begin

--- a/bsg_mem/bsg_mem_2rw_sync_mask_write_bit.sv
+++ b/bsg_mem/bsg_mem_2rw_sync_mask_write_bit.sv
@@ -64,7 +64,7 @@ module bsg_mem_2rw_sync_mask_write_bit #( parameter `BSG_INV_PARAM(width_p )
        ,.b_data_o
        );
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
    always_ff @(negedge clk_lo)
      if (a_v_i | b_v_i) begin

--- a/bsg_mem/bsg_mem_2rw_sync_mask_write_bit.sv
+++ b/bsg_mem/bsg_mem_2rw_sync_mask_write_bit.sv
@@ -64,7 +64,7 @@ module bsg_mem_2rw_sync_mask_write_bit #( parameter `BSG_INV_PARAM(width_p )
        ,.b_data_o
        );
 
-   // synopsys translate_off
+`ifndef SYNTHESIS
 
    always_ff @(negedge clk_lo)
      if (a_v_i | b_v_i) begin
@@ -89,7 +89,7 @@ module bsg_mem_2rw_sync_mask_write_bit #( parameter `BSG_INV_PARAM(width_p )
           $display("## %m %L: disable_collision_warning_p is set; you should not have this on unless you have broken code. fix it!\n");
      end
 
-  // synopsys translate_on
+`endif
 
    
 endmodule

--- a/bsg_mem/bsg_mem_2rw_sync_mask_write_bit_synth.sv
+++ b/bsg_mem/bsg_mem_2rw_sync_mask_write_bit_synth.sv
@@ -74,6 +74,7 @@ module bsg_mem_2rw_sync_mask_write_bit_synth #( parameter `BSG_INV_PARAM(width_p
         else
             b_addr_r <= 'X;
 
+`ifndef BSG_HIDE_FROM_SYNTHESIS
         // if addresses match and this is forbidden, then nuke the read address
 
         if (a_addr_i == b_addr_i && a_v_i && b_v_i && (a_w_i || b_w_i) && !read_write_same_addr_p)

--- a/bsg_mem/bsg_mem_2rw_sync_mask_write_bit_synth.sv
+++ b/bsg_mem/bsg_mem_2rw_sync_mask_write_bit_synth.sv
@@ -85,7 +85,7 @@ module bsg_mem_2rw_sync_mask_write_bit_synth #( parameter `BSG_INV_PARAM(width_p
              a_addr_r <= 'X;
              b_addr_r <= 'X;
           end
-        // synopsys translate_on
+`endif
 
      end
 

--- a/bsg_mem/bsg_mem_2rw_sync_mask_write_byte.sv
+++ b/bsg_mem/bsg_mem_2rw_sync_mask_write_byte.sv
@@ -66,7 +66,7 @@ module bsg_mem_2rw_sync_mask_write_byte #( parameter `BSG_INV_PARAM(width_p )
        ,.b_data_o
        );
 
-   // synopsys translate_off
+`ifndef SYNTHESIS
 
    always_ff @(negedge clk_lo)
      if (a_v_i || b_v_i) begin
@@ -91,7 +91,7 @@ module bsg_mem_2rw_sync_mask_write_byte #( parameter `BSG_INV_PARAM(width_p )
           $display("## %m %L: disable_collision_warning_p is set; you should not have this on unless you have broken code. fix it!\n");
      end
 
-  // synopsys translate_on
+`endif
 
    
 endmodule

--- a/bsg_mem/bsg_mem_2rw_sync_mask_write_byte.sv
+++ b/bsg_mem/bsg_mem_2rw_sync_mask_write_byte.sv
@@ -66,7 +66,7 @@ module bsg_mem_2rw_sync_mask_write_byte #( parameter `BSG_INV_PARAM(width_p )
        ,.b_data_o
        );
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
    always_ff @(negedge clk_lo)
      if (a_v_i || b_v_i) begin

--- a/bsg_mem/bsg_mem_2rw_sync_synth.sv
+++ b/bsg_mem/bsg_mem_2rw_sync_synth.sv
@@ -72,7 +72,7 @@ module bsg_mem_2rw_sync_synth #( parameter `BSG_INV_PARAM(width_p )
         else
             b_addr_r <= 'X;
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
         // if addresses match and this is forbidden, then nuke the read address
 
         if (a_addr_i == b_addr_i && a_v_i && b_v_i && (a_w_i || b_w_i) && !read_write_same_addr_p)

--- a/bsg_mem/bsg_mem_2rw_sync_synth.sv
+++ b/bsg_mem/bsg_mem_2rw_sync_synth.sv
@@ -72,7 +72,7 @@ module bsg_mem_2rw_sync_synth #( parameter `BSG_INV_PARAM(width_p )
         else
             b_addr_r <= 'X;
 
-        // synopsys translate_off
+`ifndef SYNTHESIS
         // if addresses match and this is forbidden, then nuke the read address
 
         if (a_addr_i == b_addr_i && a_v_i && b_v_i && (a_w_i || b_w_i) && !read_write_same_addr_p)
@@ -84,7 +84,7 @@ module bsg_mem_2rw_sync_synth #( parameter `BSG_INV_PARAM(width_p )
              a_addr_r <= 'X;
              b_addr_r <= 'X;
           end
-        // synopsys translate_on
+`endif
 
      end
 

--- a/bsg_mem/bsg_mem_3r1w.sv
+++ b/bsg_mem/bsg_mem_3r1w.sv
@@ -39,7 +39,7 @@ module bsg_mem_3r1w #(parameter `BSG_INV_PARAM(width_p)
      ) synth
     (.*);
 
-//synopsys translate_off
+`ifndef SYNTHESIS
    always_ff @(negedge w_clk_i)
      if (w_v_i)
        begin
@@ -61,7 +61,7 @@ module bsg_mem_3r1w #(parameter `BSG_INV_PARAM(width_p)
      begin
         $display("## bsg_mem_3r1w: instantiating width_p=%d, els_p=%d, read_write_same_addr_p=%d (%m)",width_p,els_p,read_write_same_addr_p);
      end
-//synopsys translate_on
+`endif
 
 endmodule
 

--- a/bsg_mem/bsg_mem_3r1w.sv
+++ b/bsg_mem/bsg_mem_3r1w.sv
@@ -39,7 +39,7 @@ module bsg_mem_3r1w #(parameter `BSG_INV_PARAM(width_p)
      ) synth
     (.*);
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
    always_ff @(negedge w_clk_i)
      if (w_v_i)
        begin

--- a/bsg_mem/bsg_mem_3r1w_sync.sv
+++ b/bsg_mem/bsg_mem_3r1w_sync.sv
@@ -79,7 +79,7 @@ module bsg_mem_3r1w_sync #(parameter `BSG_INV_PARAM(width_p)
     );
 
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
    always_ff @(negedge clk_lo)
      if (w_v_i)

--- a/bsg_mem/bsg_mem_3r1w_sync.sv
+++ b/bsg_mem/bsg_mem_3r1w_sync.sv
@@ -79,7 +79,7 @@ module bsg_mem_3r1w_sync #(parameter `BSG_INV_PARAM(width_p)
     );
 
 
-//synopsys translate_off
+`ifndef SYNTHESIS
 
    always_ff @(negedge clk_lo)
      if (w_v_i)
@@ -103,7 +103,7 @@ module bsg_mem_3r1w_sync #(parameter `BSG_INV_PARAM(width_p)
 		 ,width_p,els_p,read_write_same_addr_p,harden_p);
      end
 
-//synopsys translate_on
+`endif
 
 endmodule
 

--- a/bsg_mem/bsg_mem_banked_crossbar.sv
+++ b/bsg_mem/bsg_mem_banked_crossbar.sv
@@ -169,19 +169,19 @@ module bsg_mem_banked_crossbar #
    localparam debug_reads_lp = debug_reads_p;
 //   localparam debug_reads_lp = 1;
 
-  // synopsys translate_off
+`ifndef SYNTHESIS
   initial
     assert((bank_size_p & bank_size_p-1) == 0)
       else $error("bank_size_p must be a power of 2");
 
-  // synopsys translate_on
+`endif
 
 
   logic [num_ports_p-1:0][addr_hash_width_lp-1:0] bank_reqs;
 
   genvar i;
 
-  // synopsys translate_off
+`ifndef SYNTHESIS
    logic [num_ports_p-1:0][addr_width_lp-1:0] addr_r;
 
    always_ff @(posedge clk_i)
@@ -202,7 +202,7 @@ module bsg_mem_banked_crossbar #
             if (v_o[i] && debug_reads_lp)
               $display("%m port %d  %x = [%x]", i,data_o[i],addr_r[i]*debug_lp);
          end
-  // synopsys translate_on
+`endif
 
   if(num_banks_p > 1)
     for(i=0; i<num_ports_p; i=i+1)
@@ -294,7 +294,7 @@ module bsg_mem_banked_crossbar #
   for(i=0; i<num_banks_p; i=i+1)
   begin: z
 
-   // synopsys translate_off
+`ifndef SYNTHESIS
    if (debug_lp > 1)
      always @(negedge clk_i)
        begin
@@ -304,7 +304,7 @@ module bsg_mem_banked_crossbar #
             else
               $display("%m <= [%x]", bank_addr[i]*debug_p);
        end
-   // synopsys translate_on
+`endif
 
     // to be replaced with bsg_mem_1rw_sync_byte_masked
     bsg_mem_1rw_sync_mask_write_byte #( .data_width_p (data_width_p)

--- a/bsg_mem/bsg_mem_banked_crossbar.sv
+++ b/bsg_mem/bsg_mem_banked_crossbar.sv
@@ -169,7 +169,7 @@ module bsg_mem_banked_crossbar #
    localparam debug_reads_lp = debug_reads_p;
 //   localparam debug_reads_lp = 1;
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
   initial
     assert((bank_size_p & bank_size_p-1) == 0)
       else $error("bank_size_p must be a power of 2");
@@ -181,7 +181,7 @@ module bsg_mem_banked_crossbar #
 
   genvar i;
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
    logic [num_ports_p-1:0][addr_width_lp-1:0] addr_r;
 
    always_ff @(posedge clk_i)
@@ -294,7 +294,7 @@ module bsg_mem_banked_crossbar #
   for(i=0; i<num_banks_p; i=i+1)
   begin: z
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
    if (debug_lp > 1)
      always @(negedge clk_i)
        begin

--- a/bsg_mem/bsg_mem_multiport.sv
+++ b/bsg_mem/bsg_mem_multiport.sv
@@ -76,7 +76,7 @@ module bsg_mem_multiport #(parameter `BSG_INV_PARAM(width_p)
      end
 
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
    initial
      begin
         $display("## bsg_mem_multiport: instantiating width_p=%d, els_p=%d, read_write_same_addr_p=%d, write_write_same_addr_p=%d harden_p=%d (%m,%L)"

--- a/bsg_mem/bsg_mem_multiport.sv
+++ b/bsg_mem/bsg_mem_multiport.sv
@@ -76,13 +76,13 @@ module bsg_mem_multiport #(parameter `BSG_INV_PARAM(width_p)
      end
 
 
-   // synopsys translate_off
+`ifndef SYNTHESIS
    initial
      begin
         $display("## bsg_mem_multiport: instantiating width_p=%d, els_p=%d, read_write_same_addr_p=%d, write_write_same_addr_p=%d harden_p=%d (%m,%L)"
                  ,width_p,els_p,read_write_same_addr_p, write_write_same_addr_p,harden_p);
      end
-   // synopsys translate_on
+`endif
 
 endmodule
 

--- a/bsg_mem/bsg_mem_multiport_latch_write_banked_bypassing.sv
+++ b/bsg_mem/bsg_mem_multiport_latch_write_banked_bypassing.sv
@@ -33,11 +33,11 @@ module bsg_mem_multiport_latch_write_banked_bypassing
 
 
   // parameter checking
-  // synopsys translate_off
+`ifndef SYNTHESIS
   initial begin
     assert((els_p%num_banks_p) == 0) else $error("els_p has to be multiples of num_banks_p.");
   end
-  // synopsys translate_on
+`endif
 
 
   wire unused = reset_i;

--- a/bsg_mem/bsg_mem_multiport_latch_write_banked_bypassing.sv
+++ b/bsg_mem/bsg_mem_multiport_latch_write_banked_bypassing.sv
@@ -33,7 +33,7 @@ module bsg_mem_multiport_latch_write_banked_bypassing
 
 
   // parameter checking
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
   initial begin
     assert((els_p%num_banks_p) == 0) else $error("els_p has to be multiples of num_banks_p.");
   end

--- a/bsg_misc/bsg_circular_ptr.sv
+++ b/bsg_misc/bsg_circular_ptr.sv
@@ -68,7 +68,7 @@ module bsg_circular_ptr #(parameter `BSG_INV_PARAM(slots_p)
           // then we have wrapped around
           assign ptr_n = ~ptr_wrap[ptr_width_lp] ? ptr_wrap[0+:ptr_width_lp] : ptr_nowrap;
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
           always_comb
             begin
               assert final( (ptr_n < slots_p) || (|ptr_n === 'X) || reset_i || (add_i > slots_p))

--- a/bsg_misc/bsg_circular_ptr.sv
+++ b/bsg_misc/bsg_circular_ptr.sv
@@ -68,13 +68,13 @@ module bsg_circular_ptr #(parameter `BSG_INV_PARAM(slots_p)
           // then we have wrapped around
           assign ptr_n = ~ptr_wrap[ptr_width_lp] ? ptr_wrap[0+:ptr_width_lp] : ptr_nowrap;
 
-	  // synopsys translate_off
+`ifndef SYNTHESIS
           always_comb
             begin
               assert final( (ptr_n < slots_p) || (|ptr_n === 'X) || reset_i || (add_i > slots_p))
                 else $error("bsg_circular_ptr counter overflow (ptr_r=%b/add_i=%b/ptr_wrap=%b/ptr_n=%b)",ptr_r,add_i,ptr_wrap,ptr_n, slots_p);
             end
-	  // synopsys translate_on
+`endif
 end
 endmodule // bsg_circular_ptr
 

--- a/bsg_misc/bsg_clkgate_optional.sv
+++ b/bsg_misc/bsg_clkgate_optional.sv
@@ -4,7 +4,7 @@
 
 `include "bsg_defines.sv"
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
 // This is an integrated clock cell using a negative latch and an AND gate
 // This logic may be susceptible bug if en_i changes multiple times within a clk cyle

--- a/bsg_misc/bsg_counter_clear_up.sv
+++ b/bsg_misc/bsg_counter_clear_up.sv
@@ -42,7 +42,7 @@ module bsg_counter_clear_up #(parameter `BSG_INV_PARAM(max_val_p)
         end
      end
 
-//synopsys translate_off
+`ifndef SYNTHESIS
 
    always_ff @ (negedge clk_i) 
      begin
@@ -50,7 +50,7 @@ module bsg_counter_clear_up #(parameter `BSG_INV_PARAM(max_val_p)
          $display("%m error: counter overflow at time %t", $time);
      end
 
-//synopsys translate_on
+`endif
 
 endmodule
 

--- a/bsg_misc/bsg_counter_clear_up.sv
+++ b/bsg_misc/bsg_counter_clear_up.sv
@@ -42,7 +42,7 @@ module bsg_counter_clear_up #(parameter `BSG_INV_PARAM(max_val_p)
         end
      end
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
    always_ff @ (negedge clk_i) 
      begin

--- a/bsg_misc/bsg_counter_set_down.sv
+++ b/bsg_misc/bsg_counter_set_down.sv
@@ -51,7 +51,7 @@ module bsg_counter_set_down #(parameter `BSG_INV_PARAM(width_p), parameter init_
   
   assign count_r_o = ctr_r;
   
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
   always_ff @(negedge clk_i)
     begin
       if (!reset_i && down_i && (ctr_n == '1))

--- a/bsg_misc/bsg_counter_up_down.sv
+++ b/bsg_misc/bsg_counter_up_down.sv
@@ -57,14 +57,14 @@ always_ff @(posedge clk_i)
       count_o <= count_o - down_i + up_i;
   end
 
-//synopsys translate_off
+`ifndef SYNTHESIS
   always_ff @ (negedge clk_i) begin
 	  if ((count_o==max_val_p) & up_i & ~down_i  & (reset_i === 1'b0))
 		  $display("%m error: counter overflow at time %t", $time);
 	  if ((count_o==0)          & down_i & ~up_i & (reset_i === 1'b0))
 		  $display("%m error: counter underflow at time %t", $time);
   end
-//synopsys translate_on
+`endif
 
 endmodule
 

--- a/bsg_misc/bsg_counter_up_down.sv
+++ b/bsg_misc/bsg_counter_up_down.sv
@@ -57,7 +57,7 @@ always_ff @(posedge clk_i)
       count_o <= count_o - down_i + up_i;
   end
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
   always_ff @ (negedge clk_i) begin
 	  if ((count_o==max_val_p) & up_i & ~down_i  & (reset_i === 1'b0))
 		  $display("%m error: counter overflow at time %t", $time);

--- a/bsg_misc/bsg_counter_up_down_variable.sv
+++ b/bsg_misc/bsg_counter_up_down_variable.sv
@@ -39,14 +39,14 @@ always_ff @(posedge clk_i)
       count_o <= count_o - down_i + up_i;
   end
 
-//synopsys translate_off
+`ifndef SYNTHESIS
   always_ff @ (posedge clk_i) begin
      if ((count_o==max_val_p) & up_i   & (reset_i===0))
        $display("%m error: counter overflow at time %t", $time);
      if ((count_o==0)         & down_i & (reset_i===0))
        $display("%m error: counter underflow at time %t", $time);
   end
-//synopsys translate_on
+`endif
 
 endmodule
 

--- a/bsg_misc/bsg_counter_up_down_variable.sv
+++ b/bsg_misc/bsg_counter_up_down_variable.sv
@@ -39,7 +39,7 @@ always_ff @(posedge clk_i)
       count_o <= count_o - down_i + up_i;
   end
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
   always_ff @ (posedge clk_i) begin
      if ((count_o==max_val_p) & up_i   & (reset_i===0))
        $display("%m error: counter overflow at time %t", $time);

--- a/bsg_misc/bsg_defines.sv
+++ b/bsg_misc/bsg_defines.sv
@@ -95,6 +95,12 @@
 `define BSG_VIVADO_SYNTH_FAILS
 `endif
 
+// macro for denoting that a code snippet is unsynthesiable
+
+`ifdef SYNTHESIS
+  `define BSG_HIDE_FROM_SYNTHESIS
+`endif
+
 `define BSG_STRINGIFY(x) `"x`"
 
 

--- a/bsg_misc/bsg_id_pool.sv
+++ b/bsg_misc/bsg_id_pool.sv
@@ -84,7 +84,7 @@ module bsg_id_pool
   );
 
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
   always_ff @ (negedge clk_i) begin
     if (~reset_i) begin
       if (dealloc_v_i) begin

--- a/bsg_misc/bsg_id_pool.sv
+++ b/bsg_misc/bsg_id_pool.sv
@@ -84,7 +84,7 @@ module bsg_id_pool
   );
 
 
-  // synopsys translate_off
+`ifndef SYNTHESIS
   always_ff @ (negedge clk_i) begin
     if (~reset_i) begin
       if (dealloc_v_i) begin
@@ -100,7 +100,7 @@ module bsg_id_pool
       
     end
   end
-  // synopsys translate_on
+`endif
 
 
 endmodule

--- a/bsg_misc/bsg_id_pool_dealloc_alloc_one_hot.sv
+++ b/bsg_misc/bsg_id_pool_dealloc_alloc_one_hot.sv
@@ -85,7 +85,7 @@ module bsg_id_pool_dealloc_alloc_one_hot
   assign active_ids_r_o = allocated_r;
   
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
     
   always_ff @ (negedge clk_i) begin
     if (~reset_i) begin

--- a/bsg_misc/bsg_id_pool_dealloc_alloc_one_hot.sv
+++ b/bsg_misc/bsg_id_pool_dealloc_alloc_one_hot.sv
@@ -85,7 +85,7 @@ module bsg_id_pool_dealloc_alloc_one_hot
   assign active_ids_r_o = allocated_r;
   
 
-  // synopsys translate_off
+`ifndef SYNTHESIS
     
   always_ff @ (negedge clk_i) begin
     if (~reset_i) begin
@@ -98,7 +98,7 @@ module bsg_id_pool_dealloc_alloc_one_hot
       $display("bsg_id_pool_one_hot: allocated_r=%b dealloc_ids_i=%b alloc_id_v_o=%b", allocated_r, dealloc_ids_i, alloc_id_v_o);
     end
   end
-  // synopsys translate_on
+`endif
 
 endmodule
 

--- a/bsg_misc/bsg_idiv_iterative.sv
+++ b/bsg_misc/bsg_idiv_iterative.sv
@@ -45,7 +45,7 @@ module bsg_idiv_iterative #(parameter width_p=32, parameter bitstack_p=0, parame
     ,input                  yumi_i
     );
 
-   // synopsys translate_off
+`ifndef SYNTHESIS
    initial begin
         assert (bits_per_iter_p == 1 || bits_per_iter_p == 2)
         else $error("Illegal value for parameters bits_per_iter_p given: (%0d). Legal values are 1 or 2.", bits_per_iter_p);
@@ -53,7 +53,7 @@ module bsg_idiv_iterative #(parameter width_p=32, parameter bitstack_p=0, parame
 	assert (bits_per_iter_p == 1 || (bits_per_iter_p == 2 && (width_p % 2 == 0)))
 	else $error("Illegal value for parameter width_p: (%0d) given bits_per_iter_p: (%0d). Width must be even when resolving 2 bits per iteration", width_p, bits_per_iter_p);
    end
-   // synopsys translate_on
+`endif
    
    wire [width_p:0] opA_r;
    assign remainder_o = opA_r[width_p-1:0];

--- a/bsg_misc/bsg_idiv_iterative.sv
+++ b/bsg_misc/bsg_idiv_iterative.sv
@@ -45,7 +45,7 @@ module bsg_idiv_iterative #(parameter width_p=32, parameter bitstack_p=0, parame
     ,input                  yumi_i
     );
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
    initial begin
         assert (bits_per_iter_p == 1 || bits_per_iter_p == 2)
         else $error("Illegal value for parameters bits_per_iter_p given: (%0d). Legal values are 1 or 2.", bits_per_iter_p);

--- a/bsg_misc/bsg_mux.sv
+++ b/bsg_misc/bsg_mux.sv
@@ -19,11 +19,11 @@ module bsg_mux #(parameter `BSG_INV_PARAM(width_p)
    else
      assign data_o = data_i[sel_i];
 
-   // synopsys translate_off
+`ifndef SYNTHESIS
    initial
      assert(balanced_p == 0)
        else $error("%m warning: synthesizable implementation of bsg_mux does not support balanced_p");
-   // synopsys translate_on
+`endif
 
 endmodule
 

--- a/bsg_misc/bsg_mux.sv
+++ b/bsg_misc/bsg_mux.sv
@@ -19,7 +19,7 @@ module bsg_mux #(parameter `BSG_INV_PARAM(width_p)
    else
      assign data_o = data_i[sel_i];
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
    initial
      assert(balanced_p == 0)
        else $error("%m warning: synthesizable implementation of bsg_mux does not support balanced_p");

--- a/bsg_misc/bsg_reduce.sv
+++ b/bsg_misc/bsg_reduce.sv
@@ -15,11 +15,11 @@ module bsg_reduce #(parameter `BSG_INV_PARAM(width_p )
     , output o
     );
 
-   // synopsys translate_off
+`ifndef SYNTHESIS
    initial
       assert( $countones({xor_p & 1'b1, and_p & 1'b1, or_p & 1'b1}) == 1)
         else $error("bsg_reduce: exactly one function may be selected\n");
-   // synopsys translate_on
+`endif
 
    if (xor_p)
      assign o = ^i;

--- a/bsg_misc/bsg_reduce.sv
+++ b/bsg_misc/bsg_reduce.sv
@@ -15,7 +15,7 @@ module bsg_reduce #(parameter `BSG_INV_PARAM(width_p )
     , output o
     );
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
    initial
       assert( $countones({xor_p & 1'b1, and_p & 1'b1, or_p & 1'b1}) == 1)
         else $error("bsg_reduce: exactly one function may be selected\n");

--- a/bsg_misc/bsg_reduce_segmented.sv
+++ b/bsg_misc/bsg_reduce_segmented.sv
@@ -12,7 +12,7 @@ module bsg_reduce_segmented #(parameter `BSG_INV_PARAM(segments_p )
    , output [segments_p-1:0] o
     );
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
    initial
      assert( $countones({xor_p[0], and_p[0], or_p[0], nor_p[0]}) == 1)
        else $error("%m: exactly one function may be selected\n");

--- a/bsg_misc/bsg_reduce_segmented.sv
+++ b/bsg_misc/bsg_reduce_segmented.sv
@@ -12,12 +12,12 @@ module bsg_reduce_segmented #(parameter `BSG_INV_PARAM(segments_p )
    , output [segments_p-1:0] o
     );
 
-   // synopsys translate_off
+`ifndef SYNTHESIS
    initial
      assert( $countones({xor_p[0], and_p[0], or_p[0], nor_p[0]}) == 1)
        else $error("%m: exactly one function may be selected\n");
 
-  // synopsys translate_on
+`endif
 
   
   genvar j;

--- a/bsg_misc/bsg_scan.sv
+++ b/bsg_misc/bsg_scan.sv
@@ -48,7 +48,7 @@ module bsg_scan #(parameter `BSG_INV_PARAM(width_p)
 
    wire [$clog2(width_p):0][width_p-1:0] t;
 	
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
    initial
       assert( $countones({xor_p[0], and_p[0], or_p[0]}) == 1)
         else $error("bsg_scan: only one function may be selected\n");

--- a/bsg_misc/bsg_scan.sv
+++ b/bsg_misc/bsg_scan.sv
@@ -48,7 +48,7 @@ module bsg_scan #(parameter `BSG_INV_PARAM(width_p)
 
    wire [$clog2(width_p):0][width_p-1:0] t;
 	
-   // synopsys translate_off
+`ifndef SYNTHESIS
    initial
       assert( $countones({xor_p[0], and_p[0], or_p[0]}) == 1)
         else $error("bsg_scan: only one function may be selected\n");
@@ -62,7 +62,7 @@ module bsg_scan #(parameter `BSG_INV_PARAM(width_p)
         $display("i=%b, o=%b",i, o);
       end
 	
-   // synopsys translate_on
+`endif
 
    // streaming operation; reverses bits
    if (lo_to_hi_p)

--- a/bsg_misc/bsg_strobe.sv
+++ b/bsg_misc/bsg_strobe.sv
@@ -125,7 +125,7 @@ module bsg_strobe #(`BSG_INV_PARAM(width_p)
    always_ff @(posedge clk_i)
      strobe_r_o <= strobe_n_buf;
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
    if (debug_lp)
      begin : debug
         always @(negedge clk_i)
@@ -136,7 +136,7 @@ module bsg_strobe #(`BSG_INV_PARAM(width_p)
 `endif
 
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
    always @(negedge clk_i)
      assert((strobe_n === 'X) || strobe_n == & ((C_r << 1) ^ S_r))
        else $error("## faulty assumption about strobe signal in %m (C_r=%b, S_r=%b, strobe_n=%b)", C_r,S_r, strobe_n);

--- a/bsg_misc/bsg_strobe.sv
+++ b/bsg_misc/bsg_strobe.sv
@@ -125,7 +125,7 @@ module bsg_strobe #(`BSG_INV_PARAM(width_p)
    always_ff @(posedge clk_i)
      strobe_r_o <= strobe_n_buf;
 
-   // synopsys translate_off
+`ifndef SYNTHESIS
    if (debug_lp)
      begin : debug
         always @(negedge clk_i)
@@ -133,14 +133,14 @@ module bsg_strobe #(`BSG_INV_PARAM(width_p)
             $display("%t (C=%b,S=%b) reset_r_i=%d new_val=%b init_val=%d val(C,S)=%b C^S=%b",$time
                      ,  C_r,S_r, reset_r_i, new_val, init_val_r_i, (C_r << 1)+S_r, strobe_n);
      end
-   // synopsys translate_on
+`endif
 
 
-   // synopsys translate_off
+`ifndef SYNTHESIS
    always @(negedge clk_i)
      assert((strobe_n === 'X) || strobe_n == & ((C_r << 1) ^ S_r))
        else $error("## faulty assumption about strobe signal in %m (C_r=%b, S_r=%b, strobe_n=%b)", C_r,S_r, strobe_n);
-   // synopsys translate_on
+`endif
 
 endmodule
 

--- a/bsg_noc/bsg_mesh_router.sv
+++ b/bsg_noc/bsg_mesh_router.sv
@@ -183,7 +183,7 @@ module bsg_mesh_router
 
 
 
-  // synopsys translate_off
+`ifndef SYNTHESIS
   if (debug_p) begin
     always_ff @ (negedge clk_i) begin
 
@@ -196,7 +196,7 @@ module bsg_mesh_router
  
     end
   end
-  // synopsys translate_on
+`endif
 
 
 

--- a/bsg_noc/bsg_mesh_router.sv
+++ b/bsg_noc/bsg_mesh_router.sv
@@ -183,7 +183,7 @@ module bsg_mesh_router
 
 
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
   if (debug_p) begin
     always_ff @ (negedge clk_i) begin
 

--- a/bsg_noc/bsg_mesh_router_buffered.sv
+++ b/bsg_noc/bsg_mesh_router_buffered.sv
@@ -52,7 +52,7 @@ module bsg_mesh_router_buffered
 
    genvar                           i;
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
    if (debug_p)
      for (i = 0; i < dirs_lp;i=i+1)
        begin
@@ -71,7 +71,7 @@ module bsg_mesh_router_buffered
       // accept no data from outside of stubbed port
       assign link_o_cast[i].ready_and_rev = 1'b0;
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
       always @(negedge clk_i)
         assert (reset_i !== '0 || ~link_o_cast[i].v) else
           $warning("## stubbed port %x received word %x",i,link_i_cast[i].data);
@@ -107,7 +107,7 @@ module bsg_mesh_router_buffered
           ,.data_o(link_o_cast[i].ready_and_rev)
         );
         
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
         always_ff @ (negedge clk_i) begin
           if (~reset_i) begin
             if (link_i_cast[i].v) begin
@@ -144,7 +144,7 @@ module bsg_mesh_router_buffered
           begin : macro
 	     wire [width_p-1:0] tmp;
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
             initial
                begin
                   $display("%m with buffers on %d",i);

--- a/bsg_noc/bsg_mesh_router_buffered.sv
+++ b/bsg_noc/bsg_mesh_router_buffered.sv
@@ -52,7 +52,7 @@ module bsg_mesh_router_buffered
 
    genvar                           i;
 
-   //synopsys translate_off
+`ifndef SYNTHESIS
    if (debug_p)
      for (i = 0; i < dirs_lp;i=i+1)
        begin
@@ -61,7 +61,7 @@ module bsg_mesh_router_buffered
                      ,my_x_i,my_y_i,i,link_i_cast[i].v,link_o_cast[i].ready_and_rev,
                      link_o_cast[i].v,link_i_cast[i].ready_and_rev,link_i[i]);
        end
-   //synopsys translate_on
+`endif
 
   for (i = 0; i < dirs_lp; i=i+1) begin: rof
     if (stub_p[i]) begin: fi
@@ -71,11 +71,11 @@ module bsg_mesh_router_buffered
       // accept no data from outside of stubbed port
       assign link_o_cast[i].ready_and_rev = 1'b0;
 
-      // synopsys translate_off
+`ifndef SYNTHESIS
       always @(negedge clk_i)
         assert (reset_i !== '0 || ~link_o_cast[i].v) else
           $warning("## stubbed port %x received word %x",i,link_i_cast[i].data);
-      // synopsys translate_on
+`endif
     end
     else begin: fi
       logic fifo_ready_lo;
@@ -107,7 +107,7 @@ module bsg_mesh_router_buffered
           ,.data_o(link_o_cast[i].ready_and_rev)
         );
         
-        // synopsys translate_off
+`ifndef SYNTHESIS
         always_ff @ (negedge clk_i) begin
           if (~reset_i) begin
             if (link_i_cast[i].v) begin
@@ -116,7 +116,7 @@ module bsg_mesh_router_buffered
             end
           end
         end
-        // synopsys translate_on
+`endif
 
       end
       else begin
@@ -144,12 +144,12 @@ module bsg_mesh_router_buffered
           begin : macro
 	     wire [width_p-1:0] tmp;
 
-            // synopsys translate_off
+`ifndef SYNTHESIS
             initial
                begin
                   $display("%m with buffers on %d",i);
                end
-            // synopsys translate_on
+`endif
              bsg_inv #(.width_p(width_p),.vertical_p(i < 3)) data_lo_inv
                (.i (data_lo[i]         )
                 ,.o(tmp)

--- a/bsg_noc/bsg_mesh_router_decoder_dor.sv
+++ b/bsg_noc/bsg_mesh_router_decoder_dor.sv
@@ -43,7 +43,7 @@ module bsg_mesh_router_decoder_dor
 
   // check parameters
 
-  // synopsys translate_off
+`ifndef SYNTHESIS
   initial begin
     if (ruche_factor_X_p > 0) begin
       assert(dims_p > 2) else $fatal(1, "ruche in X direction requires dims_p greater than 2.");
@@ -58,7 +58,7 @@ module bsg_mesh_router_decoder_dor
     assert(ruche_factor_X_p < (1<<x_cord_width_p)) else $fatal(1, "ruche factor in X direction is too large");
     assert(ruche_factor_Y_p < (1<<y_cord_width_p)) else $fatal(1, "ruche factor in Y direction is too large");
   end
-  // synopsys translate_on
+`endif
 
 
 
@@ -267,7 +267,7 @@ module bsg_mesh_router_decoder_dor
   end
 
 
-  // synopsys translate_off
+`ifndef SYNTHESIS
   if (debug_p) begin
     always_ff @ (negedge clk_i) begin
       if (~reset_i) begin
@@ -280,7 +280,7 @@ module bsg_mesh_router_decoder_dor
     wire unused0 = clk_i;
     wire unused1 = reset_i;
   end
-  // synopsys translate_on
+`endif
 
 
 

--- a/bsg_noc/bsg_mesh_router_decoder_dor.sv
+++ b/bsg_noc/bsg_mesh_router_decoder_dor.sv
@@ -43,7 +43,7 @@ module bsg_mesh_router_decoder_dor
 
   // check parameters
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
   initial begin
     if (ruche_factor_X_p > 0) begin
       assert(dims_p > 2) else $fatal(1, "ruche in X direction requires dims_p greater than 2.");
@@ -267,7 +267,7 @@ module bsg_mesh_router_decoder_dor
   end
 
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
   if (debug_p) begin
     always_ff @ (negedge clk_i) begin
       if (~reset_i) begin

--- a/bsg_noc/bsg_ready_and_link_async_to_wormhole.sv
+++ b/bsg_noc/bsg_ready_and_link_async_to_wormhole.sv
@@ -71,13 +71,13 @@ module bsg_ready_and_link_async_to_wormhole
   localparam wormhole_width_lp = $bits(wormhole_packet_s);
   localparam wormhole_ratio_lp = `BSG_CDIV(wormhole_width_lp, flit_width_p);
   
-  // synopsys translate_off
+`ifndef SYNTHESIS
   initial
   begin
     assert (len_width_p >= `BSG_SAFE_CLOG2(wormhole_ratio_lp))
     else $error("Wormhole packet len width %d is too narrow for convertion ratio %d. Please increase len width.", len_width_p, wormhole_ratio_lp);
   end
-  // synopsys translate_on
+`endif
   
   
   /********************* Interfacing ral and wh link *********************/

--- a/bsg_noc/bsg_ready_and_link_async_to_wormhole.sv
+++ b/bsg_noc/bsg_ready_and_link_async_to_wormhole.sv
@@ -71,7 +71,7 @@ module bsg_ready_and_link_async_to_wormhole
   localparam wormhole_width_lp = $bits(wormhole_packet_s);
   localparam wormhole_ratio_lp = `BSG_CDIV(wormhole_width_lp, flit_width_p);
   
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
   initial
   begin
     assert (len_width_p >= `BSG_SAFE_CLOG2(wormhole_ratio_lp))

--- a/bsg_noc/bsg_router_crossbar_o_by_i.sv
+++ b/bsg_noc/bsg_router_crossbar_o_by_i.sv
@@ -85,13 +85,13 @@ module bsg_router_crossbar_o_by_i
         ,.data_o(credit_ready_and_o[i])
       );
 
-      // synopsys translate_off
+`ifndef SYNTHESIS
       always_ff @ (negedge clk_i) begin
         if (~reset_i & valid_i[i]) begin
           assert(fifo_ready_lo[i]) else $error("Trying to enque when there is no space in FIFO, while using credit interface. i =%d", i);
         end
       end
-      // synopsys translate_on
+`endif
 
     end
     else begin: rd

--- a/bsg_noc/bsg_router_crossbar_o_by_i.sv
+++ b/bsg_noc/bsg_router_crossbar_o_by_i.sv
@@ -85,7 +85,7 @@ module bsg_router_crossbar_o_by_i
         ,.data_o(credit_ready_and_o[i])
       );
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
       always_ff @ (negedge clk_i) begin
         if (~reset_i & valid_i[i]) begin
           assert(fifo_ready_lo[i]) else $error("Trying to enque when there is no space in FIFO, while using credit interface. i =%d", i);

--- a/bsg_noc/bsg_wormhole_router.sv
+++ b/bsg_noc/bsg_wormhole_router.sv
@@ -44,7 +44,7 @@ module bsg_wormhole_router
   // FIXME: move to bsg_wormhole_router.svh
   `declare_bsg_wormhole_router_header_s(cord_markers_pos_p[dims_p], len_width_p, bsg_wormhole_router_header_s);
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
     wire [dirs_lp-1:0][dirs_lp-1:0] matrix_out_in_transpose;
 
     bsg_transpose #(.width_p(dirs_lp),.els_p(dirs_lp)) tr (.i(routing_matrix_p[0])
@@ -110,7 +110,7 @@ module bsg_wormhole_router
 
       assign hdr = fifo_data_lo[i][$bits(bsg_wormhole_router_header_s)-1:0];
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
       if (debug_lp)
         begin
            logic release_r;
@@ -178,7 +178,7 @@ module bsg_wormhole_router
          ,.o (reqs[i]) // unicast
        );
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
       always_ff @(negedge clk_i)
         if (debug_lp)
           assert (detected_header_lo!==1'b1 || !(decoded_dest_lo & ~ routing_matrix_p[0][i]))
@@ -226,7 +226,7 @@ module bsg_wormhole_router
       ,.data_sel_o  (data_sel_lo)
       );
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
        always_ff @(negedge clk_i)
          begin
             if (debug_lp)

--- a/bsg_noc/bsg_wormhole_router_adapter_in.sv
+++ b/bsg_noc/bsg_wormhole_router_adapter_in.sv
@@ -59,7 +59,7 @@ module bsg_wormhole_router_adapter_in
      ,.yumi_i(link_ready_and_i & link_v_o)
      );
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
   always_ff @(negedge clk_i)
     assert(reset_i || ~packet_v_i || (packet_cast_i.len <= max_num_flits_lp))
       else 

--- a/bsg_noc/bsg_wormhole_router_adapter_out.sv
+++ b/bsg_noc/bsg_wormhole_router_adapter_out.sv
@@ -63,7 +63,7 @@ module bsg_wormhole_router_adapter_out
 
 
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
   logic recv_r;
   bsg_dff_reset_en
    #(.width_p(1))

--- a/bsg_noc/bsg_wormhole_router_decoder_dor.sv
+++ b/bsg_noc/bsg_wormhole_router_decoder_dor.sv
@@ -71,7 +71,7 @@ module bsg_wormhole_router_decoder_dor
           end
      end // else: !if(reverse_order_p)
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
        initial assert(bsg_noc_pkg::P == 0
                       && bsg_noc_pkg::W == 1
                       && bsg_noc_pkg::E == 2

--- a/bsg_tag/bsg_tag_client.sv
+++ b/bsg_tag/bsg_tag_client.sv
@@ -99,7 +99,7 @@ module bsg_tag_client
 	      ,.data_o(tag_data_r)
 	      );
    
-   // synopsys translate_off
+`ifndef SYNTHESIS
    if (debug_level_lp > 1)
    always @(negedge bsg_tag_i.clk)
      begin
@@ -110,7 +110,7 @@ module bsg_tag_client
         if (send_now)
           $display("## bsg_tag_client (send) SENDING   %b (%m)",tag_data_r);
      end
-   // synopsys translate_on
+`endif
 
    logic recv_toggle_r, recv_toggle_n;
 

--- a/bsg_tag/bsg_tag_client.sv
+++ b/bsg_tag/bsg_tag_client.sv
@@ -99,7 +99,7 @@ module bsg_tag_client
 	      ,.data_o(tag_data_r)
 	      );
    
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
    if (debug_level_lp > 1)
    always @(negedge bsg_tag_i.clk)
      begin

--- a/bsg_tag/bsg_tag_client_unsync.sv
+++ b/bsg_tag/bsg_tag_client_unsync.sv
@@ -84,7 +84,7 @@ module bsg_tag_client_unsync
   */ 
    
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
    if (debug_level_lp > 1)
      begin: debug
 	wire reset_op = ~op_r & param_r;

--- a/bsg_tag/bsg_tag_client_unsync.sv
+++ b/bsg_tag/bsg_tag_client_unsync.sv
@@ -84,7 +84,7 @@ module bsg_tag_client_unsync
   */ 
    
 
-   // synopsys translate_off
+`ifndef SYNTHESIS
    if (debug_level_lp > 1)
      begin: debug
 	wire reset_op = ~op_r & param_r;
@@ -100,7 +100,7 @@ module bsg_tag_client_unsync
                $display("## bsg_tag_client (send) SHIFTING  %b (%m)",tag_data_r);
 	  end
      end
-   // synopsys translate_on
+`endif
 
    assign data_async_r_o = tag_data_r;
 

--- a/bsg_tag/bsg_tag_master.sv
+++ b/bsg_tag/bsg_tag_master.sv
@@ -45,7 +45,7 @@ module bsg_tag_master
    // counts 0..max_packet_len_lp
    localparam lg_max_packet_len_lp = `BSG_SAFE_CLOG2(max_packet_len_lp+1);
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
    if (debug_level_lp > 2)
      always @(negedge clk_i)
        $display("## bsg_tag_master clients=%b (%m)",clients_r_o);
@@ -83,7 +83,7 @@ module bsg_tag_master
     );
 
    // veri lator doesn't support -d
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
    initial
         $display("## %m instantiating bsg_tag_master with els_p=%d, lg_width_p=%d, max_packet_len_lp=%d, reset_zero_len=%d"
                  ,els_p,lg_width_p,max_packet_len_lp,reset_len_lp);
@@ -111,7 +111,7 @@ module bsg_tag_master
      // if we hit the counter AND (subtle bug) there is no valid incoming data that would get lost
      if (tag_reset_req & ~data_i_r)
        begin
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
           if (debug_level_lp > 2) $display("## bsg_tag_master RESET time %t (%m)",$time);
 `endif
           state_r   <= eStart;
@@ -128,7 +128,7 @@ module bsg_tag_master
    always_ff @(posedge clk_i)
         hdr_r <= hdr_n;
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
    always_ff @(negedge clk_i)
      if (state_n != state_r)
        if (debug_level_lp > 1) $display("## bsg_tag_master STATE CHANGE  # %s --> %s #",state_r.name(),state_n.name());
@@ -157,7 +157,7 @@ module bsg_tag_master
                end
           eHeader:
                begin
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
                   if (debug_level_lp > 1)
                     $display("## bsg_tag_master RECEIVING HEADER (%m) (%d) = %b",hdr_ptr_r,data_i_r);
 `endif
@@ -170,14 +170,14 @@ module bsg_tag_master
                        if (hdr_n.len == 0)
                          begin
                             state_n = eStart;
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
                             $display("## bsg_tag_master NULL PACKET, len=0 (%m)");
 `endif
                          end
                        else
                          begin
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
                             if (debug_level_lp > 1)
                               $display("## bsg_tag_master PACKET HEADER RECEIVED (length=%b,data_not_reset=%b,nodeID=%b) (%m) "
                                        ,hdr_n.len,hdr_n.data_not_reset,hdr_n.nodeID);
@@ -199,7 +199,7 @@ module bsg_tag_master
                   bsg_tag_n.op    = hdr_r.data_not_reset;
                   bsg_tag_n.param = data_i_r;
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
                   if (debug_level_lp > 2)
                     $display("## bsg_tag_master PACKET TRANSFER op,param=<%b,%b> (%m)", bsg_tag_n.op, bsg_tag_n.param);
 `endif
@@ -209,7 +209,7 @@ module bsg_tag_master
                     begin
                        state_n = eStart;
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
                        if (debug_level_lp > 1) $display("## bsg_tag_master PACKET END (%m)");
 `endif
 
@@ -223,7 +223,7 @@ module bsg_tag_master
               begin
                  state_n = eStuck;
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
                  $display("## bsg_tag_master transitioning to error state; be sure to run gate-level netlist to avoid sim/synth mismatch (%m)");
 `endif
 

--- a/bsg_tag/bsg_tag_master.sv
+++ b/bsg_tag/bsg_tag_master.sv
@@ -45,11 +45,11 @@ module bsg_tag_master
    // counts 0..max_packet_len_lp
    localparam lg_max_packet_len_lp = `BSG_SAFE_CLOG2(max_packet_len_lp+1);
 
-   // synopsys translate_off
+`ifndef SYNTHESIS
    if (debug_level_lp > 2)
      always @(negedge clk_i)
        $display("## bsg_tag_master clients=%b (%m)",clients_r_o);
-   // synopsys translate_on
+`endif
 
    logic  data_i_r;
 
@@ -83,11 +83,11 @@ module bsg_tag_master
     );
 
    // veri lator doesn't support -d
-   // synopsys translate_off
+`ifndef SYNTHESIS
    initial
         $display("## %m instantiating bsg_tag_master with els_p=%d, lg_width_p=%d, max_packet_len_lp=%d, reset_zero_len=%d"
                  ,els_p,lg_width_p,max_packet_len_lp,reset_len_lp);
-   // synopsys translate_on
+`endif
 
    //
    // END RESET LOGIC
@@ -111,9 +111,9 @@ module bsg_tag_master
      // if we hit the counter AND (subtle bug) there is no valid incoming data that would get lost
      if (tag_reset_req & ~data_i_r)
        begin
-          // synopsys translate_off
+`ifndef SYNTHESIS
           if (debug_level_lp > 2) $display("## bsg_tag_master RESET time %t (%m)",$time);
-          // synopsys translate_on
+`endif
           state_r   <= eStart;
 
           // we put this here because DC did not currently infer "reset" logic
@@ -128,11 +128,11 @@ module bsg_tag_master
    always_ff @(posedge clk_i)
         hdr_r <= hdr_n;
 
-   // synopsys translate_off
+`ifndef SYNTHESIS
    always_ff @(negedge clk_i)
      if (state_n != state_r)
        if (debug_level_lp > 1) $display("## bsg_tag_master STATE CHANGE  # %s --> %s #",state_r.name(),state_n.name());
-   // synopsys translate_on
+`endif
 
    always_comb
      begin
@@ -157,10 +157,10 @@ module bsg_tag_master
                end
           eHeader:
                begin
-                  // synopsys translate_off
+`ifndef SYNTHESIS
                   if (debug_level_lp > 1)
                     $display("## bsg_tag_master RECEIVING HEADER (%m) (%d) = %b",hdr_ptr_r,data_i_r);
-                  // synopsys translate_on
+`endif
 
                   hdr_n     = { data_i_r, hdr_r[1+:($bits(bsg_tag_header_s)-1)] };
                   hdr_ptr_n = hdr_ptr_r + 1'b1;
@@ -170,18 +170,18 @@ module bsg_tag_master
                        if (hdr_n.len == 0)
                          begin
                             state_n = eStart;
-                            // synopsys translate_off
+`ifndef SYNTHESIS
                             $display("## bsg_tag_master NULL PACKET, len=0 (%m)");
-                            // synopsys translate_on
+`endif
                          end
                        else
                          begin
 
-                            // synopsys translate_off
+`ifndef SYNTHESIS
                             if (debug_level_lp > 1)
                               $display("## bsg_tag_master PACKET HEADER RECEIVED (length=%b,data_not_reset=%b,nodeID=%b) (%m) "
                                        ,hdr_n.len,hdr_n.data_not_reset,hdr_n.nodeID);
-                            // synopsys translate_on
+`endif
 
                             // if we have data to transfer go to transfer state
                             state_n = eTransfer;
@@ -199,19 +199,19 @@ module bsg_tag_master
                   bsg_tag_n.op    = hdr_r.data_not_reset;
                   bsg_tag_n.param = data_i_r;
 
-                  // synopsys translate_off
+`ifndef SYNTHESIS
                   if (debug_level_lp > 2)
                     $display("## bsg_tag_master PACKET TRANSFER op,param=<%b,%b> (%m)", bsg_tag_n.op, bsg_tag_n.param);
-                  // synopsys translate_on
+`endif
 
                   // finishing words
                   if (hdr_r.len== lg_width_p ' (1))
                     begin
                        state_n = eStart;
 
-                       // synopsys translate_off
+`ifndef SYNTHESIS
                        if (debug_level_lp > 1) $display("## bsg_tag_master PACKET END (%m)");
-                       // synopsys translate_on
+`endif
 
                     end
                   hdr_n.len = hdr_r.len - 1;
@@ -223,9 +223,9 @@ module bsg_tag_master
               begin
                  state_n = eStuck;
 
-                 // synopsys translate_off
+`ifndef SYNTHESIS
                  $display("## bsg_tag_master transitioning to error state; be sure to run gate-level netlist to avoid sim/synth mismatch (%m)");
-                 // synopsys translate_on
+`endif
 
               end
         endcase // case (state_r)

--- a/bsg_tag/bsg_tag_master_decentralized.sv
+++ b/bsg_tag/bsg_tag_master_decentralized.sv
@@ -56,11 +56,11 @@ module bsg_tag_master_decentralized
    // counts 0..max_packet_len_lp
    localparam lg_max_packet_len_lp = `BSG_SAFE_CLOG2(max_packet_len_lp+1);
 
-   // synopsys translate_off
+`ifndef SYNTHESIS
    if (debug_level_lp > 2)
      always @(negedge clk_i)
        $display("## bsg_tag_master clients=%b (%m)",clients_o);
-   // synopsys translate_on
+`endif
 
    logic  data_i_r;
 
@@ -94,11 +94,11 @@ module bsg_tag_master_decentralized
     );
 
    // veri lator doesn't support -d
-   // synopsys translate_off
+`ifndef SYNTHESIS
    initial
         $display("## %m instantiating bsg_tag_master_decentralized with els_p=%d, local_els_p=%d, lg_width_p=%d, max_packet_len_lp=%d, reset_zero_len=%d"
                  ,els_p,local_els_p,lg_width_p,max_packet_len_lp,reset_len_lp);
-   // synopsys translate_on
+`endif
 
    //
    // END RESET LOGIC
@@ -122,9 +122,9 @@ module bsg_tag_master_decentralized
      // if we hit the counter AND (subtle bug) there is no valid incoming data that would get lost
      if (tag_reset_req & ~data_i_r)
        begin
-          // synopsys translate_off
+`ifndef SYNTHESIS
           if (debug_level_lp > 2) $display("## bsg_tag_master RESET time %t (%m)",$time);
-          // synopsys translate_on
+`endif
           state_r   <= eStart;
 
           // we put this here because DC did not currently infer "reset" logic
@@ -139,11 +139,11 @@ module bsg_tag_master_decentralized
    always_ff @(posedge clk_i)
         hdr_r <= hdr_n;
 
-   // synopsys translate_off
+`ifndef SYNTHESIS
    always_ff @(negedge clk_i)
      if (state_n != state_r)
        if (debug_level_lp > 1) $display("## bsg_tag_master STATE CHANGE  # %s --> %s #",state_r.name(),state_n.name());
-   // synopsys translate_on
+`endif
 
    always_comb
      begin
@@ -168,10 +168,10 @@ module bsg_tag_master_decentralized
                end
           eHeader:
                begin
-                  // synopsys translate_off
+`ifndef SYNTHESIS
                   if (debug_level_lp > 1)
                     $display("## bsg_tag_master RECEIVING HEADER (%m) (%d) = %b",hdr_ptr_r,data_i_r);
-                  // synopsys translate_on
+`endif
 
                   hdr_n     = { data_i_r, hdr_r[1+:($bits(bsg_tag_header_s)-1)] };
                   hdr_ptr_n = hdr_ptr_r + 1'b1;
@@ -181,18 +181,18 @@ module bsg_tag_master_decentralized
                        if (hdr_n.len == 0)
                          begin
                             state_n = eStart;
-                            // synopsys translate_off
+`ifndef SYNTHESIS
                             $display("## bsg_tag_master NULL PACKET, len=0 (%m)");
-                            // synopsys translate_on
+`endif
                          end
                        else
                          begin
 
-                            // synopsys translate_off
+`ifndef SYNTHESIS
                             if (debug_level_lp > 1)
                               $display("## bsg_tag_master PACKET HEADER RECEIVED (length=%b,data_not_reset=%b,nodeID=%b) (%m) "
                                        ,hdr_n.len,hdr_n.data_not_reset,hdr_n.nodeID);
-                            // synopsys translate_on
+`endif
 
                             // if we have data to transfer go to transfer state
                             state_n = eTransfer;
@@ -210,19 +210,19 @@ module bsg_tag_master_decentralized
                   bsg_tag_n.op    = hdr_r.data_not_reset;
                   bsg_tag_n.param = data_i_r;
 
-                  // synopsys translate_off
+`ifndef SYNTHESIS
                   if (debug_level_lp > 2)
                     $display("## bsg_tag_master PACKET TRANSFER op,param=<%b,%b> (%m)", bsg_tag_n.op, bsg_tag_n.param);
-                  // synopsys translate_on
+`endif
 
                   // finishing words
                   if (hdr_r.len== lg_width_p ' (1))
                     begin
                        state_n = eStart;
 
-                       // synopsys translate_off
+`ifndef SYNTHESIS
                        if (debug_level_lp > 1) $display("## bsg_tag_master PACKET END (%m)");
-                       // synopsys translate_on
+`endif
 
                     end
                   hdr_n.len = hdr_r.len - 1;
@@ -234,9 +234,9 @@ module bsg_tag_master_decentralized
               begin
                  state_n = eStuck;
 
-                 // synopsys translate_off
+`ifndef SYNTHESIS
                  $display("## bsg_tag_master transitioning to error state; be sure to run gate-level netlist to avoid sim/synth mismatch (%m)");
-                 // synopsys translate_on
+`endif
 
               end
         endcase // case (state_r)

--- a/bsg_tag/bsg_tag_master_decentralized.sv
+++ b/bsg_tag/bsg_tag_master_decentralized.sv
@@ -56,7 +56,7 @@ module bsg_tag_master_decentralized
    // counts 0..max_packet_len_lp
    localparam lg_max_packet_len_lp = `BSG_SAFE_CLOG2(max_packet_len_lp+1);
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
    if (debug_level_lp > 2)
      always @(negedge clk_i)
        $display("## bsg_tag_master clients=%b (%m)",clients_o);
@@ -94,7 +94,7 @@ module bsg_tag_master_decentralized
     );
 
    // veri lator doesn't support -d
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
    initial
         $display("## %m instantiating bsg_tag_master_decentralized with els_p=%d, local_els_p=%d, lg_width_p=%d, max_packet_len_lp=%d, reset_zero_len=%d"
                  ,els_p,local_els_p,lg_width_p,max_packet_len_lp,reset_len_lp);
@@ -122,7 +122,7 @@ module bsg_tag_master_decentralized
      // if we hit the counter AND (subtle bug) there is no valid incoming data that would get lost
      if (tag_reset_req & ~data_i_r)
        begin
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
           if (debug_level_lp > 2) $display("## bsg_tag_master RESET time %t (%m)",$time);
 `endif
           state_r   <= eStart;
@@ -139,7 +139,7 @@ module bsg_tag_master_decentralized
    always_ff @(posedge clk_i)
         hdr_r <= hdr_n;
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
    always_ff @(negedge clk_i)
      if (state_n != state_r)
        if (debug_level_lp > 1) $display("## bsg_tag_master STATE CHANGE  # %s --> %s #",state_r.name(),state_n.name());
@@ -168,7 +168,7 @@ module bsg_tag_master_decentralized
                end
           eHeader:
                begin
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
                   if (debug_level_lp > 1)
                     $display("## bsg_tag_master RECEIVING HEADER (%m) (%d) = %b",hdr_ptr_r,data_i_r);
 `endif
@@ -181,14 +181,14 @@ module bsg_tag_master_decentralized
                        if (hdr_n.len == 0)
                          begin
                             state_n = eStart;
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
                             $display("## bsg_tag_master NULL PACKET, len=0 (%m)");
 `endif
                          end
                        else
                          begin
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
                             if (debug_level_lp > 1)
                               $display("## bsg_tag_master PACKET HEADER RECEIVED (length=%b,data_not_reset=%b,nodeID=%b) (%m) "
                                        ,hdr_n.len,hdr_n.data_not_reset,hdr_n.nodeID);
@@ -210,7 +210,7 @@ module bsg_tag_master_decentralized
                   bsg_tag_n.op    = hdr_r.data_not_reset;
                   bsg_tag_n.param = data_i_r;
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
                   if (debug_level_lp > 2)
                     $display("## bsg_tag_master PACKET TRANSFER op,param=<%b,%b> (%m)", bsg_tag_n.op, bsg_tag_n.param);
 `endif
@@ -220,7 +220,7 @@ module bsg_tag_master_decentralized
                     begin
                        state_n = eStart;
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
                        if (debug_level_lp > 1) $display("## bsg_tag_master PACKET END (%m)");
 `endif
 
@@ -234,7 +234,7 @@ module bsg_tag_master_decentralized
               begin
                  state_n = eStuck;
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
                  $display("## bsg_tag_master transitioning to error state; be sure to run gate-level netlist to avoid sim/synth mismatch (%m)");
 `endif
 

--- a/hard/common/bsg_mem/bsg_mem_generator.py
+++ b/hard/common/bsg_mem/bsg_mem_generator.py
@@ -33,7 +33,7 @@ bsg_mem_1r1w_sync_template = """
       , output logic [`BSG_SAFE_MINUS(width_p,1):0] r_data_o
     );
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
     initial begin
       if (latch_last_read_p && !{latch_last_read_en})
         $error("BSG ERROR: latch_last_read_p is set but unsupported");
@@ -58,7 +58,7 @@ bsg_mem_1r1w_sync_template = """
       ) synth (.*);
     end
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
       initial
         begin
            $display("## %L: instantiating width_p=%d, els_p=%d (%m)", width_p, els_p);
@@ -99,7 +99,7 @@ bsg_mem_1r1w_sync_mask_write_bit_template = """
       , output logic [`BSG_SAFE_MINUS(width_p,1):0] r_data_o
     );
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
     initial begin
       if (latch_last_read_p && !{latch_last_read_en})
         $error("BSG ERROR: latch_last_read_p is set but unsupported");
@@ -124,7 +124,7 @@ bsg_mem_1r1w_sync_mask_write_bit_template = """
       ) synth (.*);
     end
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
       initial
         begin
            $display("## %L: instantiating width_p=%d, els_p=%d (%m)", width_p, els_p);
@@ -166,7 +166,7 @@ bsg_mem_1r1w_sync_mask_write_byte_template = """
       , output logic [`BSG_SAFE_MINUS(width_p,1):0] r_data_o
     );
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
     initial begin
       if (latch_last_read_p && !{latch_last_read_en})
         $error("BSG ERROR: latch_last_read_p is set but unsupported");
@@ -191,7 +191,7 @@ bsg_mem_1r1w_sync_mask_write_byte_template = """
       ) synth (.*);
     end
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
       initial
         begin
            $display("## %L: instantiating width_p=%d, els_p=%d (%m)", width_p, els_p);
@@ -224,7 +224,7 @@ module bsg_mem_1rw_sync #(parameter `BSG_INV_PARAM(width_p)
     , output logic [`BSG_SAFE_MINUS(width_p,1):0]  data_o
     );
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
     initial begin
       if (latch_last_read_p && !{latch_last_read_en})
         $error("BSG ERROR: latch_last_read_p is set but unsupported");
@@ -244,7 +244,7 @@ module bsg_mem_1rw_sync #(parameter `BSG_INV_PARAM(width_p)
       ) synth (.*);
     end
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
       initial
         begin
            $display("## %L: instantiating width_p=%d, els_p=%d (%m)", width_p, els_p);
@@ -276,7 +276,7 @@ module bsg_mem_1rw_sync_mask_write_bit #(parameter `BSG_INV_PARAM(width_p)
     , output logic [`BSG_SAFE_MINUS(width_p,1):0]  data_o
     );
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
     initial begin
       if (latch_last_read_p && !{latch_last_read_en})
         $error("BSG ERROR: latch_last_read_p is set but unsupported");
@@ -296,7 +296,7 @@ module bsg_mem_1rw_sync_mask_write_bit #(parameter `BSG_INV_PARAM(width_p)
       ) synth (.*);
     end
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
       initial
         begin
            $display("## %L: instantiating width_p=%d, els_p=%d (%m)", width_p, els_p);
@@ -329,7 +329,7 @@ module bsg_mem_1rw_sync_mask_write_byte #(parameter `BSG_INV_PARAM(data_width_p)
     , output logic [`BSG_SAFE_MINUS(data_width_p,1):0]  data_o
     );
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
     initial begin
       if (latch_last_read_p && !{latch_last_read_en})
         $error("BSG ERROR: latch_last_read_p is set but unsupported");
@@ -349,7 +349,7 @@ module bsg_mem_1rw_sync_mask_write_byte #(parameter `BSG_INV_PARAM(data_width_p)
       ) synth (.*);
     end
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
       initial
         begin
            $display("## %L: instantiating data_width_p=%d, els_p=%d (%m)", data_width_p, els_p);
@@ -387,7 +387,7 @@ bsg_mem_2r1w_sync_template = """
       , output logic [`BSG_SAFE_MINUS(width_p,1):0] r1_data_o
     );
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
     initial begin
       if (read_write_same_addr_p && !{read_write_same_addr_en})
         $error("BSG ERROR: read_write_same_addr_p is set but unsupported");
@@ -407,7 +407,7 @@ bsg_mem_2r1w_sync_template = """
       ) synth (.*);
     end
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
       initial
         begin
            $display("## %L: instantiating width_p=%d, els_p=%d (%m)", width_p, els_p);
@@ -449,7 +449,7 @@ bsg_mem_2rw_sync_template = """
   , output logic [`BSG_SAFE_MINUS(width_p,1):0] b_data_o
   );
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
     initial begin
       if (read_write_same_addr_p && !{read_write_same_addr_en})
         $error("BSG ERROR: read_write_same_addr_p is set but unsupported");
@@ -471,7 +471,7 @@ bsg_mem_2rw_sync_template = """
       ) synth (.*);
     end
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
       initial
         begin
            $display("## %L: instantiating width_p=%d, els_p=%d (%m)", width_p, els_p);
@@ -515,7 +515,7 @@ bsg_mem_2rw_sync_mask_write_bit_template = """
   , output logic [`BSG_SAFE_MINUS(width_p,1):0] b_data_o
   );
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
     initial begin
       if (read_write_same_addr_p && !{read_write_same_addr_en})
         $error("BSG ERROR: read_write_same_addr_p is set but unsupported");
@@ -537,7 +537,7 @@ bsg_mem_2rw_sync_mask_write_bit_template = """
       ) synth (.*);
     end
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
       initial
         begin
            $display("## %L: instantiating width_p=%d, els_p=%d (%m)", width_p, els_p);
@@ -582,7 +582,7 @@ bsg_mem_2rw_sync_mask_write_byte_template = """
   , output logic [`BSG_SAFE_MINUS(width_p,1):0] b_data_o
   );
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
     initial begin
       if (read_write_same_addr_p && !{read_write_same_addr_en})
         $error("BSG ERROR: read_write_same_addr_p is set but unsupported");
@@ -604,7 +604,7 @@ bsg_mem_2rw_sync_mask_write_byte_template = """
       ) synth (.*);
     end
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
       initial
         begin
            $display("## %L: instantiating width_p=%d, els_p=%d (%m)", width_p, els_p);
@@ -649,7 +649,7 @@ bsg_mem_3r1w_sync_template = """
       , output logic [`BSG_SAFE_MINUS(width_p,1):0] r2_data_o
     );
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
     initial begin
       if (read_write_same_addr_p && !{read_write_same_addr_en})
         $error("BSG ERROR: read_write_same_addr_p is set but unsupported");
@@ -669,7 +669,7 @@ bsg_mem_3r1w_sync_template = """
       ) synth (.*);
     end
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
       initial
         begin
            $display("## %L: instantiating width_p=%d, els_p=%d (%m)", width_p, els_p);

--- a/hard/common/bsg_mem/bsg_mem_generator.py
+++ b/hard/common/bsg_mem/bsg_mem_generator.py
@@ -33,7 +33,7 @@ bsg_mem_1r1w_sync_template = """
       , output logic [`BSG_SAFE_MINUS(width_p,1):0] r_data_o
     );
 
-    // synopsys translate_off
+`ifndef SYNTHESIS
     initial begin
       if (latch_last_read_p && !{latch_last_read_en})
         $error("BSG ERROR: latch_last_read_p is set but unsupported");
@@ -44,7 +44,7 @@ bsg_mem_1r1w_sync_template = """
       if (disable_collision_warning_p && !{disable_collision_warning_en})
         $warning("BSG ERROR: disable_collision_warning_p is set but unsupported");
     end
-    // synopsys translate_on
+`endif
 
     if (0) begin end else
     // Hardened macro selections
@@ -58,12 +58,12 @@ bsg_mem_1r1w_sync_template = """
       ) synth (.*);
     end
 
-    //synopsys translate_off
+`ifndef SYNTHESIS
       initial
         begin
            $display("## %L: instantiating width_p=%d, els_p=%d (%m)", width_p, els_p);
         end
-    //synopsys translate_on
+`endif
 
   endmodule
 
@@ -99,7 +99,7 @@ bsg_mem_1r1w_sync_mask_write_bit_template = """
       , output logic [`BSG_SAFE_MINUS(width_p,1):0] r_data_o
     );
 
-    // synopsys translate_off
+`ifndef SYNTHESIS
     initial begin
       if (latch_last_read_p && !{latch_last_read_en})
         $error("BSG ERROR: latch_last_read_p is set but unsupported");
@@ -110,7 +110,7 @@ bsg_mem_1r1w_sync_mask_write_bit_template = """
       if (disable_collision_warning_p && !{disable_collision_warning_en})
         $warning("BSG ERROR: disable_collision_warning_p is set but unsupported");
     end
-    // synopsys translate_on
+`endif
 
     if (0) begin end else
     // Hardened macro selections
@@ -124,12 +124,12 @@ bsg_mem_1r1w_sync_mask_write_bit_template = """
       ) synth (.*);
     end
 
-    //synopsys translate_off
+`ifndef SYNTHESIS
       initial
         begin
            $display("## %L: instantiating width_p=%d, els_p=%d (%m)", width_p, els_p);
         end
-    //synopsys translate_on
+`endif
 
   endmodule
 
@@ -166,7 +166,7 @@ bsg_mem_1r1w_sync_mask_write_byte_template = """
       , output logic [`BSG_SAFE_MINUS(width_p,1):0] r_data_o
     );
 
-    // synopsys translate_off
+`ifndef SYNTHESIS
     initial begin
       if (latch_last_read_p && !{latch_last_read_en})
         $error("BSG ERROR: latch_last_read_p is set but unsupported");
@@ -177,7 +177,7 @@ bsg_mem_1r1w_sync_mask_write_byte_template = """
       if (disable_collision_warning_p && !{disable_collision_warning_en})
         $warning("BSG ERROR: disable_collision_warning_p is set but unsupported");
     end
-    // synopsys translate_on
+`endif
 
     if (0) begin end else
     // Hardened macro selections
@@ -191,12 +191,12 @@ bsg_mem_1r1w_sync_mask_write_byte_template = """
       ) synth (.*);
     end
 
-    //synopsys translate_off
+`ifndef SYNTHESIS
       initial
         begin
            $display("## %L: instantiating width_p=%d, els_p=%d (%m)", width_p, els_p);
         end
-    //synopsys translate_on
+`endif
 
   endmodule
 
@@ -224,14 +224,14 @@ module bsg_mem_1rw_sync #(parameter `BSG_INV_PARAM(width_p)
     , output logic [`BSG_SAFE_MINUS(width_p,1):0]  data_o
     );
 
-    // synopsys translate_off
+`ifndef SYNTHESIS
     initial begin
       if (latch_last_read_p && !{latch_last_read_en})
         $error("BSG ERROR: latch_last_read_p is set but unsupported");
       if (enable_clock_gating_p && !{enable_clock_gating_en})
         $error("BSG ERROR: enable_clock_gating_p is set but unsupported");
     end
-    // synopsys translate_on
+`endif
 
     if (0) begin end else
     // Hardened macro selections
@@ -244,12 +244,12 @@ module bsg_mem_1rw_sync #(parameter `BSG_INV_PARAM(width_p)
       ) synth (.*);
     end
 
-    //synopsys translate_off
+`ifndef SYNTHESIS
       initial
         begin
            $display("## %L: instantiating width_p=%d, els_p=%d (%m)", width_p, els_p);
         end
-    //synopsys translate_on
+`endif
 
 endmodule
 """
@@ -276,14 +276,14 @@ module bsg_mem_1rw_sync_mask_write_bit #(parameter `BSG_INV_PARAM(width_p)
     , output logic [`BSG_SAFE_MINUS(width_p,1):0]  data_o
     );
 
-    // synopsys translate_off
+`ifndef SYNTHESIS
     initial begin
       if (latch_last_read_p && !{latch_last_read_en})
         $error("BSG ERROR: latch_last_read_p is set but unsupported");
       if (enable_clock_gating_p && !{enable_clock_gating_en})
         $error("BSG ERROR: enable_clock_gating_p is set but unsupported");
     end
-    // synopsys translate_on
+`endif
 
     if (0) begin end else
     // Hardened macro selections
@@ -296,12 +296,12 @@ module bsg_mem_1rw_sync_mask_write_bit #(parameter `BSG_INV_PARAM(width_p)
       ) synth (.*);
     end
 
-    //synopsys translate_off
+`ifndef SYNTHESIS
       initial
         begin
            $display("## %L: instantiating width_p=%d, els_p=%d (%m)", width_p, els_p);
         end
-    //synopsys translate_on
+`endif
 
 endmodule
 """
@@ -329,14 +329,14 @@ module bsg_mem_1rw_sync_mask_write_byte #(parameter `BSG_INV_PARAM(data_width_p)
     , output logic [`BSG_SAFE_MINUS(data_width_p,1):0]  data_o
     );
 
-    // synopsys translate_off
+`ifndef SYNTHESIS
     initial begin
       if (latch_last_read_p && !{latch_last_read_en})
         $error("BSG ERROR: latch_last_read_p is set but unsupported");
       if (enable_clock_gating_p && !{enable_clock_gating_en})
         $error("BSG ERROR: enable_clock_gating_p is set but unsupported");
     end
-    // synopsys translate_on
+`endif
 
     if (0) begin end else
     // Hardened macro selections
@@ -349,12 +349,12 @@ module bsg_mem_1rw_sync_mask_write_byte #(parameter `BSG_INV_PARAM(data_width_p)
       ) synth (.*);
     end
 
-    //synopsys translate_off
+`ifndef SYNTHESIS
       initial
         begin
            $display("## %L: instantiating data_width_p=%d, els_p=%d (%m)", data_width_p, els_p);
         end
-    //synopsys translate_on
+`endif
 endmodule
 """
 
@@ -387,14 +387,14 @@ bsg_mem_2r1w_sync_template = """
       , output logic [`BSG_SAFE_MINUS(width_p,1):0] r1_data_o
     );
 
-    // synopsys translate_off
+`ifndef SYNTHESIS
     initial begin
       if (read_write_same_addr_p && !{read_write_same_addr_en})
         $error("BSG ERROR: read_write_same_addr_p is set but unsupported");
       if (enable_clock_gating_p && !{enable_clock_gating_en})
         $error("BSG ERROR: enable_clock_gating_p is set but unsupported");
     end
-    // synopsys translate_on
+`endif
 
     if (0) begin end else
     // Hardened macro selections
@@ -407,12 +407,12 @@ bsg_mem_2r1w_sync_template = """
       ) synth (.*);
     end
 
-    //synopsys translate_off
+`ifndef SYNTHESIS
       initial
         begin
            $display("## %L: instantiating width_p=%d, els_p=%d (%m)", width_p, els_p);
         end
-    //synopsys translate_on
+`endif
 
   endmodule
 
@@ -449,7 +449,7 @@ bsg_mem_2rw_sync_template = """
   , output logic [`BSG_SAFE_MINUS(width_p,1):0] b_data_o
   );
 
-    // synopsys translate_off
+`ifndef SYNTHESIS
     initial begin
       if (read_write_same_addr_p && !{read_write_same_addr_en})
         $error("BSG ERROR: read_write_same_addr_p is set but unsupported");
@@ -458,7 +458,7 @@ bsg_mem_2rw_sync_template = """
       if (disable_collision_warning_p && !{disable_collision_warning_en})
         $warning("BSG ERROR: disable_collision_warning_p is set but unsupported");
     end
-    // synopsys translate_on
+`endif
 
     if (0) begin end else
     // Hardened macro selections
@@ -471,12 +471,12 @@ bsg_mem_2rw_sync_template = """
       ) synth (.*);
     end
 
-    //synopsys translate_off
+`ifndef SYNTHESIS
       initial
         begin
            $display("## %L: instantiating width_p=%d, els_p=%d (%m)", width_p, els_p);
         end
-    //synopsys translate_on
+`endif
 
   endmodule
 
@@ -515,7 +515,7 @@ bsg_mem_2rw_sync_mask_write_bit_template = """
   , output logic [`BSG_SAFE_MINUS(width_p,1):0] b_data_o
   );
 
-    // synopsys translate_off
+`ifndef SYNTHESIS
     initial begin
       if (read_write_same_addr_p && !{read_write_same_addr_en})
         $error("BSG ERROR: read_write_same_addr_p is set but unsupported");
@@ -524,7 +524,7 @@ bsg_mem_2rw_sync_mask_write_bit_template = """
       if (disable_collision_warning_p && !{disable_collision_warning_en})
         $warning("BSG ERROR: disable_collision_warning_p is set but unsupported");
     end
-    // synopsys translate_on
+`endif
 
     if (0) begin end else
     // Hardened macro selections
@@ -537,12 +537,12 @@ bsg_mem_2rw_sync_mask_write_bit_template = """
       ) synth (.*);
     end
 
-    //synopsys translate_off
+`ifndef SYNTHESIS
       initial
         begin
            $display("## %L: instantiating width_p=%d, els_p=%d (%m)", width_p, els_p);
         end
-    //synopsys translate_on
+`endif
 
   endmodule
 
@@ -582,7 +582,7 @@ bsg_mem_2rw_sync_mask_write_byte_template = """
   , output logic [`BSG_SAFE_MINUS(width_p,1):0] b_data_o
   );
 
-    // synopsys translate_off
+`ifndef SYNTHESIS
     initial begin
       if (read_write_same_addr_p && !{read_write_same_addr_en})
         $error("BSG ERROR: read_write_same_addr_p is set but unsupported");
@@ -591,7 +591,7 @@ bsg_mem_2rw_sync_mask_write_byte_template = """
       if (disable_collision_warning_p && !{disable_collision_warning_en})
         $warning("BSG ERROR: disable_collision_warning_p is set but unsupported");
     end
-    // synopsys translate_on
+`endif
 
     if (0) begin end else
     // Hardened macro selections
@@ -604,12 +604,12 @@ bsg_mem_2rw_sync_mask_write_byte_template = """
       ) synth (.*);
     end
 
-    //synopsys translate_off
+`ifndef SYNTHESIS
       initial
         begin
            $display("## %L: instantiating width_p=%d, els_p=%d (%m)", width_p, els_p);
         end
-    //synopsys translate_on
+`endif
 
   endmodule
 
@@ -649,14 +649,14 @@ bsg_mem_3r1w_sync_template = """
       , output logic [`BSG_SAFE_MINUS(width_p,1):0] r2_data_o
     );
 
-    // synopsys translate_off
+`ifndef SYNTHESIS
     initial begin
       if (read_write_same_addr_p && !{read_write_same_addr_en})
         $error("BSG ERROR: read_write_same_addr_p is set but unsupported");
       if (enable_clock_gating_p && !{enable_clock_gating_en})
         $error("BSG ERROR: enable_clock_gating_p is set but unsupported");
     end
-    // synopsys translate_on
+`endif
 
     if (0) begin end else
     // Hardened macro selections
@@ -669,12 +669,12 @@ bsg_mem_3r1w_sync_template = """
       ) synth (.*);
     end
 
-    //synopsys translate_off
+`ifndef SYNTHESIS
       initial
         begin
            $display("## %L: instantiating width_p=%d, els_p=%d (%m)", width_p, els_p);
         end
-    //synopsys translate_on
+`endif
 
   endmodule
 

--- a/hard/gf_14/bsg_async/bsg_launch_sync_sync.sv
+++ b/hard/gf_14/bsg_async/bsg_launch_sync_sync.sv
@@ -218,7 +218,7 @@ module bsg_launch_sync_sync #(parameter `BSG_INV_PARAM(width_p)
     , output [width_p-1:0] oclk_data_o // after sync flops
     );
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
 /*   initial
      begin

--- a/hard/gf_14/bsg_async/bsg_launch_sync_sync.sv
+++ b/hard/gf_14/bsg_async/bsg_launch_sync_sync.sv
@@ -218,7 +218,7 @@ module bsg_launch_sync_sync #(parameter `BSG_INV_PARAM(width_p)
     , output [width_p-1:0] oclk_data_o // after sync flops
     );
 
-// synopsys translate_off
+`ifndef SYNTHESIS
 
 /*   initial
      begin
@@ -232,7 +232,7 @@ module bsg_launch_sync_sync #(parameter `BSG_INV_PARAM(width_p)
           $finish();
        end
 
-// synopsys translate_on
+`endif
 
    genvar i;
 

--- a/hard/gf_14/bsg_async/bsg_sync_sync.sv
+++ b/hard/gf_14/bsg_async/bsg_sync_sync.sv
@@ -85,7 +85,7 @@ module bsg_sync_sync #(parameter `BSG_INV_PARAM(width_p ))
 
    genvar   i;
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
  /*
    initial
      begin

--- a/hard/gf_14/bsg_async/bsg_sync_sync.sv
+++ b/hard/gf_14/bsg_async/bsg_sync_sync.sv
@@ -85,14 +85,14 @@ module bsg_sync_sync #(parameter `BSG_INV_PARAM(width_p ))
 
    genvar   i;
 
-   // synopsys translate_off
+`ifndef SYNTHESIS
  /*
    initial
      begin
         $display("%m: instantiating bss of size %d",width_p);
      end
   */
-   // synopsys translate_on
+`endif
 
    for (i = 0; i < (width_p/`bss_max_block); i = i + 1)
      begin : maxb

--- a/hard/gf_14/bsg_clk_gen/bsg_clk_gen_osc.sv
+++ b/hard/gf_14/bsg_clk_gen/bsg_clk_gen_osc.sv
@@ -129,13 +129,13 @@ module bsg_clk_gen_osc
    wire [15:0] fb_clk_dly_time;
    assign #(fb_clk_dly_time) fb_clk_del = fb_clk;
 
-   // synopsys translate_off
+`ifndef SYNTHESIS
    bsg_clk_gen_osc_tag_payload_s tag_r_sync;
    always @(posedge clk_o or posedge async_reset_i)
      tag_r_sync <= (async_reset_i)? '0 :
        ((tag_trigger_r_async)? tag_r_async : tag_r_sync);
    assign fb_clk_dly_time = 125+((1<<$bits(tag_r_sync))-tag_r_sync)*5;
-   // synopsys translate_on
+`endif
 
    bsg_rp_clk_gen_atomic_delay_tuner  adt_BSG_DONT_TOUCH
      (.i(fb_clk_del)

--- a/hard/gf_14/bsg_clk_gen/bsg_clk_gen_osc.sv
+++ b/hard/gf_14/bsg_clk_gen/bsg_clk_gen_osc.sv
@@ -129,7 +129,7 @@ module bsg_clk_gen_osc
    wire [15:0] fb_clk_dly_time;
    assign #(fb_clk_dly_time) fb_clk_del = fb_clk;
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
    bsg_clk_gen_osc_tag_payload_s tag_r_sync;
    always @(posedge clk_o or posedge async_reset_i)
      tag_r_sync <= (async_reset_i)? '0 :

--- a/hard/gf_14/bsg_misc/bsg_mux.sv
+++ b/hard/gf_14/bsg_misc/bsg_mux.sv
@@ -34,11 +34,11 @@ module bsg_mux #(parameter `BSG_INV_PARAM(width_p)
         end
 
 
-        // synopsys translate_off
+`ifndef SYNTHESIS
         initial
           assert(balanced_p == 0)
             else $error("%m warning: synthesizable implementation of bsg_mux does not support balanced_p");
-       // synopsys translate_on
+`endif
      end
 
 endmodule

--- a/hard/gf_14/bsg_misc/bsg_mux.sv
+++ b/hard/gf_14/bsg_misc/bsg_mux.sv
@@ -34,7 +34,7 @@ module bsg_mux #(parameter `BSG_INV_PARAM(width_p)
         end
 
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
         initial
           assert(balanced_p == 0)
             else $error("%m warning: synthesizable implementation of bsg_mux does not support balanced_p");

--- a/hard/pickle_40/bsg_mem/bsg_mem_1rw_sync.sv
+++ b/hard/pickle_40/bsg_mem/bsg_mem_1rw_sync.sv
@@ -77,12 +77,12 @@ module bsg_mem_1rw_sync #( parameter `BSG_INV_PARAM(width_p )
       end // block: z
 
 
-  // synopsys translate_off
+`ifndef SYNTHESIS
   initial
     begin
       $display("## %L: instantiating width_p=%d, els_p=%d, substitute_1r1w_p=%d (%m)",width_p,els_p,substitute_1r1w_p);
     end
-  // synopsys translate_on
+`endif
 
 endmodule
 

--- a/hard/pickle_40/bsg_mem/bsg_mem_1rw_sync.sv
+++ b/hard/pickle_40/bsg_mem/bsg_mem_1rw_sync.sv
@@ -77,7 +77,7 @@ module bsg_mem_1rw_sync #( parameter `BSG_INV_PARAM(width_p )
       end // block: z
 
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
   initial
     begin
       $display("## %L: instantiating width_p=%d, els_p=%d, substitute_1r1w_p=%d (%m)",width_p,els_p,substitute_1r1w_p);

--- a/hard/pickle_40/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.sv
+++ b/hard/pickle_40/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.sv
@@ -70,7 +70,7 @@ module bsg_mem_1rw_sync_mask_write_bit #( parameter `BSG_INV_PARAM(width_p )
           (.*);
     end // block: notmacro
 
-  // synopsys translate_off
+`ifndef SYNTHESIS
   always_ff @(posedge clk_i)
     begin
       if (v_i)
@@ -82,7 +82,7 @@ module bsg_mem_1rw_sync_mask_write_bit #( parameter `BSG_INV_PARAM(width_p )
     begin
       $display("## %L: instantiating width_p=%d, els_p=%d (%m)",width_p,els_p);
     end
-// synopsys translate_on
+`endif
 
 endmodule
 

--- a/hard/pickle_40/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.sv
+++ b/hard/pickle_40/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.sv
@@ -70,7 +70,7 @@ module bsg_mem_1rw_sync_mask_write_bit #( parameter `BSG_INV_PARAM(width_p )
           (.*);
     end // block: notmacro
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
   always_ff @(posedge clk_i)
     begin
       if (v_i)

--- a/hard/pickle_40/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
+++ b/hard/pickle_40/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
@@ -44,7 +44,7 @@ module bsg_mem_1rw_sync_mask_write_byte #( parameter `BSG_INV_PARAM(els_p )
     end // block: notmacro
 
 
-  // synopsys translate_off
+`ifndef SYNTHESIS
   always_comb
     begin
       assert (data_width_p % 8 == 0)
@@ -55,7 +55,7 @@ module bsg_mem_1rw_sync_mask_write_byte #( parameter `BSG_INV_PARAM(els_p )
     begin
       $display("## bsg_mem_1rw_sync_mask_write_byte: instantiating data_width_p=%d, els_p=%d (%m)",data_width_p,els_p);
     end
-  // synopsys translate_on
+`endif
    
 endmodule
 

--- a/hard/pickle_40/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
+++ b/hard/pickle_40/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
@@ -44,7 +44,7 @@ module bsg_mem_1rw_sync_mask_write_byte #( parameter `BSG_INV_PARAM(els_p )
     end // block: notmacro
 
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
   always_comb
     begin
       assert (data_width_p % 8 == 0)

--- a/hard/pickle_40/bsg_mem/bsg_mem_2r1w_sync.sv
+++ b/hard/pickle_40/bsg_mem/bsg_mem_2r1w_sync.sv
@@ -97,7 +97,7 @@ module bsg_mem_2r1w_sync #( parameter `BSG_INV_PARAM(width_p )
         end // block: notmacro
     end // block: z
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
   always_ff @(posedge clk_i)
     if (w_v_i)
     begin

--- a/hard/pickle_40/bsg_mem/bsg_mem_2r1w_sync.sv
+++ b/hard/pickle_40/bsg_mem/bsg_mem_2r1w_sync.sv
@@ -97,7 +97,7 @@ module bsg_mem_2r1w_sync #( parameter `BSG_INV_PARAM(width_p )
         end // block: notmacro
     end // block: z
 
-  //synopsys translate_off
+`ifndef SYNTHESIS
   always_ff @(posedge clk_i)
     if (w_v_i)
     begin
@@ -115,7 +115,7 @@ module bsg_mem_2r1w_sync #( parameter `BSG_INV_PARAM(width_p )
     begin
       $display("## %L: instantiating width_p=%d, els_p=%d, read_write_same_addr_p=%d, harden_p=%d (%m)",width_p,els_p,read_write_same_addr_p,harden_p);
     end
-  //synopsys translate_on
+`endif
 
 endmodule
 

--- a/hard/saed_90/bsg_mem/bsg_mem_1r1w_sync.sv
+++ b/hard/saed_90/bsg_mem/bsg_mem_1r1w_sync.sv
@@ -98,7 +98,7 @@ module bsg_mem_1r1w_sync #(parameter `BSG_INV_PARAM(width_p)
       end // block: notmacro
   end // block: z
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
   //initial
     //begin
       //$display("## %L: instantiating width_p=%d, els_p=%d, substitute_1r1w_p=%d (%m)",width_p,els_p/**,substitute_1r1w_p**/);

--- a/hard/saed_90/bsg_mem/bsg_mem_1r1w_sync.sv
+++ b/hard/saed_90/bsg_mem/bsg_mem_1r1w_sync.sv
@@ -98,12 +98,12 @@ module bsg_mem_1r1w_sync #(parameter `BSG_INV_PARAM(width_p)
       end // block: notmacro
   end // block: z
 
-  // synopsys translate_off
+`ifndef SYNTHESIS
   //initial
     //begin
       //$display("## %L: instantiating width_p=%d, els_p=%d, substitute_1r1w_p=%d (%m)",width_p,els_p/**,substitute_1r1w_p**/);
     //end
-  // synopsys translate_on
+`endif
 
 endmodule
 

--- a/hard/saed_90/bsg_mem/bsg_mem_1rw_sync.sv
+++ b/hard/saed_90/bsg_mem/bsg_mem_1rw_sync.sv
@@ -100,12 +100,12 @@ module bsg_mem_1rw_sync #(parameter `BSG_INV_PARAM(width_p)
       end // block: notmacro
   end // block: z
 
-  // synopsys translate_off
+`ifndef SYNTHESIS
   initial
     begin
       $display("## %L: instantiating width_p=%d, els_p=%d, substitute_1r1w_p=%d (%m)",width_p,els_p,substitute_1r1w_p);
     end
-  // synopsys translate_on
+`endif
 
 endmodule
 

--- a/hard/saed_90/bsg_mem/bsg_mem_1rw_sync.sv
+++ b/hard/saed_90/bsg_mem/bsg_mem_1rw_sync.sv
@@ -100,7 +100,7 @@ module bsg_mem_1rw_sync #(parameter `BSG_INV_PARAM(width_p)
       end // block: notmacro
   end // block: z
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
   initial
     begin
       $display("## %L: instantiating width_p=%d, els_p=%d, substitute_1r1w_p=%d (%m)",width_p,els_p,substitute_1r1w_p);

--- a/hard/saed_90/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.sv
+++ b/hard/saed_90/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.sv
@@ -86,7 +86,7 @@ module bsg_mem_1rw_sync_mask_write_bit #(parameter `BSG_INV_PARAM(width_p)
     end // block: notmacro
 
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
    always_ff @(posedge clk_lo)
      if (v_i === 1)

--- a/hard/saed_90/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.sv
+++ b/hard/saed_90/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.sv
@@ -86,7 +86,7 @@ module bsg_mem_1rw_sync_mask_write_bit #(parameter `BSG_INV_PARAM(width_p)
     end // block: notmacro
 
 
-   // synopsys translate_off
+`ifndef SYNTHESIS
 
    always_ff @(posedge clk_lo)
      if (v_i === 1)
@@ -98,7 +98,7 @@ module bsg_mem_1rw_sync_mask_write_bit #(parameter `BSG_INV_PARAM(width_p)
         $display("## %L: instantiating width_p=%d, els_p=%d (%m)",width_p,els_p);
      end
 
-  // synopsys translate_on
+`endif
 
    
 endmodule

--- a/hard/saed_90/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
+++ b/hard/saed_90/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
@@ -72,7 +72,7 @@ module bsg_mem_1rw_sync_mask_write_byte #(parameter `BSG_INV_PARAM(els_p )
 
     end // block: notmacro
 
-  // synopsys translate_off
+`ifndef SYNTHESIS
   always_comb
     assert (data_width_p % 8 == 0)
       else $error("data width should be a multiple of 8 for byte masking");
@@ -81,7 +81,7 @@ module bsg_mem_1rw_sync_mask_write_byte #(parameter `BSG_INV_PARAM(els_p )
     begin
       $display("## bsg_mem_1rw_sync_mask_write_byte: instantiating data_width_p=%d, els_p=%d (%m)",data_width_p,els_p);
     end
-  // synopsys translate_on
+`endif
    
 endmodule
 

--- a/hard/saed_90/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
+++ b/hard/saed_90/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
@@ -72,7 +72,7 @@ module bsg_mem_1rw_sync_mask_write_byte #(parameter `BSG_INV_PARAM(els_p )
 
     end // block: notmacro
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
   always_comb
     assert (data_width_p % 8 == 0)
       else $error("data width should be a multiple of 8 for byte masking");

--- a/hard/tsmc_16/bsg_async/bsg_launch_sync_sync.sv
+++ b/hard/tsmc_16/bsg_async/bsg_launch_sync_sync.sv
@@ -111,7 +111,7 @@ module bsg_launch_sync_sync #(parameter `BSG_INV_PARAM(width_p)
 
    genvar i;
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
    initial assert (iclk_reset_i !== 'z)
      else
        begin

--- a/hard/tsmc_16/bsg_async/bsg_launch_sync_sync.sv
+++ b/hard/tsmc_16/bsg_async/bsg_launch_sync_sync.sv
@@ -111,14 +111,14 @@ module bsg_launch_sync_sync #(parameter `BSG_INV_PARAM(width_p)
 
    genvar i;
 
-   // synopsys translate_off
+`ifndef SYNTHESIS
    initial assert (iclk_reset_i !== 'z)
      else
        begin
           $error("%m iclk_reset should be connected");
           $finish();
        end
-   // synopsys translate_on
+`endif
 
    if (use_negedge_for_launch_p)
      begin: n

--- a/hard/tsmc_16/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit.sv
+++ b/hard/tsmc_16/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit.sv
@@ -103,7 +103,7 @@ module bsg_mem_1r1w_sync_mask_write_bit #(parameter `BSG_INV_PARAM(width_p)
          ) synth
          (.*);
 
-   //synopsys translate_off
+`ifndef SYNTHESIS
 
    always_ff @(posedge clk_i)
      if (w_v_i)
@@ -125,7 +125,7 @@ module bsg_mem_1r1w_sync_mask_write_bit #(parameter `BSG_INV_PARAM(width_p)
         $display("## %L: instantiating width_p=%d, els_p=%d, read_write_same_addr_p=%d harden_p=%d (%m)",width_p,els_p,read_write_same_addr_p, harden_p);
      end
 
-   //synopsys translate_on
+`endif
 
 endmodule
 

--- a/hard/tsmc_16/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit.sv
+++ b/hard/tsmc_16/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit.sv
@@ -103,7 +103,7 @@ module bsg_mem_1r1w_sync_mask_write_bit #(parameter `BSG_INV_PARAM(width_p)
          ) synth
          (.*);
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
    always_ff @(posedge clk_i)
      if (w_v_i)

--- a/hard/tsmc_16/bsg_mem/bsg_mem_1rw_sync.sv
+++ b/hard/tsmc_16/bsg_mem/bsg_mem_1rw_sync.sv
@@ -96,7 +96,7 @@ module bsg_mem_1rw_sync #(parameter `BSG_INV_PARAM(width_p)
       end // block: notmacro
   end // block: z
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
   initial
     begin
       $display("## %L: instantiating width_p=%d, els_p=%d, substitute_1r1w_p=%d (%m)",width_p,els_p,substitute_1r1w_p);

--- a/hard/tsmc_16/bsg_mem/bsg_mem_1rw_sync.sv
+++ b/hard/tsmc_16/bsg_mem/bsg_mem_1rw_sync.sv
@@ -96,12 +96,12 @@ module bsg_mem_1rw_sync #(parameter `BSG_INV_PARAM(width_p)
       end // block: notmacro
   end // block: z
 
-  // synopsys translate_off
+`ifndef SYNTHESIS
   initial
     begin
       $display("## %L: instantiating width_p=%d, els_p=%d, substitute_1r1w_p=%d (%m)",width_p,els_p,substitute_1r1w_p);
     end
-  // synopsys translate_on
+`endif
 
 endmodule
 

--- a/hard/tsmc_16/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.sv
+++ b/hard/tsmc_16/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.sv
@@ -76,7 +76,7 @@ module bsg_mem_1rw_sync_mask_write_bit #(parameter `BSG_INV_PARAM(width_p)
        ) synth
        (.*);
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
    always_ff @(posedge clk_i)
      if (v_i)

--- a/hard/tsmc_16/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.sv
+++ b/hard/tsmc_16/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.sv
@@ -76,7 +76,7 @@ module bsg_mem_1rw_sync_mask_write_bit #(parameter `BSG_INV_PARAM(width_p)
        ) synth
        (.*);
 
-   // synopsys translate_off
+`ifndef SYNTHESIS
 
    always_ff @(posedge clk_i)
      if (v_i)
@@ -88,7 +88,7 @@ module bsg_mem_1rw_sync_mask_write_bit #(parameter `BSG_INV_PARAM(width_p)
         $display("## %L: instantiating width_p=%d, els_p=%d (%m)",width_p,els_p);
      end
 
-  // synopsys translate_on
+`endif
 
 
 endmodule

--- a/hard/tsmc_16/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
+++ b/hard/tsmc_16/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
@@ -49,7 +49,7 @@ module bsg_mem_1rw_sync_mask_write_byte #(parameter `BSG_INV_PARAM(els_p )
 
     end // block: notmacro
 
-  // synopsys translate_off
+`ifndef SYNTHESIS
   always_comb
     assert (data_width_p % 8 == 0)
       else $error("data width should be a multiple of 8 for byte masking");
@@ -58,7 +58,7 @@ module bsg_mem_1rw_sync_mask_write_byte #(parameter `BSG_INV_PARAM(els_p )
     begin
       $display("## bsg_mem_1rw_sync_mask_write_byte: instantiating data_width_p=%d, els_p=%d (%m)",data_width_p,els_p);
     end
-  // synopsys translate_on
+`endif
    
 endmodule
 

--- a/hard/tsmc_16/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
+++ b/hard/tsmc_16/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
@@ -49,7 +49,7 @@ module bsg_mem_1rw_sync_mask_write_byte #(parameter `BSG_INV_PARAM(els_p )
 
     end // block: notmacro
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
   always_comb
     assert (data_width_p % 8 == 0)
       else $error("data width should be a multiple of 8 for byte masking");

--- a/hard/tsmc_16/bsg_mem/bsg_mem_2r1w_sync.sv
+++ b/hard/tsmc_16/bsg_mem/bsg_mem_2r1w_sync.sv
@@ -92,7 +92,7 @@ module bsg_mem_2r1w_sync #(parameter `BSG_INV_PARAM(width_p)
      end
 
 
-//synopsys translate_off
+`ifndef SYNTHESIS
 
    always_ff @(posedge clk_i)
      if (w_v_i)
@@ -113,7 +113,7 @@ module bsg_mem_2r1w_sync #(parameter `BSG_INV_PARAM(width_p)
 		 ,width_p,els_p,read_write_same_addr_p,harden_p);
      end
 
-//synopsys translate_on
+`endif
 
    
 

--- a/hard/tsmc_16/bsg_mem/bsg_mem_2r1w_sync.sv
+++ b/hard/tsmc_16/bsg_mem/bsg_mem_2r1w_sync.sv
@@ -92,7 +92,7 @@ module bsg_mem_2r1w_sync #(parameter `BSG_INV_PARAM(width_p)
      end
 
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
    always_ff @(posedge clk_i)
      if (w_v_i)

--- a/hard/tsmc_180_250/bsg_mem/bsg_mem_1r1w.sv
+++ b/hard/tsmc_180_250/bsg_mem/bsg_mem_1r1w.sv
@@ -151,7 +151,7 @@ module bsg_mem_1r1w #(parameter `BSG_INV_PARAM(width_p)
 		    (.*);
 	     end
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
    initial
      begin

--- a/hard/tsmc_180_250/bsg_mem/bsg_mem_1r1w.sv
+++ b/hard/tsmc_180_250/bsg_mem/bsg_mem_1r1w.sv
@@ -151,7 +151,7 @@ module bsg_mem_1r1w #(parameter `BSG_INV_PARAM(width_p)
 		    (.*);
 	     end
 
-   // synopsys translate_off
+`ifndef SYNTHESIS
 
    initial
      begin
@@ -170,7 +170,7 @@ module bsg_mem_1r1w #(parameter `BSG_INV_PARAM(width_p)
             else $error("%m: Attempt to read and write same address %x",w_addr_i);
        end
    
-   // synopsys translate_on
+`endif
 
 endmodule
 

--- a/hard/tsmc_180_250/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit.sv
+++ b/hard/tsmc_180_250/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit.sv
@@ -55,7 +55,7 @@ module bsg_mem_1r1w_sync_mask_write_bit #(parameter `BSG_INV_PARAM(width_p)
        ) synth
        (.*);
 
-   //synopsys translate_off
+`ifndef SYNTHESIS
 
 /*
    always_ff @(negedge clk_i)
@@ -84,7 +84,7 @@ module bsg_mem_1r1w_sync_mask_write_bit #(parameter `BSG_INV_PARAM(width_p)
         $display("## %L: instantiating width_p=%d, els_p=%d, read_write_same_addr_p=%d harden_p=%d (%m)",width_p,els_p,read_write_same_addr_p, harden_p);
      end
 
-   //synopsys translate_on
+`endif
 
 endmodule
 

--- a/hard/tsmc_180_250/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit.sv
+++ b/hard/tsmc_180_250/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit.sv
@@ -55,7 +55,7 @@ module bsg_mem_1r1w_sync_mask_write_bit #(parameter `BSG_INV_PARAM(width_p)
        ) synth
        (.*);
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
 /*
    always_ff @(negedge clk_i)

--- a/hard/tsmc_180_250/bsg_mem/bsg_mem_1rw_sync.sv
+++ b/hard/tsmc_180_250/bsg_mem/bsg_mem_1rw_sync.sv
@@ -108,7 +108,7 @@ module bsg_mem_1rw_sync #(parameter `BSG_INV_PARAM(width_p)
      end // block: z
 
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
    initial
      begin
         $display("## %L: instantiating width_p=%d, els_p=%d, substitute_1r1w_p=%d (%m)",width_p,els_p,substitute_1r1w_p);

--- a/hard/tsmc_180_250/bsg_mem/bsg_mem_1rw_sync.sv
+++ b/hard/tsmc_180_250/bsg_mem/bsg_mem_1rw_sync.sv
@@ -108,13 +108,13 @@ module bsg_mem_1rw_sync #(parameter `BSG_INV_PARAM(width_p)
      end // block: z
 
 
-   // synopsys translate_off
+`ifndef SYNTHESIS
    initial
      begin
         $display("## %L: instantiating width_p=%d, els_p=%d, substitute_1r1w_p=%d (%m)",width_p,els_p,substitute_1r1w_p);
      end
 
-   // synopsys translate_on
+`endif
 
 endmodule
 

--- a/hard/tsmc_180_250/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.sv
+++ b/hard/tsmc_180_250/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.sv
@@ -47,7 +47,7 @@ module bsg_mem_1rw_sync_mask_write_bit #(parameter `BSG_INV_PARAM(width_p)
        ) synth
        (.*);
 
-   // synopsys translate_off
+`ifndef SYNTHESIS
 
    always_ff @(posedge clk_i)
      if (v_i)
@@ -59,7 +59,7 @@ module bsg_mem_1rw_sync_mask_write_bit #(parameter `BSG_INV_PARAM(width_p)
         $display("## %L: instantiating width_p=%d, els_p=%d (%m)",width_p,els_p);
      end
 
-  // synopsys translate_on
+`endif
 
 
 endmodule

--- a/hard/tsmc_180_250/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.sv
+++ b/hard/tsmc_180_250/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.sv
@@ -47,7 +47,7 @@ module bsg_mem_1rw_sync_mask_write_bit #(parameter `BSG_INV_PARAM(width_p)
        ) synth
        (.*);
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
    always_ff @(posedge clk_i)
      if (v_i)

--- a/hard/tsmc_180_250/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
+++ b/hard/tsmc_180_250/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
@@ -55,7 +55,7 @@ module bsg_mem_1rw_sync_mask_write_byte
     end
 
 
-  // synopsys translate_off
+`ifndef SYNTHESIS
 
   always_comb
     assert (data_width_p % 8 == 0)
@@ -66,7 +66,7 @@ module bsg_mem_1rw_sync_mask_write_byte
         $display("## bsg_mem_1rw_sync_mask_write_byte: instantiating data_width_p=%d, els_p=%d (%m)",data_width_p,els_p);
      end
 
-  // synopsys translate_on
+`endif
    
 endmodule
 

--- a/hard/tsmc_180_250/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
+++ b/hard/tsmc_180_250/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
@@ -55,7 +55,7 @@ module bsg_mem_1rw_sync_mask_write_byte
     end
 
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
   always_comb
     assert (data_width_p % 8 == 0)

--- a/hard/tsmc_180_250/bsg_mem/bsg_mem_2r1w.sv
+++ b/hard/tsmc_180_250/bsg_mem/bsg_mem_2r1w.sv
@@ -56,7 +56,7 @@ module bsg_mem_2r1w #(parameter `BSG_INV_PARAM(width_p)
 	      (.*);
        end
 
-// synopsys translate_off
+`ifndef SYNTHESIS
 
    always_ff @(posedge w_clk_i)
      if (w_v_i)
@@ -76,7 +76,7 @@ module bsg_mem_2r1w #(parameter `BSG_INV_PARAM(width_p)
         $display("## %L: instantiating width_p=%d, els_p=%d, read_write_same_addr_p=%d (%m)",width_p,els_p,read_write_same_addr_p);
      end
 
-// synopsys translate_on
+`endif
 
    
 endmodule

--- a/hard/tsmc_180_250/bsg_mem/bsg_mem_2r1w.sv
+++ b/hard/tsmc_180_250/bsg_mem/bsg_mem_2r1w.sv
@@ -56,7 +56,7 @@ module bsg_mem_2r1w #(parameter `BSG_INV_PARAM(width_p)
 	      (.*);
        end
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
    always_ff @(posedge w_clk_i)
      if (w_v_i)

--- a/hard/tsmc_180_250/bsg_mem/bsg_mem_2r1w_sync.sv
+++ b/hard/tsmc_180_250/bsg_mem/bsg_mem_2r1w_sync.sv
@@ -32,7 +32,7 @@ module bsg_mem_2r1w_sync #(parameter `BSG_INV_PARAM(width_p)
 
    if ((width_p == 32) && (els_p == 32))
      begin: macro
-        // synopsys translate_off
+`ifndef SYNTHESIS
         initial
           begin
              assert(read_write_same_addr_p==0)
@@ -42,7 +42,7 @@ module bsg_mem_2r1w_sync #(parameter `BSG_INV_PARAM(width_p)
                     $finish();
                  end
           end
-        // synopsys translate_on
+`endif
 
         // use two 1R1W rams to create
         tsmc180_2rf_lg5_w32_m1_all mem0
@@ -93,7 +93,7 @@ module bsg_mem_2r1w_sync #(parameter `BSG_INV_PARAM(width_p)
      end
 
 
-//synopsys translate_off
+`ifndef SYNTHESIS
 
    always_ff @(posedge clk_i)
      if (w_v_i)
@@ -114,7 +114,7 @@ module bsg_mem_2r1w_sync #(parameter `BSG_INV_PARAM(width_p)
 		 ,width_p,els_p,read_write_same_addr_p,harden_p);
      end
 
-//synopsys translate_on
+`endif
 
    
 

--- a/hard/tsmc_180_250/bsg_mem/bsg_mem_2r1w_sync.sv
+++ b/hard/tsmc_180_250/bsg_mem/bsg_mem_2r1w_sync.sv
@@ -32,7 +32,7 @@ module bsg_mem_2r1w_sync #(parameter `BSG_INV_PARAM(width_p)
 
    if ((width_p == 32) && (els_p == 32))
      begin: macro
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
         initial
           begin
              assert(read_write_same_addr_p==0)
@@ -93,7 +93,7 @@ module bsg_mem_2r1w_sync #(parameter `BSG_INV_PARAM(width_p)
      end
 
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
    always_ff @(posedge clk_i)
      if (w_v_i)

--- a/hard/tsmc_180_250/bsg_misc/bsg_clkbuf.sv
+++ b/hard/tsmc_180_250/bsg_misc/bsg_clkbuf.sv
@@ -24,7 +24,7 @@ module bsg_clkbuf #(parameter width_p=1
 
         assign o = i;
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
         initial assert(harden_p==0) else $error("## %m wanted to harden but no macro");
 

--- a/hard/tsmc_180_250/bsg_misc/bsg_clkbuf.sv
+++ b/hard/tsmc_180_250/bsg_misc/bsg_clkbuf.sv
@@ -24,11 +24,11 @@ module bsg_clkbuf #(parameter width_p=1
 
         assign o = i;
 
-        // synopsys translate_off
+`ifndef SYNTHESIS
 
         initial assert(harden_p==0) else $error("## %m wanted to harden but no macro");
 
-        // synopsys translate_on
+`endif
 
       end
 endmodule

--- a/hard/tsmc_180_250/bsg_misc/bsg_reduce.sv
+++ b/hard/tsmc_180_250/bsg_misc/bsg_reduce.sv
@@ -20,11 +20,11 @@ module bsg_reduce #(parameter `BSG_INV_PARAM(width_p )
     , output o
     );
 
-   // synopsys translate_off
+`ifndef SYNTHESIS
    initial
       assert( $countones({xor_p & 1'b1, and_p & 1'b1, or_p & 1'b1}) == 1)
         else $error("bsg_scan: only one function may be selected\n");
-   // synopsys translate_on
+`endif
 
    if (xor_p)
      begin: xorr

--- a/hard/tsmc_180_250/bsg_misc/bsg_reduce.sv
+++ b/hard/tsmc_180_250/bsg_misc/bsg_reduce.sv
@@ -20,7 +20,7 @@ module bsg_reduce #(parameter `BSG_INV_PARAM(width_p )
     , output o
     );
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
    initial
       assert( $countones({xor_p & 1'b1, and_p & 1'b1, or_p & 1'b1}) == 1)
         else $error("bsg_scan: only one function may be selected\n");

--- a/hard/tsmc_180_250/bsg_misc/bsg_tiehi.sv
+++ b/hard/tsmc_180_250/bsg_misc/bsg_tiehi.sv
@@ -47,9 +47,9 @@ module bsg_tiehi #(parameter `BSG_INV_PARAM(width_p)
        begin :notmacro
           assign o = { width_p {1'b1} };
 
-          // synopsys translate_off
+`ifndef SYNTHESIS
           initial assert(harden_p==0) else $error("## %m wanted to harden but no macro");
-          // synopsys translate_on
+`endif
 
       end
 endmodule

--- a/hard/tsmc_180_250/bsg_misc/bsg_tiehi.sv
+++ b/hard/tsmc_180_250/bsg_misc/bsg_tiehi.sv
@@ -47,7 +47,7 @@ module bsg_tiehi #(parameter `BSG_INV_PARAM(width_p)
        begin :notmacro
           assign o = { width_p {1'b1} };
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
           initial assert(harden_p==0) else $error("## %m wanted to harden but no macro");
 `endif
 

--- a/hard/tsmc_180_250/bsg_misc/bsg_tielo.sv
+++ b/hard/tsmc_180_250/bsg_misc/bsg_tielo.sv
@@ -47,7 +47,7 @@ module bsg_tielo #(parameter `BSG_INV_PARAM(width_p)
        begin :notmacro
           assign o = { width_p {1'b0} };
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
           initial assert(harden_p==0) else $error("## %m wanted to harden but no macro");
 

--- a/hard/tsmc_180_250/bsg_misc/bsg_tielo.sv
+++ b/hard/tsmc_180_250/bsg_misc/bsg_tielo.sv
@@ -47,11 +47,11 @@ module bsg_tielo #(parameter `BSG_INV_PARAM(width_p)
        begin :notmacro
           assign o = { width_p {1'b0} };
 
-          // synopsys translate_off
+`ifndef SYNTHESIS
 
           initial assert(harden_p==0) else $error("## %m wanted to harden but no macro");
 
-          // synopsys translate_on
+`endif
 
       end
 endmodule

--- a/hard/tsmc_28/bsg_async/bsg_launch_sync_sync.sv
+++ b/hard/tsmc_28/bsg_async/bsg_launch_sync_sync.sv
@@ -171,7 +171,7 @@ module bsg_launch_sync_sync #(parameter `BSG_INV_PARAM(width_p)
     , output [width_p-1:0] oclk_data_o // after sync flops
     );
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
 /*   initial
      begin

--- a/hard/tsmc_28/bsg_async/bsg_launch_sync_sync.sv
+++ b/hard/tsmc_28/bsg_async/bsg_launch_sync_sync.sv
@@ -171,7 +171,7 @@ module bsg_launch_sync_sync #(parameter `BSG_INV_PARAM(width_p)
     , output [width_p-1:0] oclk_data_o // after sync flops
     );
 
-// synopsys translate_off
+`ifndef SYNTHESIS
 
 /*   initial
      begin
@@ -185,7 +185,7 @@ module bsg_launch_sync_sync #(parameter `BSG_INV_PARAM(width_p)
           $finish();
        end
 
-// synopsys translate_on
+`endif
 
    genvar i;
 

--- a/hard/tsmc_28/bsg_async/bsg_sync_sync.sv
+++ b/hard/tsmc_28/bsg_async/bsg_sync_sync.sv
@@ -66,7 +66,7 @@ module bsg_sync_sync #(parameter `BSG_INV_PARAM(width_p ))
 
    genvar   i;
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
  /*
    initial
      begin

--- a/hard/tsmc_28/bsg_async/bsg_sync_sync.sv
+++ b/hard/tsmc_28/bsg_async/bsg_sync_sync.sv
@@ -66,14 +66,14 @@ module bsg_sync_sync #(parameter `BSG_INV_PARAM(width_p ))
 
    genvar   i;
 
-   // synopsys translate_off
+`ifndef SYNTHESIS
  /*
    initial
      begin
         $display("%m: instantiating bss of size %d",width_p);
      end
   */
-   // synopsys translate_on
+`endif
 
    for (i = 0; i < (width_p/`bss_max_block); i = i + 1)
      begin : maxb

--- a/hard/tsmc_28/bsg_misc/bsg_mux.sv
+++ b/hard/tsmc_28/bsg_misc/bsg_mux.sv
@@ -34,11 +34,11 @@ module bsg_mux #(parameter `BSG_INV_PARAM(width_p)
         end
 
 
-        // synopsys translate_off
+`ifndef SYNTHESIS
         initial
           assert(balanced_p == 0)
             else $error("%m warning: synthesizable implementation of bsg_mux does not support balanced_p");
-       // synopsys translate_on
+`endif
      end
 
 endmodule

--- a/hard/tsmc_28/bsg_misc/bsg_mux.sv
+++ b/hard/tsmc_28/bsg_misc/bsg_mux.sv
@@ -34,7 +34,7 @@ module bsg_mux #(parameter `BSG_INV_PARAM(width_p)
         end
 
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
         initial
           assert(balanced_p == 0)
             else $error("%m warning: synthesizable implementation of bsg_mux does not support balanced_p");

--- a/hard/tsmc_40/bsg_mem/bsg_mem_1r1w.sv
+++ b/hard/tsmc_40/bsg_mem/bsg_mem_1r1w.sv
@@ -161,7 +161,7 @@ module bsg_mem_1r1w
 		    (.*);
 	     end
 
-   // synopsys translate_off
+`ifndef SYNTHESIS
 
    initial begin
      if (debug_p) begin
@@ -181,7 +181,7 @@ module bsg_mem_1r1w
             else $error("%m: Attempt to read and write same address %x",w_addr_i);
        end
    
-   // synopsys translate_on
+`endif
 
 endmodule
 

--- a/hard/tsmc_40/bsg_mem/bsg_mem_1r1w.sv
+++ b/hard/tsmc_40/bsg_mem/bsg_mem_1r1w.sv
@@ -161,7 +161,7 @@ module bsg_mem_1r1w
 		    (.*);
 	     end
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
    initial begin
      if (debug_p) begin

--- a/hard/tsmc_40/bsg_mem/bsg_mem_1r1w_sync.sv
+++ b/hard/tsmc_40/bsg_mem/bsg_mem_1r1w_sync.sv
@@ -108,7 +108,7 @@ module bsg_mem_1r1w_sync #(parameter `BSG_INV_PARAM(width_p)
      end // block: z
 
 
-   // synopsys translate_off
+`ifndef SYNTHESIS
    initial
      begin
         $display("## %L: instantiating width_p=%d, els_p=%d, substitute_1r1w_p=%d (%m)",width_p,els_p,substitute_1r1w_p);
@@ -118,7 +118,7 @@ module bsg_mem_1r1w_sync #(parameter `BSG_INV_PARAM(width_p)
         end
      end
 
-   // synopsys translate_on
+`endif
 
 endmodule
 

--- a/hard/tsmc_40/bsg_mem/bsg_mem_1r1w_sync.sv
+++ b/hard/tsmc_40/bsg_mem/bsg_mem_1r1w_sync.sv
@@ -108,7 +108,7 @@ module bsg_mem_1r1w_sync #(parameter `BSG_INV_PARAM(width_p)
      end // block: z
 
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
    initial
      begin
         $display("## %L: instantiating width_p=%d, els_p=%d, substitute_1r1w_p=%d (%m)",width_p,els_p,substitute_1r1w_p);

--- a/hard/tsmc_40/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit.sv
+++ b/hard/tsmc_40/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit.sv
@@ -63,7 +63,7 @@ module bsg_mem_1r1w_sync_mask_write_bit #(parameter `BSG_INV_PARAM(width_p)
        ) synth
        (.*);
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
 /*
    always_ff @(negedge clk_i)

--- a/hard/tsmc_40/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit.sv
+++ b/hard/tsmc_40/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit.sv
@@ -63,7 +63,7 @@ module bsg_mem_1r1w_sync_mask_write_bit #(parameter `BSG_INV_PARAM(width_p)
        ) synth
        (.*);
 
-   //synopsys translate_off
+`ifndef SYNTHESIS
 
 /*
    always_ff @(negedge clk_i)
@@ -95,7 +95,7 @@ module bsg_mem_1r1w_sync_mask_write_bit #(parameter `BSG_INV_PARAM(width_p)
                 $finish;
      end
 
-   //synopsys translate_on
+`endif
 
 endmodule
 

--- a/hard/tsmc_40/bsg_mem/bsg_mem_1rw_sync.sv
+++ b/hard/tsmc_40/bsg_mem/bsg_mem_1rw_sync.sv
@@ -108,7 +108,7 @@ module bsg_mem_1rw_sync #(parameter `BSG_INV_PARAM(width_p)
      end // block: z
 
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
    initial
      begin
         $display("## %L: instantiating width_p=%d, els_p=%d, substitute_1r1w_p=%d (%m)",width_p,els_p,substitute_1r1w_p);

--- a/hard/tsmc_40/bsg_mem/bsg_mem_1rw_sync.sv
+++ b/hard/tsmc_40/bsg_mem/bsg_mem_1rw_sync.sv
@@ -108,13 +108,13 @@ module bsg_mem_1rw_sync #(parameter `BSG_INV_PARAM(width_p)
      end // block: z
 
 
-   // synopsys translate_off
+`ifndef SYNTHESIS
    initial
      begin
         $display("## %L: instantiating width_p=%d, els_p=%d, substitute_1r1w_p=%d (%m)",width_p,els_p,substitute_1r1w_p);
      end
 
-   // synopsys translate_on
+`endif
 
 endmodule
 

--- a/hard/tsmc_40/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.sv
+++ b/hard/tsmc_40/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.sv
@@ -62,7 +62,7 @@ module bsg_mem_1rw_sync_mask_write_bit #(parameter `BSG_INV_PARAM(width_p)
        ) synth
        (.*);
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
    always_ff @(posedge clk_i)
      if (v_i)

--- a/hard/tsmc_40/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.sv
+++ b/hard/tsmc_40/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.sv
@@ -62,7 +62,7 @@ module bsg_mem_1rw_sync_mask_write_bit #(parameter `BSG_INV_PARAM(width_p)
        ) synth
        (.*);
 
-   // synopsys translate_off
+`ifndef SYNTHESIS
 
    always_ff @(posedge clk_i)
      if (v_i)
@@ -74,7 +74,7 @@ module bsg_mem_1rw_sync_mask_write_bit #(parameter `BSG_INV_PARAM(width_p)
         $display("## %L: instantiating width_p=%d, els_p=%d (%m)",width_p,els_p);
      end
 
-  // synopsys translate_on
+`endif
 
 
 endmodule

--- a/hard/tsmc_40/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
+++ b/hard/tsmc_40/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
@@ -113,7 +113,7 @@ module bsg_mem_1rw_sync_mask_write_byte
     end
 
 
-  // synopsys translate_off
+`ifndef SYNTHESIS
 
   always_comb
     assert (data_width_p % 8 == 0)
@@ -124,7 +124,7 @@ module bsg_mem_1rw_sync_mask_write_byte
         $display("## bsg_mem_1rw_sync_mask_write_byte: instantiating data_width_p=%d, els_p=%d (%m)",data_width_p,els_p);
      end
 
-  // synopsys translate_on
+`endif
    
 endmodule
 

--- a/hard/tsmc_40/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
+++ b/hard/tsmc_40/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
@@ -113,7 +113,7 @@ module bsg_mem_1rw_sync_mask_write_byte
     end
 
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
   always_comb
     assert (data_width_p % 8 == 0)

--- a/hard/tsmc_40/bsg_mem/bsg_mem_2r1w.sv
+++ b/hard/tsmc_40/bsg_mem/bsg_mem_2r1w.sv
@@ -56,7 +56,7 @@ module bsg_mem_2r1w #(parameter `BSG_INV_PARAM(width_p)
 	      (.*);
        end
 
-// synopsys translate_off
+`ifndef SYNTHESIS
 
    always_ff @(posedge w_clk_i)
      if (w_v_i)
@@ -76,7 +76,7 @@ module bsg_mem_2r1w #(parameter `BSG_INV_PARAM(width_p)
         $display("## %L: instantiating width_p=%d, els_p=%d, read_write_same_addr_p=%d (%m)",width_p,els_p,read_write_same_addr_p);
      end
 
-// synopsys translate_on
+`endif
 
    
 endmodule

--- a/hard/tsmc_40/bsg_mem/bsg_mem_2r1w.sv
+++ b/hard/tsmc_40/bsg_mem/bsg_mem_2r1w.sv
@@ -56,7 +56,7 @@ module bsg_mem_2r1w #(parameter `BSG_INV_PARAM(width_p)
 	      (.*);
        end
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
    always_ff @(posedge w_clk_i)
      if (w_v_i)

--- a/hard/tsmc_40/bsg_mem/bsg_mem_2r1w_sync.sv
+++ b/hard/tsmc_40/bsg_mem/bsg_mem_2r1w_sync.sv
@@ -65,7 +65,7 @@ module bsg_mem_2r1w_sync #(parameter `BSG_INV_PARAM(width_p)
    else
    if ((width_p == 32) && (els_p == 32))
      begin: macro
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
         initial
           begin
              assert(read_write_same_addr_p==0)
@@ -127,7 +127,7 @@ module bsg_mem_2r1w_sync #(parameter `BSG_INV_PARAM(width_p)
      end
 
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
    always_ff @(posedge clk_i)
      if (w_v_i)

--- a/hard/tsmc_40/bsg_mem/bsg_mem_2r1w_sync.sv
+++ b/hard/tsmc_40/bsg_mem/bsg_mem_2r1w_sync.sv
@@ -65,7 +65,7 @@ module bsg_mem_2r1w_sync #(parameter `BSG_INV_PARAM(width_p)
    else
    if ((width_p == 32) && (els_p == 32))
      begin: macro
-        // synopsys translate_off
+`ifndef SYNTHESIS
         initial
           begin
              assert(read_write_same_addr_p==0)
@@ -75,7 +75,7 @@ module bsg_mem_2r1w_sync #(parameter `BSG_INV_PARAM(width_p)
                     $finish();
                  end
           end
-        // synopsys translate_on
+`endif
 
         // use two 1R1W rams to create
          tsmc40_2rf_lg5_w32_m2 mem0    
@@ -127,7 +127,7 @@ module bsg_mem_2r1w_sync #(parameter `BSG_INV_PARAM(width_p)
      end
 
 
-//synopsys translate_off
+`ifndef SYNTHESIS
 
    always_ff @(posedge clk_i)
      if (w_v_i)
@@ -148,7 +148,7 @@ module bsg_mem_2r1w_sync #(parameter `BSG_INV_PARAM(width_p)
 		 ,width_p,els_p,read_write_same_addr_p,harden_p);
      end
 
-//synopsys translate_on
+`endif
 
    
 

--- a/hard/tsmc_40/bsg_misc/bsg_clkbuf.sv
+++ b/hard/tsmc_40/bsg_misc/bsg_clkbuf.sv
@@ -24,7 +24,7 @@ module bsg_clkbuf #(parameter width_p=1
 
         assign o = i;
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
         initial assert(harden_p==0) else $error("## %m wanted to harden but no macro");
 

--- a/hard/tsmc_40/bsg_misc/bsg_clkbuf.sv
+++ b/hard/tsmc_40/bsg_misc/bsg_clkbuf.sv
@@ -24,11 +24,11 @@ module bsg_clkbuf #(parameter width_p=1
 
         assign o = i;
 
-        // synopsys translate_off
+`ifndef SYNTHESIS
 
         initial assert(harden_p==0) else $error("## %m wanted to harden but no macro");
 
-        // synopsys translate_on
+`endif
 
       end
 endmodule

--- a/hard/tsmc_40/bsg_misc/bsg_reduce.sv
+++ b/hard/tsmc_40/bsg_misc/bsg_reduce.sv
@@ -20,11 +20,11 @@ module bsg_reduce #(parameter `BSG_INV_PARAM(width_p )
     , output o
     );
 
-   // synopsys translate_off
+`ifndef SYNTHESIS
    initial
       assert( $countones({xor_p & 1'b1, and_p & 1'b1, or_p & 1'b1}) == 1)
         else $error("bsg_scan: only one function may be selected\n");
-   // synopsys translate_on
+`endif
 
    if (xor_p)
      begin: xorr

--- a/hard/tsmc_40/bsg_misc/bsg_reduce.sv
+++ b/hard/tsmc_40/bsg_misc/bsg_reduce.sv
@@ -20,7 +20,7 @@ module bsg_reduce #(parameter `BSG_INV_PARAM(width_p )
     , output o
     );
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
    initial
       assert( $countones({xor_p & 1'b1, and_p & 1'b1, or_p & 1'b1}) == 1)
         else $error("bsg_scan: only one function may be selected\n");

--- a/hard/tsmc_40/bsg_misc/bsg_tiehi.sv
+++ b/hard/tsmc_40/bsg_misc/bsg_tiehi.sv
@@ -47,9 +47,9 @@ module bsg_tiehi #(parameter `BSG_INV_PARAM(width_p)
        begin :notmacro
           assign o = { width_p {1'b1} };
 
-          // synopsys translate_off
+`ifndef SYNTHESIS
           initial assert(harden_p==0) else $error("## %m wanted to harden but no macro");
-          // synopsys translate_on
+`endif
 
       end
 endmodule

--- a/hard/tsmc_40/bsg_misc/bsg_tiehi.sv
+++ b/hard/tsmc_40/bsg_misc/bsg_tiehi.sv
@@ -47,7 +47,7 @@ module bsg_tiehi #(parameter `BSG_INV_PARAM(width_p)
        begin :notmacro
           assign o = { width_p {1'b1} };
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
           initial assert(harden_p==0) else $error("## %m wanted to harden but no macro");
 `endif
 

--- a/hard/tsmc_40/bsg_misc/bsg_tielo.sv
+++ b/hard/tsmc_40/bsg_misc/bsg_tielo.sv
@@ -47,7 +47,7 @@ module bsg_tielo #(parameter `BSG_INV_PARAM(width_p)
        begin :notmacro
           assign o = { width_p {1'b0} };
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
           initial assert(harden_p==0) else $error("## %m wanted to harden but no macro");
 

--- a/hard/tsmc_40/bsg_misc/bsg_tielo.sv
+++ b/hard/tsmc_40/bsg_misc/bsg_tielo.sv
@@ -47,11 +47,11 @@ module bsg_tielo #(parameter `BSG_INV_PARAM(width_p)
        begin :notmacro
           assign o = { width_p {1'b0} };
 
-          // synopsys translate_off
+`ifndef SYNTHESIS
 
           initial assert(harden_p==0) else $error("## %m wanted to harden but no macro");
 
-          // synopsys translate_on
+`endif
 
       end
 endmodule

--- a/hard/ultrascale_plus/bsg_async/bsg_launch_sync_sync.sv
+++ b/hard/ultrascale_plus/bsg_async/bsg_launch_sync_sync.sv
@@ -235,7 +235,7 @@ module bsg_launch_sync_sync #(parameter `BSG_INV_PARAM(width_p)
     , output [width_p-1:0] oclk_data_o // after sync flops
     );
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
 /*   initial
      begin

--- a/hard/ultrascale_plus/bsg_async/bsg_launch_sync_sync.sv
+++ b/hard/ultrascale_plus/bsg_async/bsg_launch_sync_sync.sv
@@ -235,7 +235,7 @@ module bsg_launch_sync_sync #(parameter `BSG_INV_PARAM(width_p)
     , output [width_p-1:0] oclk_data_o // after sync flops
     );
 
-// synopsys translate_off
+`ifndef SYNTHESIS
 
 /*   initial
      begin
@@ -252,7 +252,7 @@ module bsg_launch_sync_sync #(parameter `BSG_INV_PARAM(width_p)
           $finish();
        end
 `endif
-// synopsys translate_on
+`endif
 
    genvar i;
 

--- a/hard/ultrascale_plus/bsg_link/bsg_link_ddr_upstream.sv
+++ b/hard/ultrascale_plus/bsg_link/bsg_link_ddr_upstream.sv
@@ -217,7 +217,7 @@ module bsg_link_ddr_upstream
   
   end
   
-  // synopsys translate_off
+`ifndef SYNTHESIS
   initial 
   begin
     assert (piso_ratio_lp > 0)
@@ -234,7 +234,7 @@ module bsg_link_ddr_upstream
         $finish;
       end
   end
-  // synopsys translate_on
+`endif
 
 endmodule
 `BSG_ABSTRACT_MODULE(bsg_link_ddr_upstream)

--- a/hard/ultrascale_plus/bsg_link/bsg_link_ddr_upstream.sv
+++ b/hard/ultrascale_plus/bsg_link/bsg_link_ddr_upstream.sv
@@ -217,7 +217,7 @@ module bsg_link_ddr_upstream
   
   end
   
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
   initial 
   begin
     assert (piso_ratio_lp > 0)

--- a/hard/ultrascale_plus/bsg_misc/bsg_mux.sv
+++ b/hard/ultrascale_plus/bsg_misc/bsg_mux.sv
@@ -54,7 +54,7 @@ module bsg_mux #(parameter `BSG_INV_PARAM(width_p)
       else
         assign data_o = data_i[sel_i];
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
       initial
         assert(balanced_p == 0)
           else $error("%m warning: synthesizable implementation of bsg_mux does not support the provided parameters");

--- a/hard/ultrascale_plus/bsg_misc/bsg_mux.sv
+++ b/hard/ultrascale_plus/bsg_misc/bsg_mux.sv
@@ -54,11 +54,11 @@ module bsg_mux #(parameter `BSG_INV_PARAM(width_p)
       else
         assign data_o = data_i[sel_i];
 
-      // synopsys translate_off
+`ifndef SYNTHESIS
       initial
         assert(balanced_p == 0)
           else $error("%m warning: synthesizable implementation of bsg_mux does not support the provided parameters");
-      // synopsys translate_on
+`endif
     end
 
 endmodule

--- a/testing/bsg_cache/regression_non_blocking/testbench.sv
+++ b/testing/bsg_cache/regression_non_blocking/testbench.sv
@@ -33,7 +33,7 @@ module testbench();
   localparam tag_width_lp = (addr_width_p-lg_sets_lp-lg_block_size_in_words_lp-byte_sel_width_lp);
   localparam block_offset_width_lp = lg_block_size_in_words_lp+byte_sel_width_lp;
 
-  // synopsys translate_off
+`ifndef SYNTHESIS
   integer status;
   integer wave;
   string checker;
@@ -64,7 +64,7 @@ module testbench();
     .clk_i(clk)
     ,.async_reset_o(reset)
   );
-  // synopsys translate_on
+`endif
 
 
   // non-blocking cache
@@ -127,7 +127,7 @@ module testbench();
     ,.dma_data_yumi_i(dma_data_yumi_li)
   );
 
-  // synopsys translate_off
+`ifndef SYNTHESIS
 
   // random yumi generator
   //
@@ -314,6 +314,6 @@ module testbench();
     $finish;
   end
 
-  // synopsys translate_on
+`endif
 
 endmodule

--- a/testing/bsg_cache/regression_non_blocking/testbench.sv
+++ b/testing/bsg_cache/regression_non_blocking/testbench.sv
@@ -33,7 +33,7 @@ module testbench();
   localparam tag_width_lp = (addr_width_p-lg_sets_lp-lg_block_size_in_words_lp-byte_sel_width_lp);
   localparam block_offset_width_lp = lg_block_size_in_words_lp+byte_sel_width_lp;
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
   integer status;
   integer wave;
   string checker;
@@ -127,7 +127,7 @@ module testbench();
     ,.dma_data_yumi_i(dma_data_yumi_li)
   );
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
 
   // random yumi generator
   //

--- a/testing/bsg_link/bsg_link_ddr_downstream_encode.sv
+++ b/testing/bsg_link/bsg_link_ddr_downstream_encode.sv
@@ -215,7 +215,7 @@ module bsg_link_ddr_downstream_encode
   ,.yumi_i (core_yumi_i)
   );
   
-  // synopsys translate_off
+`ifndef SYNTHESIS
   initial 
   begin
     assert (sipo_ratio_lp > 0)
@@ -232,7 +232,7 @@ module bsg_link_ddr_downstream_encode
         $finish;
       end
   end
-  // synopsys translate_on
+`endif
 
 endmodule
 `BSG_ABSTRACT_MODULE(bsg_link_ddr_downstream_encode)

--- a/testing/bsg_link/bsg_link_ddr_downstream_encode.sv
+++ b/testing/bsg_link/bsg_link_ddr_downstream_encode.sv
@@ -215,7 +215,7 @@ module bsg_link_ddr_downstream_encode
   ,.yumi_i (core_yumi_i)
   );
   
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
   initial 
   begin
     assert (sipo_ratio_lp > 0)

--- a/testing/bsg_link/bsg_link_sdr/bsg_link_sdr_test_node.sv
+++ b/testing/bsg_link/bsg_link_sdr/bsg_link_sdr_test_node.sv
@@ -107,7 +107,7 @@ module bsg_link_sdr_test_node
         else
             if (node_async_fifo_yumi_li && data_check != node_async_fifo_data_lo)
               begin
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
                 $error("%m mismatched resp data %x %x",data_check, node_async_fifo_data_lo);
 `endif
                 error_o <= 1;

--- a/testing/bsg_link/bsg_link_sdr/bsg_link_sdr_test_node.sv
+++ b/testing/bsg_link/bsg_link_sdr/bsg_link_sdr_test_node.sv
@@ -107,9 +107,9 @@ module bsg_link_sdr_test_node
         else
             if (node_async_fifo_yumi_li && data_check != node_async_fifo_data_lo)
               begin
-                // synopsys translate_off
+`ifndef SYNTHESIS
                 $error("%m mismatched resp data %x %x",data_check, node_async_fifo_data_lo);
-                // synopsys translate_on
+`endif
                 error_o <= 1;
               end
     end

--- a/testing/bsg_noc/bsg_wormhole_concentrator/bsg_wormhole_concentrator_test_node.sv
+++ b/testing/bsg_noc/bsg_wormhole_concentrator/bsg_wormhole_concentrator_test_node.sv
@@ -71,13 +71,13 @@ module bsg_wormhole_concentrator_test_node
   // Determine PISO and SIPOF convertion ratio
   localparam wh_ratio_lp = `BSG_CDIV(wh_width_lp, flit_width_p);
 
-  // synopsys translate_off
+`ifndef SYNTHESIS
   initial
   begin
     assert (len_width_p >= `BSG_SAFE_CLOG2(wh_ratio_lp))
     else $error("Wormhole packet len width %d is too narrow for ratio %d. Please increase len width.", len_width_p, wh_ratio_lp);
   end
-  // synopsys translate_on
+`endif
 
   // wormhole packets
   wormhole_concentrator_test_node_s node_piso_data_li_cast, node_sipof_data_lo_cast;

--- a/testing/bsg_noc/bsg_wormhole_concentrator/bsg_wormhole_concentrator_test_node.sv
+++ b/testing/bsg_noc/bsg_wormhole_concentrator/bsg_wormhole_concentrator_test_node.sv
@@ -71,7 +71,7 @@ module bsg_wormhole_concentrator_test_node
   // Determine PISO and SIPOF convertion ratio
   localparam wh_ratio_lp = `BSG_CDIV(wh_width_lp, flit_width_p);
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
   initial
   begin
     assert (len_width_p >= `BSG_SAFE_CLOG2(wh_ratio_lp))

--- a/testing/bsg_noc/bsg_wormhole_network/bsg_wormhole_network_test_node_master.sv
+++ b/testing/bsg_noc/bsg_wormhole_network/bsg_wormhole_network_test_node_master.sv
@@ -52,13 +52,13 @@ module bsg_wormhole_router_test_node_master
     bsg_wormhole_router_header_s  hdr;
   } wormhole_network_header_flit_s;
   
-  // synopsys translate_off
+`ifndef SYNTHESIS
   initial
   begin
     assert ($bits(wormhole_network_header_flit_s)-$bits(bsg_wormhole_router_header_s) >= width_lp)
     else $error("Packet data width %d is too narrow for data width %d.", $bits(wormhole_network_header_flit_s)-$bits(bsg_wormhole_router_header_s), width_lp);
   end
-  // synopsys translate_on
+`endif
   
   
   /********************* Interfacing bsg_noc link *********************/

--- a/testing/bsg_noc/bsg_wormhole_network/bsg_wormhole_network_test_node_master.sv
+++ b/testing/bsg_noc/bsg_wormhole_network/bsg_wormhole_network_test_node_master.sv
@@ -52,7 +52,7 @@ module bsg_wormhole_router_test_node_master
     bsg_wormhole_router_header_s  hdr;
   } wormhole_network_header_flit_s;
   
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
   initial
   begin
     assert ($bits(wormhole_network_header_flit_s)-$bits(bsg_wormhole_router_header_s) >= width_lp)

--- a/testing/bsg_noc/bsg_wormhole_router/bsg_wormhole_router_test_node.sv
+++ b/testing/bsg_noc/bsg_wormhole_router/bsg_wormhole_router_test_node.sv
@@ -87,7 +87,7 @@ module bsg_wormhole_router_test_node
   localparam wh_fwd_ratio_lp = `BSG_CDIV(wh_fwd_width_lp, flit_width_p);
   localparam wh_rev_ratio_lp = `BSG_CDIV(wh_rev_width_lp, flit_width_p);
 
-`ifndef SYNTHESIS
+`ifndef BSG_HIDE_FROM_SYNTHESIS
   initial
   begin
     assert (len_width_p >= `BSG_SAFE_CLOG2(wh_fwd_ratio_lp))

--- a/testing/bsg_noc/bsg_wormhole_router/bsg_wormhole_router_test_node.sv
+++ b/testing/bsg_noc/bsg_wormhole_router/bsg_wormhole_router_test_node.sv
@@ -87,7 +87,7 @@ module bsg_wormhole_router_test_node
   localparam wh_fwd_ratio_lp = `BSG_CDIV(wh_fwd_width_lp, flit_width_p);
   localparam wh_rev_ratio_lp = `BSG_CDIV(wh_rev_width_lp, flit_width_p);
 
-  // synopsys translate_off
+`ifndef SYNTHESIS
   initial
   begin
     assert (len_width_p >= `BSG_SAFE_CLOG2(wh_fwd_ratio_lp))
@@ -96,7 +96,7 @@ module bsg_wormhole_router_test_node
     assert (len_width_p >= `BSG_SAFE_CLOG2(wh_rev_ratio_lp))
     else $error("Wormhole packet len width %d is too narrow for rev ratio %d. Please increase len width.", len_width_p, wh_rev_ratio_lp);
   end
-  // synopsys translate_on
+`endif
 
   // fwd and rev wormhole packets
   fwd_wormhole_router_test_node_s mc_fwd_piso_data_li_cast, mc_fwd_sipof_data_lo_cast;


### PR DESCRIPTION
Hello!

According to the IEEE 1364.1-2005 spec 6.3.2, the use of `translate_off`/`translate_on` is discouraged as opposed to `` `ifndef SYNTHESIS ``. Plus, some newer SystemVerilog frontends such as sv2v, Verible, and PySlint do not have any extra AST support for `translate_off`, so they may get confused by unsupported unsynthesizable constructs.

Therefore, I changed 200 occurrences of `translate_off` to `` `ifndef SYNTHESIS ``.

I would be happy to hear another perspective if you feel that `translate_off` is in fact the better option.

Thanks!