### PR TITLE
Fix Verilator Warnings in bsg_mem and bsg_misc

### DIFF
--- a/bsg_mem/bsg_mem_1r1w.sv
+++ b/bsg_mem/bsg_mem_1r1w.sv
@@ -46,7 +46,7 @@ module bsg_mem_1r1w #(parameter `BSG_INV_PARAM(width_p)
    always_ff @(negedge w_clk_i)
      if (w_v_i===1'b1)
        begin
-         assert ((w_reset_i === 'X) || (w_reset_i === 1'b1) || (w_addr_i < els_p) || (els_p <= 1))
+         assert ((w_reset_i === 'X) || (w_reset_i === 1'b1) || (int'(w_addr_i) < els_p) || (els_p <= 1))
             else $error("Invalid address %x to %m of size %x (w_reset_i=%b, w_v_i=%b)\n", w_addr_i, els_p, w_reset_i, w_v_i);
           assert ((w_reset_i === 'X) || (w_reset_i === 1'b1) || !(r_addr_i == w_addr_i && w_v_i && r_v_i && !read_write_same_addr_p))
             else $error("%m: Attempt to read and write same address %x (w_v_i = %b, w_reset_i = %b)",w_addr_i,w_v_i,w_reset_i);

--- a/bsg_mem/bsg_mem_2rw_sync.sv
+++ b/bsg_mem/bsg_mem_2rw_sync.sv
@@ -74,11 +74,11 @@ module bsg_mem_2rw_sync #( parameter `BSG_INV_PARAM(width_p )
        assert ((reset_i === 'X) || (reset_i === 1'b1) || (b_addr_i < els_p))
          else $error("Invalid address %x to %m of size %x (reset_i = %b, v_i = %b, clk_lo=%b)\n", b_addr_i, els_p, reset_i, b_v_i, clk_lo);
 
-       assert ((reset_i === 'X) || (reset_i === 1'b1) || (~(a_addr_i == b_addr_i && a_v_i && b_v_i && (a_w_i ^ b_w_i))) && !read_write_same_addr_p && !disable_collision_warning_p)
-         else $error("%m: Attempt to read and write same address reset_i %b, %x <= %x",reset_i, a_addr_i,a_data_i);
+     assert ((reset_i === 'X) || (reset_i === 1'b1) || (~(a_addr_i == b_addr_i && a_v_i && b_v_i && (a_w_i ^ b_w_i))) && !read_write_same_addr_p && !disable_collision_warning_p)
+       else $error("%m: Attempt to read and write same address reset_i %b, %x <= %x",reset_i, a_addr_i,a_data_i);
 
-       assert ((reset_i === 'X) || (reset_i === 1'b1) || (~(a_addr_i == b_addr_i && a_v_i && b_v_i && (a_w_i & b_w_i))))
-         else $error("%m: Attempt to write and write same address reset_i %b, %x <= %x",reset_i, a_addr_i,a_data_i);
+     assert ((reset_i === 'X) || (reset_i === 1'b1) || (~(a_addr_i == b_addr_i && a_v_i && b_v_i && (a_w_i & b_w_i))))
+       else $error("%m: Attempt to write and write same address reset_i %b, %x <= %x",reset_i, a_addr_i,a_data_i);
    end
 
    initial

--- a/bsg_mem/bsg_mem_multiport_latch_write_banked_bypassing.sv
+++ b/bsg_mem/bsg_mem_multiport_latch_write_banked_bypassing.sv
@@ -92,7 +92,7 @@ module bsg_mem_multiport_latch_write_banked_bypassing
     //    ,.data_i(w_data_i[bank_id_lp][j])
     //    ,.data_o(mem_r[i][j])
     //  );
-    end
+    //end
   end
 
 

--- a/bsg_misc/bsg_counter_overflow_en.sv
+++ b/bsg_misc/bsg_counter_overflow_en.sv
@@ -12,7 +12,7 @@ module bsg_counter_overflow_en #(parameter `BSG_INV_PARAM(max_val_p    )
   , output logic                    overflow_o
   );
 
-  assign overflow_o  = (count_o == max_val_p);
+  assign overflow_o  = (int'(count_o) == max_val_p);
   
   always_ff @(posedge clk_i)
     begin

--- a/bsg_misc/bsg_mul.sv
+++ b/bsg_misc/bsg_mul.sv
@@ -14,7 +14,7 @@ module bsg_mul #(parameter `BSG_INV_PARAM(width_p)
                        ,.pipeline_p(0       )
                        ,.harden_p  (harden_p)
                        ) bmp
-   (.clock_i(1'b0)
+   (.clk_i(1'b0)
     ,.en_i(1'b0)
     ,.x_i
     ,.y_i


### PR DESCRIPTION
Non-functional changes in bsg_mem and bsg_misc to fix Verilator lint warnings and 1 syntax error.

- `bsg_mem/bsg_mem_multiport_latch_write_banked_bypassing.sv`: Fix syntax error due to mismatched `end`. Looks like it should have been commented out with the rest of the block above it.
- `bsg_misc/bsg_mul.sv`: Fix incorrect port name. Fixes Verilator `PINMISSING` warning.
- `bsg_mem/bsg_mem_2rw_sync.sv`: Fix misleading indentation of `assert ... else` blocks. Fixes Verilator `MISINDENT` warnings.
- `bsg_mem/bsg_mem_1r1w.sv`: Cast logic to int before comparison with parameter. Fixes Verilator `WIDTHEXPAND` warning.
- `bsg_misc/bsg_counter_overflow_en.sv`: Cast logic to int before comparison with parameter. Fixes Verilator `WIDTHEXPAND` warning.