### PR TITLE
SDR Token Clock Timing

### DIFF
--- a/bsg_link/bsg_link_isdr_phy.sv
+++ b/bsg_link/bsg_link_isdr_phy.sv
@@ -31,9 +31,12 @@ module bsg_link_isdr_phy
   ,output               clk_o
   ,input  [width_p-1:0] data_i
   ,output [width_p-1:0] data_o
+  ,input                token_i
+  ,output               token_o
   );
 
   assign clk_o = clk_i;
+  assign token_o = token_i;
 
   bsg_dff #(.width_p(width_p)) data_ff 
   (.clk_i(clk_i),.data_i(data_i),.data_o(data_o));

--- a/bsg_link/bsg_link_osdr_phy.sv
+++ b/bsg_link/bsg_link_osdr_phy.sv
@@ -41,7 +41,11 @@ module bsg_link_osdr_phy
   ,input  [width_p-1:0] data_i
   ,output               clk_o
   ,output [width_p-1:0] data_o
+  ,input                token_i
+  ,output               token_o
   );
+
+  assign token_o = token_i;
 
   bsg_link_osdr_phy_phase_align clk_pa
   (.clk_i  (clk_i)

--- a/bsg_link/bsg_link_sdr_downstream.sv
+++ b/bsg_link/bsg_link_sdr_downstream.sv
@@ -62,6 +62,7 @@ module bsg_link_sdr_downstream
 
   logic isdr_clk_lo, isdr_v_lo;
   logic [width_p-1:0] isdr_data_lo;
+  logic isdr_token_li;
 
   // valid and data signals are received together
   bsg_link_isdr_phy
@@ -71,6 +72,8 @@ module bsg_link_sdr_downstream
   ,.clk_o  (isdr_clk_lo)
   ,.data_i ({io_v_i, io_data_i})
   ,.data_o ({isdr_v_lo, isdr_data_lo})
+  ,.token_i(isdr_token_li)
+  ,.token_o(core_token_r_o)
   );
 
   logic io_link_reset_sync;
@@ -93,7 +96,7 @@ module bsg_link_sdr_downstream
   ,.io_clk_i         (isdr_clk_lo)
   ,.io_data_i        (isdr_data_lo)
   ,.io_valid_i       (isdr_v_lo)
-  ,.core_token_r_o   (core_token_r_o)
+  ,.core_token_r_o   (isdr_token_li)
   // going into core
   ,.core_data_o      (core_data_o)
   ,.core_valid_o     (core_v_o)

--- a/bsg_link/bsg_link_sdr_upstream.sv
+++ b/bsg_link/bsg_link_sdr_upstream.sv
@@ -63,6 +63,7 @@ module bsg_link_sdr_upstream
 
   logic osdr_v_li;
   logic [width_p-1:0] osdr_data_li;
+  logic osdr_token_lo;
 
   bsg_link_source_sync_upstream_sync
  #(.width_p                        (width_p)
@@ -78,7 +79,7 @@ module bsg_link_sdr_upstream
   ,.io_ready_and_o     (io_ready_and_o)
   ,.io_v_o             (osdr_v_li)
   ,.io_data_o          (osdr_data_li)
-  ,.token_clk_i        (token_clk_i)
+  ,.token_clk_i        (osdr_token_lo)
   );
 
   // valid and data signals are sent together
@@ -91,6 +92,8 @@ module bsg_link_sdr_upstream
   ,.data_i ({osdr_v_li, osdr_data_li})
   ,.clk_o  (io_clk_o)
   ,.data_o ({io_v_o, io_data_o})
+  ,.token_i(token_clk_i)
+  ,.token_o(osdr_token_lo)
   );
 
 endmodule

--- a/hard/gf_14/bsg_link/bsg_link_isdr_phy.sv
+++ b/hard/gf_14/bsg_link/bsg_link_isdr_phy.sv
@@ -7,11 +7,14 @@ module bsg_link_isdr_phy
   ,output               clk_o
   ,input  [width_p-1:0] data_i
   ,output [width_p-1:0] data_o
+  ,input                token_i
+  ,output               token_o
   );
 
   wire [width_p-1:0] data_i_buf;
 
   SC7P5T_CKBUFX4_SSC14R BSG_ISDR_CKBUF_BSG_DONT_TOUCH (.CLK(clk_i),.Z(clk_o));
+  SC7P5T_CKBUFX4_SSC14R BSG_ISDR_TKNBUF_BSG_DONT_TOUCH (.CLK(token_i),.Z(token_o));
 
   for (genvar i = 0; i < width_p; i++)
   begin: data

--- a/hard/gf_14/bsg_link/bsg_link_osdr_phy.sv
+++ b/hard/gf_14/bsg_link/bsg_link_osdr_phy.sv
@@ -37,7 +37,9 @@ module bsg_link_osdr_phy
   SC7P5T_CKXOR2X2_SSC14R BSG_OSDR_CKXOR2_BSG_DONT_TOUCH
   (.Z(clk_o_buf),.CLK(clk_r_p),.EN(clk_r_n));
   `BSG_LINK_OSDR_PHY_CKBUF_MACRO(BSG_OSDR_CKBUF_BSG_DONT_TOUCH, clk_o_buf, clk_o)
+  begin: token
   `BSG_LINK_OSDR_PHY_CKBUF_MACRO(BSG_OSDR_TKNBUF_BSG_DONT_TOUCH, token_i, token_o)
+  end
 
   SC7P5T_DFFQX2_SSC14R BSG_OSDR_DFFPOS_BSG_DONT_TOUCH
   (.D(~(clk_r_p|reset_i)),.CLK(clk_i),.Q(clk_r_p));

--- a/hard/gf_14/bsg_link/bsg_link_osdr_phy.sv
+++ b/hard/gf_14/bsg_link/bsg_link_osdr_phy.sv
@@ -9,6 +9,8 @@ module bsg_link_osdr_phy
   ,input  [width_p-1:0] data_i
   ,output               clk_o
   ,output [width_p-1:0] data_o
+  ,input                token_i
+  ,output               token_o
   );
 
 `define BSG_LINK_OSDR_PHY_CKBUF_INST_MACRO(strength,name,in,out)          \
@@ -35,6 +37,7 @@ module bsg_link_osdr_phy
   SC7P5T_CKXOR2X2_SSC14R BSG_OSDR_CKXOR2_BSG_DONT_TOUCH
   (.Z(clk_o_buf),.CLK(clk_r_p),.EN(clk_r_n));
   `BSG_LINK_OSDR_PHY_CKBUF_MACRO(BSG_OSDR_CKBUF_BSG_DONT_TOUCH, clk_o_buf, clk_o)
+  `BSG_LINK_OSDR_PHY_CKBUF_MACRO(BSG_OSDR_TKNBUF_BSG_DONT_TOUCH, token_i, token_o)
 
   SC7P5T_DFFQX2_SSC14R BSG_OSDR_DFFPOS_BSG_DONT_TOUCH
   (.D(~(clk_r_p|reset_i)),.CLK(clk_i),.Q(clk_r_p));

--- a/hard/gf_14/bsg_link/bsg_link_osdr_phy.sv
+++ b/hard/gf_14/bsg_link/bsg_link_osdr_phy.sv
@@ -37,7 +37,7 @@ module bsg_link_osdr_phy
   SC7P5T_CKXOR2X2_SSC14R BSG_OSDR_CKXOR2_BSG_DONT_TOUCH
   (.Z(clk_o_buf),.CLK(clk_r_p),.EN(clk_r_n));
   `BSG_LINK_OSDR_PHY_CKBUF_MACRO(BSG_OSDR_CKBUF_BSG_DONT_TOUCH, clk_o_buf, clk_o)
-  begin: token
+  if (1) begin: token
   `BSG_LINK_OSDR_PHY_CKBUF_MACRO(BSG_OSDR_TKNBUF_BSG_DONT_TOUCH, token_i, token_o)
   end
 

--- a/hard/gf_14/bsg_link/tcl/bsg_link_ddr.constraints.tcl
+++ b/hard/gf_14/bsg_link/tcl/bsg_link_ddr.constraints.tcl
@@ -49,6 +49,7 @@ proc bsg_link_ddr_constraints { \
   set tkn_clk_period         [expr $in_clk_period]
   create_clock -period $tkn_clk_period -name $tkn_clk_name $tkn_clk_port
   set_clock_uncertainty $uncertainty [get_clocks $tkn_clk_name]
+  set_driving_cell -no_design_rule -lib_cell "IN12LP_GPIO18_13M9S30P_IO_H" -pin Y $tkn_clk_port
 
   # input
   set max_input_delay        [expr ($in_clk_period/2.0)-$in_clk_margin]

--- a/hard/gf_14/bsg_link/tcl/bsg_link_sdr.constraints.tcl
+++ b/hard/gf_14/bsg_link/tcl/bsg_link_sdr.constraints.tcl
@@ -68,6 +68,7 @@ proc bsg_link_sdr_constraints { \
   set tkn_clk_period         [expr 2*$in_clk_period]
   create_clock -period $tkn_clk_period -name $tkn_clk_name $tkn_clk_port
   set_clock_uncertainty $uncertainty [get_clocks $tkn_clk_name]
+  set_driving_cell -no_design_rule -lib_cell "SC7P5T_CKBUFX4_SSC14R" $tkn_clk_port
 
   # input
   set max_input_delay        [expr ($in_clk_period)-$in_clk_margin]

--- a/hard/tsmc_28/bsg_link/bsg_link_isdr_phy.sv
+++ b/hard/tsmc_28/bsg_link/bsg_link_isdr_phy.sv
@@ -9,11 +9,14 @@ module bsg_link_isdr_phy
   ,output               clk_o
   ,input  [width_p-1:0] data_i
   ,output [width_p-1:0] data_o
+  ,input                token_i
+  ,output               token_o
   );
 
   wire [width_p-1:0] data_i_buf;
 
   CKBD4BWP7T40P140 BSG_ISDR_CKBUF_BSG_DONT_TOUCH (.I(clk_i),.Z(clk_o));
+  CKBD4BWP7T40P140 BSG_ISDR_TKNBUF_BSG_DONT_TOUCH (.I(token_i),.Z(token_o));
 
   for (genvar i = 0; i < width_p; i++)
   begin: data

--- a/hard/tsmc_28/bsg_link/bsg_link_osdr_phy.sv
+++ b/hard/tsmc_28/bsg_link/bsg_link_osdr_phy.sv
@@ -11,6 +11,8 @@ module bsg_link_osdr_phy
   ,input  [width_p-1:0] data_i
   ,output               clk_o
   ,output [width_p-1:0] data_o
+  ,input                token_i
+  ,output               token_o
   );
 
 `define BSG_LINK_OSDR_PHY_CKBUF_INST_MACRO(strength,name,in,out)          \
@@ -35,6 +37,7 @@ module bsg_link_osdr_phy
   CKXOR2D2BWP7T40P140 BSG_OSDR_CKXOR2_BSG_DONT_TOUCH
   (.Z(clk_o_buf),.A1(clk_r_p),.A2(clk_r_n));
   `BSG_LINK_OSDR_PHY_CKBUF_MACRO(BSG_OSDR_CKBUF_BSG_DONT_TOUCH, clk_o_buf, clk_o)
+  `BSG_LINK_OSDR_PHY_CKBUF_MACRO(BSG_OSDR_TKNBUF_BSG_DONT_TOUCH, token_i, token_o)
 
   DFD2BWP7T40P140 BSG_OSDR_DFFPOS_BSG_DONT_TOUCH
   (.D(~(clk_r_p|reset_i)),.CP(clk_i),.Q(clk_r_p), .QN());

--- a/hard/tsmc_28/bsg_link/bsg_link_osdr_phy.sv
+++ b/hard/tsmc_28/bsg_link/bsg_link_osdr_phy.sv
@@ -37,7 +37,9 @@ module bsg_link_osdr_phy
   CKXOR2D2BWP7T40P140 BSG_OSDR_CKXOR2_BSG_DONT_TOUCH
   (.Z(clk_o_buf),.A1(clk_r_p),.A2(clk_r_n));
   `BSG_LINK_OSDR_PHY_CKBUF_MACRO(BSG_OSDR_CKBUF_BSG_DONT_TOUCH, clk_o_buf, clk_o)
+  begin: token
   `BSG_LINK_OSDR_PHY_CKBUF_MACRO(BSG_OSDR_TKNBUF_BSG_DONT_TOUCH, token_i, token_o)
+  end
 
   DFD2BWP7T40P140 BSG_OSDR_DFFPOS_BSG_DONT_TOUCH
   (.D(~(clk_r_p|reset_i)),.CP(clk_i),.Q(clk_r_p), .QN());

--- a/hard/tsmc_28/bsg_link/bsg_link_osdr_phy.sv
+++ b/hard/tsmc_28/bsg_link/bsg_link_osdr_phy.sv
@@ -37,7 +37,7 @@ module bsg_link_osdr_phy
   CKXOR2D2BWP7T40P140 BSG_OSDR_CKXOR2_BSG_DONT_TOUCH
   (.Z(clk_o_buf),.A1(clk_r_p),.A2(clk_r_n));
   `BSG_LINK_OSDR_PHY_CKBUF_MACRO(BSG_OSDR_CKBUF_BSG_DONT_TOUCH, clk_o_buf, clk_o)
-  begin: token
+  if (1) begin: token
   `BSG_LINK_OSDR_PHY_CKBUF_MACRO(BSG_OSDR_TKNBUF_BSG_DONT_TOUCH, token_i, token_o)
   end
 

--- a/hard/tsmc_28/bsg_link/tcl/bsg_link_sdr.constraints.tcl
+++ b/hard/tsmc_28/bsg_link/tcl/bsg_link_sdr.constraints.tcl
@@ -68,6 +68,7 @@ proc bsg_link_sdr_constraints { \
   set tkn_clk_period         [expr 2*$in_clk_period]
   create_clock -period $tkn_clk_period -name $tkn_clk_name $tkn_clk_port
   set_clock_uncertainty $uncertainty [get_clocks $tkn_clk_name]
+  set_driving_cell -no_design_rule -lib_cell "CKBD4BWP7T40P140" $tkn_clk_port
 
   # input
   set max_input_delay        [expr ($in_clk_period)-$in_clk_margin]


### PR DESCRIPTION
Add token boundary cells to improve token clock driving strength
Update token clock timing constraints, add token clock driving cell