### PR TITLE
Naming abstract gen block

### DIFF
--- a/bsg_misc/bsg_defines.sv
+++ b/bsg_misc/bsg_defines.sv
@@ -26,7 +26,7 @@
 `define BSG_ABSTRACT_MODULE(fn) \
     /*verilator lint_off DECLFILENAME*/ \
     /*verilator lint_off PINMISSING*/ \
-    module fn``__abstract(); if (0) fn not_used(); endmodule \
+    module fn``__abstract(); if (0) begin : abstract fn not_used(); end endmodule \
     /*verilator lint_on PINMISSING*/ \
     /*verilator lint_on DECLFILENAME*/
 


### PR DESCRIPTION
Disables unnamed genblk warning in Verilator, VCS and Xcelium