### PR TITLE
Update bsg_dlatch.sv

### DIFF
--- a/bsg_misc/bsg_dlatch.sv
+++ b/bsg_misc/bsg_dlatch.sv
@@ -15,7 +15,7 @@ module bsg_dlatch #(parameter `BSG_INV_PARAM(width_p)
   always_latch
     begin
       if (clk_i)
-        data_r <= data_i;
+        data_r = data_i;
     end
 
   assign data_o = data_r;


### PR DESCRIPTION
Latches are recommended to use blocking assignments as they follow similar rules to always_comb.  This doesn't affect the functionality here, but disable warnings in Verilator and Xcelium