### PR TITLE
Port bsg_cache to verilator

### DIFF
--- a/testing/bsg_cache/common/basic_checker_32.sv
+++ b/testing/bsg_cache/common/basic_checker_32.sv
@@ -29,7 +29,7 @@ module basic_checker_32
   assign cache_pkt = cache_pkt_i;
 
   logic [data_width_p-1:0] shadow_mem [mem_size_p-1:0];
-  logic [data_width_p-1:0] result [*];
+  logic [data_width_p-1:0] result [integer];
 
   wire [addr_width_p-1:0] cache_pkt_word_addr = cache_pkt.addr[addr_width_p-1:2];
 
@@ -140,16 +140,16 @@ module basic_checker_32
         if (yumi_o) begin
           case (cache_pkt.opcode)
             TAGST: begin
-              result[send_id] = '0;
-              send_id++;
+              result[send_id] <= '0;
+              send_id <= send_id + 1;
             end
             LM, LW, LH, LB, LHU, LBU: begin
-              result[send_id] = load_data_final;
-              send_id++;
+              result[send_id] <= load_data_final;
+              send_id <= send_id + 1;
             end
             SW, SH, SB, SM: begin
-              result[send_id] = '0;
-              send_id++;
+              result[send_id] <= '0;
+              send_id <= send_id + 1;
               for (integer i = 0; i < data_mask_width_lp; i++)
                 if (store_mask[i])
                   shadow_mem[cache_pkt_word_addr][8*i+:8] <= store_data[8*i+:8];
@@ -208,8 +208,8 @@ module basic_checker_32
                 : load_data;
             end
             ALOCK, AUNLOCK, TAGFL, AFLINV, AFL: begin
-              result[send_id] = '0;
-              send_id++;
+              result[send_id] <= '0;
+              send_id <= send_id + 1;
             end
           endcase
         end
@@ -219,7 +219,7 @@ module basic_checker_32
           assert(result[recv_id] == data_o)
             else $fatal(1, "[BSG_FATAL] output does not match expected result. Id=%d, Expected: %x. Actual: %x.",
                     recv_id, result[recv_id], data_o);
-          recv_id++;
+          recv_id <= recv_id + 1;
         end
       end
     end

--- a/testing/bsg_cache/regression_v2/.gitignore
+++ b/testing/bsg_cache/regression_v2/.gitignore
@@ -2,3 +2,5 @@
 out
 test_result.log
 vc_hdrs.h
+simsc
+obj_dir

--- a/testing/bsg_cache/regression_v2/Makefile
+++ b/testing/bsg_cache/regression_v2/Makefile
@@ -1,13 +1,37 @@
 include ../../../../bsg_cadenv/cadenv.mk
 export BASEJUMP_STL_DIR = $(abspath ../../..)
 
+USE_VERILATOR ?= 0
+WAVE ?= 0
+
 INCDIR =  +incdir+$(BASEJUMP_STL_DIR)/bsg_misc
 INCDIR += +incdir+$(BASEJUMP_STL_DIR)/bsg_cache
 
-VCS_FLAGS =  -full64 +lint=all,noSVA-UA,noSVA-NSVU,noVCDE -debug_access
+VCS_FLAGS =  -full64 +lint=all,noSVA-UA,noSVA-NSVU,noVCDE
+ifeq ($(WAVE),1)
+VCS_FLAGS += -debug_access
+VCS_FLAGS += -DWAVE
+endif
 VCS_FLAGS += +v2k -sverilog -timescale=1ps/1ps -O4 -assert svaext
 VCS_FLAGS +=  -reportstats
 
+VERILATOR ?= verilator
+VERILATOR_THREADS ?= 4
+VERILATOR_FLAGS = --cc --binary
+VERILATOR_FLAGS += -Wno-TIMESCALEMOD
+VERILATOR_FLAGS += -Wno-fatal
+VERILATOR_FLAGS += -Wno-UNOPTFLAT
+ifeq ($(WAVE),1)
+VERILATOR_FLAGS += --trace-fst --trace-structs --trace-depth 15
+VERILATOR_FLAGS += -DWAVE
+endif
+VERILATOR_FLAGS += -O3
+VERILATOR_FLAGS += --verilate-jobs $(VERILATOR_THREADS)
+VERILATOR_FLAGS += --threads $(VERILATOR_THREADS)
+VERILATOR_FLAGS += --trace-threads 1
+#VERILATOR_FLAGS += --assert
+VERILATOR_FLAGS += --top-module testbench
+VERILATOR_FLAGS += -o simsc
 
 ##### Test Suite #######
 BASIC_TEST = test_random1 test_random2
@@ -48,9 +72,8 @@ VCS_DEFINES += +define+DMA_DATA_DELAY_P=$(DMA_DATA_DELAY_P)
 VCS_DEFINES += +define+WORD_TRACKING_P=$(WORD_TRACKING_P)
 ########################
 
-
+SIMSC = $(abspath simsc)
 SIMV = $(abspath simv)
-WAVE ?= 0
 
 BASIC_TRACE_TR = $(addprefix out/, $(addsuffix /trace.tr, $(BASIC_TEST)))
 
@@ -63,14 +86,23 @@ basic_test: $(addsuffix .basic.run, $(BASIC_TEST))
 simv:
 	$(VCS) $(VCS_FLAGS) -f sv.include $(INCDIR) $(VCS_DEFINES) -l vcs.log | $(HIGHLIGHT)
 
+simsc:
+	$(VERILATOR) $(VERILATOR_FLAGS) -f sv.include $(INCDIR) $(VCS_DEFINES) | $(HIGHLIGHT)
+	ln -nsf obj_dir/$(@F) $@ 
 
 out/%/trace.tr:
 	mkdir -p out/
 	mkdir -p out/$*
 	python $*.py > $@
 
+ifeq ($(USE_VERILATOR),1)
+%.basic.run: simsc out/%/trace.tr
+	ln -nsf $(SIMSC) out/$*/simsc
+	(cd out/$*; $(SIMSC) +wave=$(WAVE) +checker=basic &> simsc.log)
+else
 %.basic.run: simv out/%/trace.tr
 	(cd out/$*; $(SIMV) -reportstats +vcs+nostdout +wave=$(WAVE) +checker=basic -l simv.log)
+endif
 
 %.dve:
 	$(DVE) -full64 -vpd out/$*/vcdplus.vpd &
@@ -89,4 +121,6 @@ clean:
 	rm -rf ucli.key vcdplus.vpd simv cm.log *.tar.gz
 	rm -rf stack.info.* *.pyc
 	rm -rf out
+	rm -rf obj_dir
 	rm -f ../common/*.pyc
+	rm -rf simsc

--- a/testing/bsg_cache/regression_v2/sv.include
+++ b/testing/bsg_cache/regression_v2/sv.include
@@ -20,7 +20,7 @@ $BASEJUMP_STL_DIR/bsg_misc/bsg_priority_encode_one_hot_out.sv
 $BASEJUMP_STL_DIR/bsg_misc/bsg_encode_one_hot.sv
 $BASEJUMP_STL_DIR/bsg_misc/bsg_scan.sv
 $BASEJUMP_STL_DIR/bsg_misc/bsg_expand_bitmask.sv
-$BASEJUMP_STL_DIR/bsg_legacy/bsg_fsb/bsg_fsb_node_trace_replay.v
+$BASEJUMP_STL_DIR/bsg_test/bsg_trace_replay.sv
 $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1r1w_synth.sv
 $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1r1w.sv
 $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1rw_sync.sv


### PR DESCRIPTION
Only minor changes now that verilator supports timing statements. This PR only fixes basic_32, but would be trivial to port other tests.

- resolve blocking / non-blocking mixture in checker. Should all be non-blocking
- Add USE_VERILATOR flag to switch between VCS/Verilator
- Move to bsg_trace_replay from deprecated bsg_fsb_node_trace_replay
- Adding -DWAVE definition to allow sims to be compiled w/wo dump for speed
- rename testbench.checker to testbench._checker to avoid keyword conflict (checker is a SV keyword. VCS allows this override but Verilator does not, which is probably the sane thing)
- Workaround for Verilator 5.030 regression https://github.com/verilator/verilator/pull/5616