### PR TITLE
Removing BSG_ABSTRACT_MODULE from gf14 clk gen netlist modules

### DIFF
--- a/hard/gf_14/bsg_clk_gen/bsg_rp_clk_gen_atomic_delay_tuner.sv
+++ b/hard/gf_14/bsg_clk_gen/bsg_rp_clk_gen_atomic_delay_tuner.sv
@@ -78,6 +78,3 @@ module bsg_rp_clk_gen_atomic_delay_tuner
 // synopsys rp_endgroup (bsg_clk_gen_cde)
 
 endmodule
-
-`BSG_ABSTRACT_MODULE(bsg_rp_clk_gen_atomic_delay_tuner)
-

--- a/hard/gf_14/bsg_clk_gen/bsg_rp_clk_gen_coarse_delay_tuner.sv
+++ b/hard/gf_14/bsg_clk_gen/bsg_rp_clk_gen_coarse_delay_tuner.sv
@@ -54,5 +54,3 @@ module bsg_rp_clk_gen_coarse_delay_tuner
 // synopsys rp_endgroup (bsg_clk_gen_cde)
 
 endmodule
-
-`BSG_ABSTRACT_MODULE(bsg_rp_clk_gen_coarse_delay_tuner)

--- a/hard/gf_14/bsg_clk_gen/bsg_rp_clk_gen_fine_delay_tuner.sv
+++ b/hard/gf_14/bsg_clk_gen/bsg_rp_clk_gen_fine_delay_tuner.sv
@@ -65,5 +65,3 @@ module bsg_rp_clk_gen_fine_delay_tuner
   // synopsys rp_endgroup(bsg_clk_gen_fdt)
 
 endmodule
-
-`BSG_ABSTRACT_MODULE(bsg_rp_clk_gen_fine_delay_tuner)


### PR DESCRIPTION
These files are netlist files (not hard swap files) and are read by synthesis using a different engine than typical RTL files. This engine does not support macros with arguments therefore this macro can not be part of a netlist files.