### PR TITLE
Making harden default 0 for synthesized modules

### DIFF
--- a/bsg_mem/bsg_mem_2rw_sync.sv
+++ b/bsg_mem/bsg_mem_2rw_sync.sv
@@ -5,7 +5,7 @@ module bsg_mem_2rw_sync #( parameter `BSG_INV_PARAM(width_p )
                          , parameter `BSG_INV_PARAM(els_p )
                          , parameter read_write_same_addr_p=0
                          , parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
-                         , parameter harden_p=1
+                         , parameter harden_p=0
                          , parameter disable_collision_warning_p=0
                          , parameter enable_clock_gating_p=0
                          )

--- a/bsg_mem/bsg_mem_2rw_sync_mask_write_bit.sv
+++ b/bsg_mem/bsg_mem_2rw_sync_mask_write_bit.sv
@@ -5,7 +5,7 @@ module bsg_mem_2rw_sync_mask_write_bit #( parameter `BSG_INV_PARAM(width_p )
                          , parameter `BSG_INV_PARAM(els_p )
                          , parameter read_write_same_addr_p=0
                          , parameter addr_width_lp = `BSG_SAFE_CLOG2(els_p)
-                         , parameter harden_p=1
+                         , parameter harden_p=0
                          , parameter disable_collision_warning_p=0
                          , parameter enable_clock_gating_p=0
                          )

--- a/bsg_mem/bsg_mem_2rw_sync_mask_write_bit_synth.sv
+++ b/bsg_mem/bsg_mem_2rw_sync_mask_write_bit_synth.sv
@@ -6,7 +6,7 @@ module bsg_mem_2rw_sync_mask_write_bit_synth #( parameter `BSG_INV_PARAM(width_p
                          , parameter read_write_same_addr_p = 0
                          , parameter disable_collision_warning_p = 0
                          , parameter addr_width_lp = `BSG_SAFE_CLOG2(els_p)
-                         , parameter harden_p = 1
+                         , parameter harden_p=0
                          )
   ( input                      clk_i
   , input                      reset_i

--- a/bsg_mem/bsg_mem_2rw_sync_mask_write_byte.sv
+++ b/bsg_mem/bsg_mem_2rw_sync_mask_write_byte.sv
@@ -4,7 +4,7 @@ module bsg_mem_2rw_sync_mask_write_byte #( parameter `BSG_INV_PARAM(width_p )
                          , parameter `BSG_INV_PARAM(els_p )
                          , parameter read_write_same_addr_p=0
                          , parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
-                         , parameter harden_p=1
+                         , parameter harden_p=0
                          , parameter disable_collision_warning_p=0
                          , parameter enable_clock_gating_p=0
                          , parameter write_mask_width_lp=(width_p>>3)

--- a/bsg_mem/bsg_mem_2rw_sync_mask_write_byte_synth.sv
+++ b/bsg_mem/bsg_mem_2rw_sync_mask_write_byte_synth.sv
@@ -4,7 +4,7 @@ module bsg_mem_2rw_sync_mask_write_byte_synth #( parameter `BSG_INV_PARAM(width_
                          , parameter `BSG_INV_PARAM(els_p )
                          , parameter read_write_same_addr_p=0
                          , parameter addr_width_lp = `BSG_SAFE_CLOG2(els_p)
-                         , parameter harden_p = 1
+                         , parameter harden_p=0
                          , parameter disable_collision_warning_p=0     
                          , parameter write_mask_width_lp=(width_p>>3)              
                          )

--- a/bsg_mem/bsg_mem_2rw_sync_synth.sv
+++ b/bsg_mem/bsg_mem_2rw_sync_synth.sv
@@ -5,7 +5,7 @@ module bsg_mem_2rw_sync_synth #( parameter `BSG_INV_PARAM(width_p )
                          , parameter `BSG_INV_PARAM(els_p )
                          , parameter read_write_same_addr_p=0
                          , parameter addr_width_lp = `BSG_SAFE_CLOG2(els_p)
-                         , parameter harden_p = 1
+                         , parameter harden_p=0
                          , parameter disable_collision_warning_p=0                   
                          )
   ( input                      clk_i

--- a/bsg_misc/bsg_adder_cin.sv
+++ b/bsg_misc/bsg_adder_cin.sv
@@ -2,7 +2,7 @@
 `include "bsg_defines.sv"
 
 module bsg_adder_cin #(parameter `BSG_INV_PARAM(width_p)
-                 , harden_p=1)
+                 , harden_p=0)
    ( input [width_p-1:0] a_i
     , input [width_p-1:0] b_i
     , input               cin_i

--- a/bsg_misc/bsg_and.sv
+++ b/bsg_misc/bsg_and.sv
@@ -1,7 +1,7 @@
 `include "bsg_defines.sv"
 
 module bsg_and #(parameter `BSG_INV_PARAM(width_p)
-                 , harden_p=1)
+                 , harden_p=0)
    (input [width_p-1:0] a_i
     , input [width_p-1:0] b_i
     , output [width_p-1:0] o

--- a/bsg_misc/bsg_buf.sv
+++ b/bsg_misc/bsg_buf.sv
@@ -1,7 +1,7 @@
 `include "bsg_defines.sv"
 
 module bsg_buf #(parameter `BSG_INV_PARAM(width_p)
-                 , harden_p=1)
+                 , harden_p=0)
    (input [width_p-1:0] i
     , output [width_p-1:0] o
     );

--- a/bsg_misc/bsg_buf_ctrl.sv
+++ b/bsg_misc/bsg_buf_ctrl.sv
@@ -2,7 +2,7 @@
 `include "bsg_defines.sv"
 
 module bsg_buf_ctrl #(parameter `BSG_INV_PARAM(width_p)
-                 , harden_p=1)
+                 , harden_p=0)
    (input i
   , output [width_p-1:0] o
   );

--- a/bsg_misc/bsg_clkbuf.sv
+++ b/bsg_misc/bsg_clkbuf.sv
@@ -2,7 +2,7 @@
 
 module bsg_clkbuf #(parameter width_p=1
 		    , parameter strength_p=8
-                    , parameter harden_p=1
+                    , parameter harden_p=0
                     )
    (input    [width_p-1:0] i
     , output [width_p-1:0] o

--- a/bsg_misc/bsg_dff_en.sv
+++ b/bsg_misc/bsg_dff_en.sv
@@ -6,7 +6,7 @@
 `include "bsg_defines.sv"
 
 module bsg_dff_en #(parameter `BSG_INV_PARAM(width_p)
-                   ,parameter harden_p=1   // mbt fixme: maybe this should not be a default
+                   ,parameter harden_p=0   // mbt fixme: maybe this should not be a default
                    ,parameter strength_p=1)
 (
   input clk_i

--- a/bsg_misc/bsg_dff_gatestack.sv
+++ b/bsg_misc/bsg_dff_gatestack.sv
@@ -1,6 +1,6 @@
 `include "bsg_defines.sv"
 
-module bsg_dff_gatestack #(`BSG_INV_PARAM(width_p), harden_p=1)
+module bsg_dff_gatestack #(`BSG_INV_PARAM(width_p), harden_p=0)
    (input [width_p-1:0] i0
     , input [width_p-1:0] i1
     , output logic [width_p-1:0] o

--- a/bsg_misc/bsg_inv.sv
+++ b/bsg_misc/bsg_inv.sv
@@ -1,7 +1,7 @@
 `include "bsg_defines.sv"
 
 module bsg_inv #(parameter `BSG_INV_PARAM(width_p)
-                 , harden_p=1
+                 , harden_p=0
 		 , vertical_p=1)
    (input [width_p-1:0] i
     , output [width_p-1:0] o

--- a/bsg_misc/bsg_mul.sv
+++ b/bsg_misc/bsg_mul.sv
@@ -2,7 +2,7 @@
 `include "bsg_defines.sv"
 
 module bsg_mul #(parameter `BSG_INV_PARAM(width_p)
-                 ,harden_p=1
+                 ,harden_p=0
                  )
    (input    [width_p-1:0]   x_i
     , input  [width_p-1:0]   y_i

--- a/bsg_misc/bsg_mul_pipelined.sv
+++ b/bsg_misc/bsg_mul_pipelined.sv
@@ -62,7 +62,7 @@ endfunction
 
 module bsg_mul_pipelined #(parameter `BSG_INV_PARAM(width_p)
                            , parameter pipeline_p=1
-                           , parameter harden_p  =1
+                           , parameter harden_p=0
                            )
    (  input clk_i
     , input en_i
@@ -570,7 +570,7 @@ endmodule
 module bsg_dff_en_rep_rep #(parameter blocks_p=0
                             , width_p=0
                             , group_vec_p=0
-                            , harden_p=1
+                            , harden_p=0
                             )
    (input clk_i
     , input en_i
@@ -607,7 +607,7 @@ endmodule
 module bsg_mul_comp42_rep_rep #(parameter blocks_p=0
                                 , width_p=0
                                 , group_vec_p=0
-                                , harden_p=1
+                                , harden_p=0
                                 )
 
    // we do this so that it is easy to combine vectors of results from blocks
@@ -659,7 +659,7 @@ module bsg_mul_B4B_rep_rep
     , parameter dot_bar_vec_p = 0
     , parameter B_vec_p     = 0
     , parameter one_vec_p   = 0
-    , parameter harden_p    = 1'b0
+    , parameter harden_p=0'b0
     )
    ( input [4:0][2:0] SDN_i
      , input cr_i

--- a/bsg_misc/bsg_mux2_gatestack.sv
+++ b/bsg_misc/bsg_mux2_gatestack.sv
@@ -1,6 +1,6 @@
 `include "bsg_defines.sv"
 
-module bsg_mux2_gatestack #(parameter `BSG_INV_PARAM(width_p), harden_p=1)
+module bsg_mux2_gatestack #(parameter `BSG_INV_PARAM(width_p), harden_p=0)
    (input [width_p-1:0] i0
     , input [width_p-1:0] i1
     , input [width_p-1:0] i2

--- a/bsg_misc/bsg_mux_one_hot.sv
+++ b/bsg_misc/bsg_mux_one_hot.sv
@@ -3,7 +3,7 @@
 
 module bsg_mux_one_hot #(parameter `BSG_INV_PARAM(width_p)
                          , els_p=1
-			 , harden_p=1
+			 , harden_p=0
                          )
    (
     input [els_p-1:0][width_p-1:0] data_i

--- a/bsg_misc/bsg_muxi2_gatestack.sv
+++ b/bsg_misc/bsg_muxi2_gatestack.sv
@@ -1,6 +1,6 @@
 `include "bsg_defines.sv"
 
-module bsg_muxi2_gatestack #(`BSG_INV_PARAM(width_p), harden_p=1)
+module bsg_muxi2_gatestack #(`BSG_INV_PARAM(width_p), harden_p=0)
    (input [width_p-1:0] i0
     , input [width_p-1:0] i1
     , input [width_p-1:0] i2

--- a/bsg_misc/bsg_nand.sv
+++ b/bsg_misc/bsg_nand.sv
@@ -1,7 +1,7 @@
 `include "bsg_defines.sv"
 
 module bsg_nand #(parameter `BSG_INV_PARAM(width_p)
-                 , harden_p=1)
+                 , harden_p=0)
    (input [width_p-1:0] a_i
     , input [width_p-1:0] b_i
     , output [width_p-1:0] o

--- a/bsg_misc/bsg_nor2.sv
+++ b/bsg_misc/bsg_nor2.sv
@@ -1,7 +1,7 @@
 `include "bsg_defines.sv"
 
 module bsg_nor2 #(parameter `BSG_INV_PARAM(width_p)
-                 , harden_p=1)
+                 , harden_p=0)
    (input [width_p-1:0] a_i
     , input [width_p-1:0] b_i
     , output [width_p-1:0] o

--- a/bsg_misc/bsg_nor3.sv
+++ b/bsg_misc/bsg_nor3.sv
@@ -1,7 +1,7 @@
 `include "bsg_defines.sv"
 
 module bsg_nor3 #(parameter `BSG_INV_PARAM(width_p)
-                 , harden_p=1)
+                 , harden_p=0)
    (input [width_p-1:0] a_i
     , input [width_p-1:0] b_i
     , input [width_p-1:0] c_i

--- a/bsg_misc/bsg_tiehi.sv
+++ b/bsg_misc/bsg_tiehi.sv
@@ -2,7 +2,7 @@
 `include "bsg_defines.sv"
 
 module bsg_tiehi #(parameter `BSG_INV_PARAM(width_p)
-                   , parameter harden_p=1
+                   , parameter harden_p=0
                    )
    (output [width_p-1:0] o
     );

--- a/bsg_misc/bsg_tielo.sv
+++ b/bsg_misc/bsg_tielo.sv
@@ -2,7 +2,7 @@
 `include "bsg_defines.sv"
 
 module bsg_tielo #(parameter `BSG_INV_PARAM(width_p)
-                 , parameter harden_p=1
+                 , parameter harden_p=0
                  )
    (output [width_p-1:0] o
     );

--- a/bsg_misc/bsg_xnor.sv
+++ b/bsg_misc/bsg_xnor.sv
@@ -1,7 +1,7 @@
 `include "bsg_defines.sv"
 
 module bsg_xnor #(parameter `BSG_INV_PARAM(width_p)
-                 , harden_p=1)
+                 , harden_p=0)
    (input [width_p-1:0] a_i
     , input [width_p-1:0] b_i
     , output [width_p-1:0] o

--- a/bsg_misc/bsg_xor.sv
+++ b/bsg_misc/bsg_xor.sv
@@ -1,7 +1,7 @@
 `include "bsg_defines.sv"
 
 module bsg_xor #(parameter `BSG_INV_PARAM(width_p)
-                 , harden_p=1)
+                 , harden_p=0)
    (input [width_p-1:0] a_i
     , input [width_p-1:0] b_i
     , output [width_p-1:0] o

--- a/bsg_tag/bsg_tag_client.sv
+++ b/bsg_tag/bsg_tag_client.sv
@@ -43,7 +43,7 @@
 
 module bsg_tag_client
    import bsg_tag_pkg::bsg_tag_s;
- #(parameter `BSG_INV_PARAM(width_p), harden_p=1)
+ #(parameter `BSG_INV_PARAM(width_p), harden_p=0)
    (
     input bsg_tag_s bsg_tag_i
 

--- a/bsg_tag/bsg_tag_client_unsync.sv
+++ b/bsg_tag/bsg_tag_client_unsync.sv
@@ -27,7 +27,7 @@
 
 module bsg_tag_client_unsync
   import bsg_tag_pkg::bsg_tag_s;
-   #(parameter `BSG_INV_PARAM(width_p), harden_p=1, debug_level_lp=0)
+   #(parameter `BSG_INV_PARAM(width_p), harden_p=0, debug_level_lp=0)
    (
     input 		 bsg_tag_s bsg_tag_i
 


### PR DESCRIPTION
This PR makes harden_p "opt in" for synthesized modules. For the most part, this is the basejump_stl convention. These are stragglers