### PR TITLE
Adding bsg_link_delay_line

### DIFF
--- a/bsg_link/bsg_link_delay_line.sv
+++ b/bsg_link/bsg_link_delay_line.sv
@@ -1,0 +1,43 @@
+
+`include "bsg_defines.sv"
+
+module bsg_link_delay_line
+ import bsg_tag_pkg::*;
+ import bsg_link_pkg::*;
+ #(parameter `BSG_INV_PARAM(width_p), harden_p=0)
+  (input  tag_clk_i
+  ,input  bsg_link_delay_tag_lines_s tag_lines_i
+  ,input  [width_p-1:0] i
+  ,output [width_p-1:0] o
+  );
+
+  if (width_p != 18) $error("%m hardcoded for channel width 16");
+
+  wire [width_p-1:0][1:0] sel;
+
+  for (genvar k = 0; k < width_p; k++)
+    assign #(sel[k]*50) o[k] = i[k];
+
+  wire bsg_tag_s btc0_tag_lines_li = {tag_clk_i, tag_lines_i.data[0][2:0]};
+  wire bsg_tag_s btc1_tag_lines_li = {tag_clk_i, tag_lines_i.data[1][2:0]};
+  wire bsg_tag_s btc2_tag_lines_li = {tag_clk_i, tag_lines_i.data[2][2:0]};
+  wire bsg_tag_s btc3_tag_lines_li = {tag_clk_i, tag_lines_i.clk    [2:0]};
+
+  // hardcoded for bsg_link_channel_width_gp = 16 and tag payload width 12
+  bsg_tag_client_unsync #(.width_p(12)) btc0
+  (.bsg_tag_i     (btc0_tag_lines_li)
+  ,.data_async_r_o(sel[0+:6]));
+  bsg_tag_client_unsync #(.width_p(12)) btc1
+  (.bsg_tag_i     (btc1_tag_lines_li)
+  ,.data_async_r_o(sel[6+:6]));
+  bsg_tag_client_unsync #(.width_p(10)) btc2
+  (.bsg_tag_i     (btc2_tag_lines_li)
+  ,.data_async_r_o(sel[12+:5]));
+  bsg_tag_client_unsync #(.width_p(2)) btc3
+  (.bsg_tag_i     (btc3_tag_lines_li)
+  ,.data_async_r_o(sel[17]));
+
+endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_link_delay_line)
+

--- a/bsg_link/bsg_link_pkg.sv
+++ b/bsg_link/bsg_link_pkg.sv
@@ -16,17 +16,6 @@ package bsg_link_pkg;
 
   typedef struct packed
   {
-    bsg_tag_s sdr_disable;
-    bsg_tag_s uplink_reset;
-    bsg_tag_s downlink_reset;
-    bsg_tag_s downstream_reset;
-    bsg_tag_s token_reset;
-  }  bsg_link_sdr_w_disable_tag_lines_s;
-  localparam bsg_link_sdr_w_disable_tag_local_els_gp =
-	$bits(bsg_link_sdr_w_disable_tag_lines_s) / $bits(bsg_tag_s);
-
-  typedef struct packed
-  {
     bsg_tag_s uplink_reset;
     bsg_tag_s downlink_reset;
     bsg_tag_s downstream_reset;
@@ -34,6 +23,25 @@ package bsg_link_pkg;
   }  bsg_link_sdr_tag_lines_s;
   localparam bsg_link_sdr_tag_local_els_gp =
 	$bits(bsg_link_sdr_tag_lines_s) / $bits(bsg_tag_s);
+
+  typedef struct packed
+  {
+    bsg_tag_s       clk;
+    bsg_tag_s [2:0] data;
+  }  bsg_link_delay_tag_lines_s;
+  localparam tag_delay_local_els_gp = $bits(bsg_link_delay_tag_lines_s)/$bits(bsg_tag_s);
+
+  typedef struct packed
+  {
+    bsg_link_delay_tag_lines_s idelay;
+    bsg_link_delay_tag_lines_s odelay;
+    bsg_tag_s io_uplink_reset;
+    bsg_tag_s io_downlink_reset;
+    bsg_tag_s io_async_token_reset;
+    bsg_tag_s core_uplink_reset;
+    bsg_tag_s core_downlink_reset;
+  }  bsg_link_ddr_tag_lines_s;
+  localparam tag_ddr_local_els_gp = $bits(bsg_link_ddr_tag_lines_s)/$bits(bsg_tag_s);
 
 endpackage
 

--- a/bsg_tag/bsg_tag_pkg.sv
+++ b/bsg_tag/bsg_tag_pkg.sv
@@ -7,8 +7,10 @@ package bsg_tag_pkg;
                    //   0   1   reset
 
       logic en;    // this signal disables thru-transmit of new values
-} bsg_tag_s;
+  } bsg_tag_s;
 
+  typedef bsg_tag_s bsg_tag_lines_s;
+  localparam bsg_tag_local_els_gp = $bits(bsg_tag_lines_s) / $bits(bsg_tag_s);
 
 endpackage // bsg_tag_pkg
 

--- a/hard/tsmc_28/bsg_link/bsg_link_delay_line.sv
+++ b/hard/tsmc_28/bsg_link/bsg_link_delay_line.sv
@@ -1,0 +1,53 @@
+
+`include "bsg_defines.sv"
+
+module bsg_link_delay_line
+
+ import bsg_tag_pkg::*;
+ import bsg_link_pkg::*;
+
+ // Hardcoded for channel width 16
+ #(parameter width_p = 18, harden_p = 1)
+
+  (input  tag_clk_i
+  ,input  bsg_link_delay_tag_lines_s tag_lines_i
+  ,input  [width_p-1:0] i
+  ,output [width_p-1:0] o
+  );
+
+  wire [width_p-1:0][1:0] sel;
+  wire [width_p-1:0] dly0, dly1, dly2;
+
+  for (genvar k = 0; k < width_p; k++)
+  begin: sig
+    DEL050MD1BWP7T40P140 dly0_BSG_DONT_TOUCH (.I(i   [k]),.Z(dly0[k]));
+    DEL050MD1BWP7T40P140 dly1_BSG_DONT_TOUCH (.I(dly0[k]),.Z(dly1[k]));
+    DEL050MD1BWP7T40P140 dly2_BSG_DONT_TOUCH (.I(dly1[k]),.Z(dly2[k]));
+
+    MUX4D4BWP7T30P140ULVT mux_BSG_DONT_TOUCH
+    (.I0(i[k]),.I1(dly0[k]),.I2(dly1[k]),.I3(dly2[k])
+    ,.S0(sel[k][0]),.S1(sel[k][1]),.Z(o[k]));
+  end
+
+  wire bsg_tag_s btc0_tag_lines_li = {tag_clk_i, tag_lines_i.data[0][2:0]};
+  wire bsg_tag_s btc1_tag_lines_li = {tag_clk_i, tag_lines_i.data[1][2:0]};
+  wire bsg_tag_s btc2_tag_lines_li = {tag_clk_i, tag_lines_i.data[2][2:0]};
+  wire bsg_tag_s btc3_tag_lines_li = {tag_clk_i, tag_lines_i.clk    [2:0]};
+
+  bsg_tag_client_unsync #(.width_p(12), .harden_p(1)) btc0
+  (.bsg_tag_i     (btc0_tag_lines_li)
+  ,.data_async_r_o(sel[0+:6]));
+  bsg_tag_client_unsync #(.width_p(12), .harden_p(1)) btc1
+  (.bsg_tag_i     (btc1_tag_lines_li)
+  ,.data_async_r_o(sel[6+:6]));
+  bsg_tag_client_unsync #(.width_p(10), .harden_p(1)) btc2
+  (.bsg_tag_i     (btc2_tag_lines_li)
+  ,.data_async_r_o(sel[12+:5]));
+  bsg_tag_client_unsync #(.width_p(2), .harden_p(1)) btc3
+  (.bsg_tag_i     (btc3_tag_lines_li)
+  ,.data_async_r_o(sel[17]));
+
+endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_link_delay_line)
+


### PR DESCRIPTION
This PR adds bsg_link_delay_line which has been taped out in gf14 and tsmc28, but never landed in basejump_stl.

Part of #700 decomposition