### PR TITLE
Standardize bsg_mem width_p parameter

### DIFF
--- a/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
+++ b/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
@@ -3,9 +3,9 @@
 module bsg_mem_1rw_sync_mask_write_byte #(parameter `BSG_INV_PARAM(els_p)
                                           ,parameter addr_width_lp = `BSG_SAFE_CLOG2(els_p)
 
-                                          ,parameter `BSG_INV_PARAM(data_width_p )
+                                          ,parameter `BSG_INV_PARAM(width_p)
                                           ,parameter latch_last_read_p=0
-                                          ,parameter write_mask_width_lp = data_width_p>>3
+                                          ,parameter write_mask_width_lp = width_p>>3
                                           ,parameter enable_clock_gating_p=0
                                          )
   ( input clk_i
@@ -15,11 +15,11 @@ module bsg_mem_1rw_sync_mask_write_byte #(parameter `BSG_INV_PARAM(els_p)
    ,input w_i
 
    ,input [addr_width_lp-1:0]       addr_i
-   ,input [`BSG_SAFE_MINUS(data_width_p, 1):0]        data_i
+   ,input [`BSG_SAFE_MINUS(width_p, 1):0]        data_i
     // for each bit set in the mask, a byte is written
    ,input [`BSG_SAFE_MINUS(write_mask_width_lp, 1):0] write_mask_i
 
-   ,output logic [`BSG_SAFE_MINUS(data_width_p, 1):0] data_o
+   ,output logic [`BSG_SAFE_MINUS(width_p, 1):0] data_o
   );
 
    wire clk_lo;
@@ -39,7 +39,7 @@ module bsg_mem_1rw_sync_mask_write_byte #(parameter `BSG_INV_PARAM(els_p)
      end
 
    bsg_mem_1rw_sync_mask_write_byte_synth
-     #(.els_p(els_p), .data_width_p(data_width_p), .latch_last_read_p(latch_last_read_p))
+     #(.els_p(els_p), .width_p(width_p), .latch_last_read_p(latch_last_read_p))
    synth
    (.clk_i(clk_lo)
    ,.reset_i
@@ -54,12 +54,12 @@ module bsg_mem_1rw_sync_mask_write_byte #(parameter `BSG_INV_PARAM(els_p)
 `ifndef BSG_HIDE_FROM_SYNTHESIS
 
   always_comb
-    assert (data_width_p % 8 == 0)
+    assert (width_p % 8 == 0)
       else $error("data width should be a multiple of 8 for byte masking");
 
    initial
      begin
-        $display("## %L: instantiating data_width_p=%d, els_p=%d (%m)",data_width_p,els_p);
+        $display("## %L: instantiating width_p=%d, els_p=%d (%m)",width_p,els_p);
      end
 
 `endif

--- a/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_banked.sv
+++ b/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_banked.sv
@@ -25,11 +25,11 @@
 `include "bsg_defines.sv"
 
 module bsg_mem_1rw_sync_mask_write_byte_banked
-  #(parameter `BSG_INV_PARAM(data_width_p)
+  #(parameter `BSG_INV_PARAM(width_p)
     , parameter `BSG_INV_PARAM(els_p)
     , parameter latch_last_read_p=0
 
-    , parameter write_mask_width_lp=(data_width_p>>3)
+    , parameter write_mask_width_lp=(width_p>>3)
 
     // bank parameters
     , parameter num_width_bank_p=1
@@ -39,7 +39,7 @@ module bsg_mem_1rw_sync_mask_write_byte_banked
     , parameter bank_depth_lp=(els_p/num_depth_bank_p)
     , parameter bank_addr_width_lp=`BSG_SAFE_CLOG2(bank_depth_lp)
     , parameter depth_bank_idx_width_lp=`BSG_SAFE_CLOG2(num_depth_bank_p)
-    , parameter bank_width_lp=(data_width_p/num_width_bank_p)
+    , parameter bank_width_lp=(width_p/num_width_bank_p)
     , parameter bank_mask_width_lp=(bank_width_lp>>3)
   )
   (
@@ -50,9 +50,9 @@ module bsg_mem_1rw_sync_mask_write_byte_banked
     , input w_i
 
     , input [addr_width_lp-1:0] addr_i
-    , input [data_width_p-1:0] data_i
+    , input [width_p-1:0] data_i
     , input [write_mask_width_lp-1:0] write_mask_i
-    , output [data_width_p-1:0] data_o
+    , output [width_p-1:0] data_o
   );
 
 
@@ -60,7 +60,7 @@ module bsg_mem_1rw_sync_mask_write_byte_banked
 
     for (genvar i = 0; i < num_width_bank_p; i++) begin: wb
       bsg_mem_1rw_sync_mask_write_byte #(
-        .data_width_p(bank_width_lp)
+        .width_p(bank_width_lp)
         ,.els_p(bank_depth_lp)
         ,.latch_last_read_p(latch_last_read_p)
       ) bank (
@@ -82,7 +82,7 @@ module bsg_mem_1rw_sync_mask_write_byte_banked
     wire [bank_addr_width_lp-1:0] bank_addr_li = addr_i[depth_bank_idx_width_lp+:bank_addr_width_lp];
 
     logic [num_depth_bank_p-1:0] bank_v_li;
-    logic [num_depth_bank_p-1:0][data_width_p-1:0] bank_data_lo;
+    logic [num_depth_bank_p-1:0][width_p-1:0] bank_data_lo;
    
     
     bsg_decode_with_v #(
@@ -97,7 +97,7 @@ module bsg_mem_1rw_sync_mask_write_byte_banked
       for (genvar j = 0; j < num_depth_bank_p; j++) begin: db
 
         bsg_mem_1rw_sync_mask_write_byte #(
-          .data_width_p(bank_width_lp)
+          .width_p(bank_width_lp)
           ,.els_p(bank_depth_lp)
           ,.latch_last_read_p(latch_last_read_p)
         ) bank (
@@ -128,7 +128,7 @@ module bsg_mem_1rw_sync_mask_write_byte_banked
 
     bsg_mux #(
       .els_p(num_depth_bank_p)
-      ,.width_p(data_width_p)
+      ,.width_p(width_p)
     ) data_out_mux (
       .data_i(bank_data_lo)
       ,.sel_i(depth_bank_idx_r)
@@ -142,13 +142,13 @@ module bsg_mem_1rw_sync_mask_write_byte_banked
 
   initial begin
 
-    assert (data_width_p % 8 == 0)
-      else $error("data_width_p is not multiple of 8. %m");
+    assert (width_p % 8 == 0)
+      else $error("width_p is not multiple of 8. %m");
 
     assert(els_p % num_depth_bank_p == 0)
       else $error("[BSG_ERROR] num_depth_bank_p does not divide even with els_p. %m");
 
-    assert(data_width_p % num_width_bank_p == 0)
+    assert(width_p % num_width_bank_p == 0)
       else $error("[BSG_ERROR] num_width_bank_p does not divide even with width_p. %m");
 
   end

--- a/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_segmented.sv
+++ b/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_segmented.sv
@@ -55,7 +55,7 @@ module bsg_mem_1rw_sync_mask_write_byte_segmented
     end // for (genvar i = 0; i < num_segments_p; i++)
 
     bsg_mem_1rw_sync_mask_write_byte #(
-      .data_width_p(width_p)
+      .width_p(width_p)
       ,.els_p(els_p)
       ,.latch_last_read_p(latch_last_read_p && num_segments_p == 1)
     ) 

--- a/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_synth.sv
+++ b/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_synth.sv
@@ -8,8 +8,8 @@ module bsg_mem_1rw_sync_mask_write_byte_synth
     , parameter addr_width_lp = `BSG_SAFE_CLOG2(els_p)
     , parameter latch_last_read_p=0
 
-    , parameter `BSG_INV_PARAM(data_width_p )
-    , parameter write_mask_width_lp = data_width_p>>3
+    , parameter `BSG_INV_PARAM(width_p )
+    , parameter write_mask_width_lp = width_p>>3
   )
   ( input clk_i
    ,input reset_i
@@ -18,16 +18,16 @@ module bsg_mem_1rw_sync_mask_write_byte_synth
    ,input w_i
 
    ,input [addr_width_lp-1:0]       addr_i
-   ,input [`BSG_SAFE_MINUS(data_width_p, 1):0]        data_i
+   ,input [`BSG_SAFE_MINUS(width_p, 1):0]        data_i
     // for each bit set in the mask, a byte is written
    ,input [`BSG_SAFE_MINUS(write_mask_width_lp, 1):0] write_mask_i
 
-   ,output [`BSG_SAFE_MINUS(data_width_p, 1):0] data_o
+   ,output [`BSG_SAFE_MINUS(width_p, 1):0] data_o
   );
 
   genvar i;
 
-  if (data_width_p == 0 || els_p == 0)
+  if (width_p == 0 || els_p == 0)
    begin: z
      wire unused0 = &{clk_i, reset_i, v_i, w_i, addr_i, data_i, write_mask_i};
      assign data_o = '0;

--- a/bsg_mem/bsg_mem_1rw_sync_segmented.sv
+++ b/bsg_mem/bsg_mem_1rw_sync_segmented.sv
@@ -78,7 +78,7 @@ module bsg_mem_1rw_sync_segmented
       end // for (genvar i = 0; i < num_segments_p; i++)
   
       bsg_mem_1rw_sync_mask_write_byte #(
-        .data_width_p(width_p)
+        .width_p(width_p)
         ,.els_p(els_p)
         ,.latch_last_read_p(0)
       ) 

--- a/hard/common/bsg_mem/bsg_mem_generator.py
+++ b/hard/common/bsg_mem/bsg_mem_generator.py
@@ -311,22 +311,22 @@ bsg_mem_1rw_sync_mask_write_byte_template = """
   `include "bsg_defines.sv"
   `include "bsg_mem_1rw_sync_mask_write_byte_macros.svh"
 
-module bsg_mem_1rw_sync_mask_write_byte #(parameter `BSG_INV_PARAM(data_width_p)
+module bsg_mem_1rw_sync_mask_write_byte #(parameter `BSG_INV_PARAM(width_p)
                           , parameter `BSG_INV_PARAM(els_p)
                           , parameter latch_last_read_p=0
                           , parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
-                          , parameter write_mask_width_lp=data_width_p>>3
+                          , parameter write_mask_width_lp=width_p>>3
                           , parameter enable_clock_gating_p=0
                           , parameter harden_p=1
                           )
    (input   clk_i
     , input reset_i
-    , input [`BSG_SAFE_MINUS(data_width_p,1):0] data_i
+    , input [`BSG_SAFE_MINUS(width_p,1):0] data_i
     , input [addr_width_lp-1:0] addr_i
     , input v_i
     , input [`BSG_SAFE_MINUS(write_mask_width_lp,1):0] write_mask_i
     , input w_i
-    , output logic [`BSG_SAFE_MINUS(data_width_p,1):0]  data_o
+    , output logic [`BSG_SAFE_MINUS(width_p,1):0]  data_o
     );
 
 `ifndef BSG_HIDE_FROM_SYNTHESIS
@@ -343,7 +343,7 @@ module bsg_mem_1rw_sync_mask_write_byte #(parameter `BSG_INV_PARAM(data_width_p)
     {sram_cfg}
       begin: notmacro
       bsg_mem_1rw_sync_mask_write_byte_synth #(
-        .data_width_p(data_width_p)
+        .width_p(width_p)
         ,.els_p(els_p)
         ,.latch_last_read_p(latch_last_read_p)
       ) synth (.*);
@@ -352,7 +352,7 @@ module bsg_mem_1rw_sync_mask_write_byte #(parameter `BSG_INV_PARAM(data_width_p)
 `ifndef BSG_HIDE_FROM_SYNTHESIS
       initial
         begin
-           $display("## %L: instantiating data_width_p=%d, els_p=%d (%m)", data_width_p, els_p);
+           $display("## %L: instantiating width_p=%d, els_p=%d (%m)", width_p, els_p);
         end
 `endif
 endmodule

--- a/hard/fakeram/bsg_mem_1rw_sync_mask_write_byte_macros.svh
+++ b/hard/fakeram/bsg_mem_1rw_sync_mask_write_byte_macros.svh
@@ -8,9 +8,9 @@
   `bsg_mem_1rw_sync_mask_write_byte_1sram_macro(words,bits)
 
 `define bsg_mem_1rw_sync_mask_write_byte_1sram_macro(words,bits,tag) \
-  if (els_p == words && data_width_p == bits)                        \
+  if (els_p == words && width_p == bits)                        \
     begin: macro                                                     \
-       logic [data_width_p-1:0] w_mask_lo;                           \
+       logic [width_p-1:0] w_mask_lo;                           \
        bsg_expand_bitmask                                            \
         #(.in_width_p(write_mask_width_lp), .expand_p(8))            \
         wmask_expand                                                 \

--- a/hard/generic/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_macros.svh
+++ b/hard/generic/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_macros.svh
@@ -10,15 +10,15 @@
   `bsg_mem_1rw_sync_mask_write_byte_macro(words,bits,tag)
 
 `define bsg_mem_1rw_sync_mask_write_byte_macro(words,bits,tag) \
-  if (harden_p && els_p == words && data_width_p == bits)      \
+  if (harden_p && els_p == words && width_p == bits)      \
     begin: macro                                               \
       bsg_mem_1rw_sync_mask_write_byte_w``bits``_d``words``_``tag``_hard mem (.*); \
     end: macro
 
 `define bsg_mem_1rw_sync_mask_write_byte_banked_macro(words,bits,wbank,dbank) \
-  if (harden_p && els_p == words && data_width_p == bits) begin: macro        \
+  if (harden_p && els_p == words && width_p == bits) begin: macro        \
       bsg_mem_1rw_sync_mask_write_byte_banked #(                              \
-        .data_width_p(data_width_p)                                           \
+        .width_p(width_p)                                           \
         ,.els_p(els_p)                                                        \
         ,.latch_last_read_p(latch_last_read_p)                                \
         ,.num_width_bank_p(wbank)                                             \

--- a/hard/gf_14/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_macros.svh
+++ b/hard/gf_14/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_macros.svh
@@ -3,9 +3,9 @@
 `define BSG_MEM_1RW_SYNC_MASK_WRITE_BYTE_MACROS
 
 `define bsg_mem_1rw_sync_mask_write_byte_1rf_macro(words,bits,tag) \
-  if (harden_p && els_p == words && data_width_p == bits)      \
+  if (harden_p && els_p == words && width_p == bits)      \
     begin: macro                                               \
-      wire [data_width_p-1:0] wen;                             \
+      wire [width_p-1:0] wen;                             \
       genvar j;                                                \
       for(j = 0; j < write_mask_width_lp; j++)                 \
         assign wen[8*j+:8] = {8{write_mask_i[j]}};             \
@@ -28,9 +28,9 @@
     end: macro
 
 `define bsg_mem_1rw_sync_mask_write_byte_1sram_macro(words,bits,tag) \
-  if (harden_p && els_p == words && data_width_p == bits)      \
+  if (harden_p && els_p == words && width_p == bits)      \
     begin: macro                                               \
-      wire [data_width_p-1:0] wen;                             \
+      wire [width_p-1:0] wen;                             \
       genvar j;                                                \
       for(j = 0; j < write_mask_width_lp; j++)                 \
         assign wen[8*j+:8] = {8{write_mask_i[j]}};             \
@@ -53,9 +53,9 @@
     end: macro
 
 `define bsg_mem_1rw_sync_mask_write_byte_1hdsram_macro(words,bits,tag) \
-  if (harden_p && els_p == words && data_width_p == bits)      \
+  if (harden_p && els_p == words && width_p == bits)      \
     begin: macro                                               \
-      wire [data_width_p-1:0] wen;                             \
+      wire [width_p-1:0] wen;                             \
       genvar j;                                                \
       for(j = 0; j < write_mask_width_lp; j++)                 \
         assign wen[8*j+:8] = {8{write_mask_i[j]}};             \
@@ -78,9 +78,9 @@
     end: macro
 
 `define bsg_mem_1rw_sync_mask_write_byte_banked_macro(words,bits,wbank,dbank) \
-  if (harden_p && els_p == words && data_width_p == bits) begin: macro        \
+  if (harden_p && els_p == words && width_p == bits) begin: macro        \
       bsg_mem_1rw_sync_mask_write_byte_banked #(                              \
-        .data_width_p(data_width_p)                                           \
+        .width_p(width_p)                                           \
         ,.els_p(els_p)                                                        \
         ,.latch_last_read_p(latch_last_read_p)                                \
         ,.num_width_bank_p(wbank)                                             \

--- a/hard/pickle_40/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
+++ b/hard/pickle_40/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
@@ -1,6 +1,6 @@
 
 `define bsg_mem_1rw_sync_mask_write_byte_macro(words,bits) \
-  if (els_p == words && data_width_p == bits)              \
+  if (els_p == words && width_p == bits)              \
     begin: macro                                           \
       hard_mem_1rw_byte_mask_d``words``_w``bits``_wrapper  \
         mem                                                \
@@ -16,9 +16,9 @@
     end: macro
 
 module bsg_mem_1rw_sync_mask_write_byte #( parameter `BSG_INV_PARAM(els_p )
-                                         , parameter `BSG_INV_PARAM(data_width_p )
+                                         , parameter `BSG_INV_PARAM(width_p )
                                          , parameter addr_width_lp = `BSG_SAFE_CLOG2(els_p)
-                                         , parameter write_mask_width_lp = data_width_p>>3
+                                         , parameter write_mask_width_lp = width_p>>3
                                          )
 
   ( input                           clk_i
@@ -26,9 +26,9 @@ module bsg_mem_1rw_sync_mask_write_byte #( parameter `BSG_INV_PARAM(els_p )
   , input                           v_i
   , input                           w_i
   , input [addr_width_lp-1:0]       addr_i
-  , input [data_width_p-1:0]        data_i
+  , input [width_p-1:0]        data_i
   , input [write_mask_width_lp-1:0] write_mask_i
-  , output logic [data_width_p-1:0] data_o
+  , output logic [width_p-1:0] data_o
   );
 
   wire unused = reset_i;
@@ -38,7 +38,7 @@ module bsg_mem_1rw_sync_mask_write_byte #( parameter `BSG_INV_PARAM(els_p )
 
   // no hardened version found
     begin : notmacro
-      bsg_mem_1rw_sync_mask_write_byte_synth #(.data_width_p(data_width_p), .els_p(els_p))
+      bsg_mem_1rw_sync_mask_write_byte_synth #(.width_p(width_p), .els_p(els_p))
         synth
           (.*);
     end // block: notmacro
@@ -47,13 +47,13 @@ module bsg_mem_1rw_sync_mask_write_byte #( parameter `BSG_INV_PARAM(els_p )
 `ifndef BSG_HIDE_FROM_SYNTHESIS
   always_comb
     begin
-      assert (data_width_p % 8 == 0)
+      assert (width_p % 8 == 0)
         else $error("data width should be a multiple of 8 for byte masking");
     end
 
   initial
     begin
-      $display("## bsg_mem_1rw_sync_mask_write_byte: instantiating data_width_p=%d, els_p=%d (%m)",data_width_p,els_p);
+      $display("## bsg_mem_1rw_sync_mask_write_byte: instantiating width_p=%d, els_p=%d (%m)",width_p,els_p);
     end
 `endif
    

--- a/hard/saed_90/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
+++ b/hard/saed_90/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
@@ -5,7 +5,7 @@
 //
 
 `define bsg_mem_1rw_sync_mask_write_byte_macro(bits,words)  \
-  if (els_p == words && data_width_p == bits)    \
+  if (els_p == words && width_p == bits)    \
     begin: macro                            \
        saed90_``bits``x``words``_1P_BM mem  \
          (.CE1  (clk_lo)                     \
@@ -20,9 +20,9 @@
     end
 
 module bsg_mem_1rw_sync_mask_write_byte #(parameter `BSG_INV_PARAM(els_p )
-                                         ,parameter `BSG_INV_PARAM(data_width_p )
+                                         ,parameter `BSG_INV_PARAM(width_p )
                                          ,parameter addr_width_lp = `BSG_SAFE_CLOG2(els_p)
-                                         ,parameter write_mask_width_lp = data_width_p>>3
+                                         ,parameter write_mask_width_lp = width_p>>3
                                          ,parameter enable_clock_gating_p=1'b0
                                          )
   (input                           clk_i
@@ -30,9 +30,9 @@ module bsg_mem_1rw_sync_mask_write_byte #(parameter `BSG_INV_PARAM(els_p )
   ,input                           v_i
   ,input                           w_i
   ,input [addr_width_lp-1:0]       addr_i
-  ,input [data_width_p-1:0]        data_i
+  ,input [width_p-1:0]        data_i
   ,input [write_mask_width_lp-1:0] write_mask_i
-  ,output [data_width_p-1:0]       data_o
+  ,output [width_p-1:0]       data_o
   );
 
    wire clk_lo;
@@ -58,7 +58,7 @@ module bsg_mem_1rw_sync_mask_write_byte #(parameter `BSG_INV_PARAM(els_p )
     begin: notmacro
 
       // Instantiate a synthesizale 1rw sync mask write byte
-      bsg_mem_1rw_sync_mask_write_byte_synth #(.els_p(els_p), .data_width_p(data_width_p)) synth 
+      bsg_mem_1rw_sync_mask_write_byte_synth #(.els_p(els_p), .width_p(width_p)) synth 
        (.clk_i(clk_lo)
        ,.reset_i
        ,.v_i
@@ -74,12 +74,12 @@ module bsg_mem_1rw_sync_mask_write_byte #(parameter `BSG_INV_PARAM(els_p )
 
 `ifndef BSG_HIDE_FROM_SYNTHESIS
   always_comb
-    assert (data_width_p % 8 == 0)
+    assert (width_p % 8 == 0)
       else $error("data width should be a multiple of 8 for byte masking");
 
   initial
     begin
-      $display("## bsg_mem_1rw_sync_mask_write_byte: instantiating data_width_p=%d, els_p=%d (%m)",data_width_p,els_p);
+      $display("## bsg_mem_1rw_sync_mask_write_byte: instantiating width_p=%d, els_p=%d (%m)",width_p,els_p);
     end
 `endif
    

--- a/hard/tsmc_16/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
+++ b/hard/tsmc_16/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
@@ -4,21 +4,21 @@
 // Only one read or one write may be done per cycle.
 //
 module bsg_mem_1rw_sync_mask_write_byte #(parameter `BSG_INV_PARAM(els_p )
-                                         ,parameter `BSG_INV_PARAM(data_width_p )
+                                         ,parameter `BSG_INV_PARAM(width_p )
                                          ,parameter addr_width_lp = `BSG_SAFE_CLOG2(els_p)
-                                         ,parameter write_mask_width_lp = data_width_p>>3
+                                         ,parameter write_mask_width_lp = width_p>>3
                                          )
   (input                           clk_i
   ,input                           reset_i
   ,input                           v_i
   ,input                           w_i
   ,input [addr_width_lp-1:0]       addr_i
-  ,input [data_width_p-1:0]        data_i
+  ,input [width_p-1:0]        data_i
   ,input [write_mask_width_lp-1:0] write_mask_i
-  ,output [data_width_p-1:0]       data_o
+  ,output [width_p-1:0]       data_o
   );
 
-  if ((els_p == 1024) & (data_width_p == 32))
+  if ((els_p == 1024) & (width_p == 32))
     begin : macro
       wire [31:0] wen = ~{{8{write_mask_i[3]}}
                          ,{8{write_mask_i[2]}}
@@ -45,18 +45,18 @@ module bsg_mem_1rw_sync_mask_write_byte #(parameter `BSG_INV_PARAM(els_p )
     begin: notmacro
 
       // Instantiate a synthesizale 1rw sync mask write byte
-      bsg_mem_1rw_sync_mask_write_byte_synth #(.els_p(els_p), .data_width_p(data_width_p)) synth (.*);
+      bsg_mem_1rw_sync_mask_write_byte_synth #(.els_p(els_p), .width_p(width_p)) synth (.*);
 
     end // block: notmacro
 
 `ifndef BSG_HIDE_FROM_SYNTHESIS
   always_comb
-    assert (data_width_p % 8 == 0)
+    assert (width_p % 8 == 0)
       else $error("data width should be a multiple of 8 for byte masking");
 
   initial
     begin
-      $display("## bsg_mem_1rw_sync_mask_write_byte: instantiating data_width_p=%d, els_p=%d (%m)",data_width_p,els_p);
+      $display("## bsg_mem_1rw_sync_mask_write_byte: instantiating width_p=%d, els_p=%d (%m)",width_p,els_p);
     end
 `endif
    

--- a/hard/tsmc_180_250/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
+++ b/hard/tsmc_180_250/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
@@ -6,9 +6,9 @@
 module bsg_mem_1rw_sync_mask_write_byte
 
  #(parameter `BSG_INV_PARAM(els_p )
-  ,parameter `BSG_INV_PARAM(data_width_p )
+  ,parameter `BSG_INV_PARAM(width_p )
   ,parameter addr_width_lp = `BSG_SAFE_CLOG2(els_p)
-  ,parameter write_mask_width_lp = data_width_p>>3
+  ,parameter write_mask_width_lp = width_p>>3
   )
 
   (input                           clk_i
@@ -18,15 +18,15 @@ module bsg_mem_1rw_sync_mask_write_byte
   ,input                           w_i
 
   ,input [addr_width_lp-1:0]       addr_i
-  ,input [data_width_p-1:0]        data_i
+  ,input [width_p-1:0]        data_i
 
   ,input [write_mask_width_lp-1:0] write_mask_i
 
-  ,output [data_width_p-1:0] data_o
+  ,output [width_p-1:0] data_o
   );
 
   // TSMC 180 1024x32 Byte Mask
-  if ((els_p == 1024) & (data_width_p == 32))
+  if ((els_p == 1024) & (width_p == 32))
     begin : macro
       wire [3:0] wen = {~(w_i & write_mask_i[3])
                        ,~(w_i & write_mask_i[2])
@@ -49,7 +49,7 @@ module bsg_mem_1rw_sync_mask_write_byte
     begin  : notmacro
 
        bsg_mem_1rw_sync_mask_write_byte_synth
-	 #(.els_p(els_p), .data_width_p(data_width_p))
+	 #(.els_p(els_p), .width_p(width_p))
        synth (.*);
 
     end
@@ -58,12 +58,12 @@ module bsg_mem_1rw_sync_mask_write_byte
 `ifndef BSG_HIDE_FROM_SYNTHESIS
 
   always_comb
-    assert (data_width_p % 8 == 0)
+    assert (width_p % 8 == 0)
       else $error("data width should be a multiple of 8 for byte masking");
 
    initial
      begin
-        $display("## bsg_mem_1rw_sync_mask_write_byte: instantiating data_width_p=%d, els_p=%d (%m)",data_width_p,els_p);
+        $display("## bsg_mem_1rw_sync_mask_write_byte: instantiating width_p=%d, els_p=%d (%m)",width_p,els_p);
      end
 
 `endif

--- a/hard/tsmc_28/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_macros.svh
+++ b/hard/tsmc_28/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_macros.svh
@@ -9,9 +9,9 @@
   `bsg_mem_1rw_sync_mask_write_byte_macro(words,bits)
 
 `define bsg_mem_1rw_sync_mask_write_byte_macro(words,bits) \
-if (harden_p && els_p == words && data_width_p == bits)         \
+if (harden_p && els_p == words && width_p == bits)         \
   begin: wrap                                                   \
-    logic [data_width_p-1:0] w_mask_li;                         \
+    logic [width_p-1:0] w_mask_li;                         \
     bsg_expand_bitmask                                          \
      #(.in_width_p(write_mask_width_lp), .expand_p(8))          \
      wmask_expand                                               \
@@ -20,15 +20,15 @@ if (harden_p && els_p == words && data_width_p == bits)         \
        );                                                       \
                                                                 \
     bsg_mem_1rw_sync_mask_write_bit                             \
-     #(.width_p(data_width_p), .els_p(els_p))                   \
+     #(.width_p(width_p), .els_p(els_p))                   \
      bit_mem                                                    \
       (.w_mask_i(w_mask_li), .*);                               \
   end
 
 `define bsg_mem_1rw_sync_mask_write_byte_banked_macro(words,bits,wbank,dbank) \
-  if (harden_p && els_p == words && data_width_p == bits) begin: macro        \
+  if (harden_p && els_p == words && width_p == bits) begin: macro        \
       bsg_mem_1rw_sync_mask_write_byte_banked #(                              \
-        .data_width_p(data_width_p)                                           \
+        .width_p(width_p)                                           \
         ,.els_p(els_p)                                                        \
         ,.latch_last_read_p(latch_last_read_p)                                \
         ,.num_width_bank_p(wbank)                                             \

--- a/hard/tsmc_40/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
+++ b/hard/tsmc_40/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
@@ -5,9 +5,9 @@
 //
 
 `define bsg_mem_1rw_sync_macro_byte(words,bits,lgEls,mux) \
-if (els_p == words && data_width_p == bits)               \
+if (els_p == words && width_p == bits)               \
   begin: macro                                            \
-    wire [data_width_p-1:0] wen;                          \
+    wire [width_p-1:0] wen;                          \
     genvar i;                                             \
     for(i=0;i<write_mask_width_lp;i++)                    \
       assign wen[8*i+:8] = {8{write_mask_i[i]}};          \
@@ -24,9 +24,9 @@ if (els_p == words && data_width_p == bits)               \
   end
 
 `define bsg_mem_1rf_sync_macro_byte(words,bits,lgEls,mux) \
-if (els_p == words && data_width_p == bits)               \
+if (els_p == words && width_p == bits)               \
   begin: macro                                            \
-    wire [data_width_p-1:0] wen;                          \
+    wire [width_p-1:0] wen;                          \
     genvar i;                                             \
     for(i=0;i<write_mask_width_lp;i++)                    \
       assign wen[8*i+:8] = {8{write_mask_i[i]}};          \
@@ -42,10 +42,10 @@ if (els_p == words && data_width_p == bits)               \
   end
 
 `define bsg_mem_1rf_sync_macro_byte_banks(words,bits,lgEls,mux) \
-if (els_p == 2*``words`` && data_width_p == bits)               \
+if (els_p == 2*``words`` && width_p == bits)               \
   begin: macro                                                  \
-    wire [data_width_p-1:0] wen;                                \
-    wire [data_width_p-1:0] bank_data [0:1];                    \
+    wire [width_p-1:0] wen;                                \
+    wire [width_p-1:0] bank_data [0:1];                    \
     logic sel;                                                  \
     always_ff @(posedge clk_i)                                  \
       sel <= addr_i[0];                                         \
@@ -76,9 +76,9 @@ if (els_p == 2*``words`` && data_width_p == bits)               \
 module bsg_mem_1rw_sync_mask_write_byte
 
  #(parameter `BSG_INV_PARAM(els_p )
-  ,parameter `BSG_INV_PARAM(data_width_p )
+  ,parameter `BSG_INV_PARAM(width_p )
   ,parameter addr_width_lp = `BSG_SAFE_CLOG2(els_p)
-  ,parameter write_mask_width_lp = data_width_p>>3
+  ,parameter write_mask_width_lp = width_p>>3
   )
 
   (input                           clk_i
@@ -88,11 +88,11 @@ module bsg_mem_1rw_sync_mask_write_byte
   ,input                           w_i
 
   ,input [addr_width_lp-1:0]       addr_i
-  ,input [data_width_p-1:0]        data_i
+  ,input [width_p-1:0]        data_i
 
   ,input [write_mask_width_lp-1:0] write_mask_i
 
-  ,output [data_width_p-1:0] data_o
+  ,output [width_p-1:0] data_o
   );
 
   wire unused = reset_i;
@@ -107,7 +107,7 @@ module bsg_mem_1rw_sync_mask_write_byte
     begin  : notmacro
 
        bsg_mem_1rw_sync_mask_write_byte_synth
-	 #(.els_p(els_p), .data_width_p(data_width_p))
+	 #(.els_p(els_p), .width_p(width_p))
        synth (.*);
 
     end
@@ -116,12 +116,12 @@ module bsg_mem_1rw_sync_mask_write_byte
 `ifndef BSG_HIDE_FROM_SYNTHESIS
 
   always_comb
-    assert (data_width_p % 8 == 0)
+    assert (width_p % 8 == 0)
       else $error("data width should be a multiple of 8 for byte masking");
 
    initial
      begin
-        $display("## bsg_mem_1rw_sync_mask_write_byte: instantiating data_width_p=%d, els_p=%d (%m)",data_width_p,els_p);
+        $display("## bsg_mem_1rw_sync_mask_write_byte: instantiating width_p=%d, els_p=%d (%m)",width_p,els_p);
      end
 
 `endif

--- a/hard/ultrascale_plus/2019.1/bsg_mem_1rw_sync_mask_write_byte.sv
+++ b/hard/ultrascale_plus/2019.1/bsg_mem_1rw_sync_mask_write_byte.sv
@@ -40,9 +40,9 @@
 module bsg_mem_1rw_sync_mask_write_byte #(parameter `BSG_INV_PARAM(els_p)
                                           ,parameter addr_width_lp = `BSG_SAFE_CLOG2(els_p)
 
-                                          ,parameter `BSG_INV_PARAM(data_width_p )
+                                          ,parameter `BSG_INV_PARAM(width_p )
                                           ,parameter latch_last_read_p=0
-                                          ,parameter write_mask_width_lp = data_width_p>>3
+                                          ,parameter write_mask_width_lp = width_p>>3
                                           ,parameter enable_clock_gating_p=0
                                          )
   ( input clk_i
@@ -52,16 +52,16 @@ module bsg_mem_1rw_sync_mask_write_byte #(parameter `BSG_INV_PARAM(els_p)
    ,input w_i
 
    ,input [addr_width_lp-1:0]       addr_i
-   ,input [`BSG_SAFE_MINUS(data_width_p, 1):0]        data_i
+   ,input [`BSG_SAFE_MINUS(width_p, 1):0]        data_i
     // for each bit set in the mask, a byte is written
    ,input [`BSG_SAFE_MINUS(write_mask_width_lp, 1):0] write_mask_i
 
-   ,output logic [`BSG_SAFE_MINUS(data_width_p, 1):0] data_o
+   ,output logic [`BSG_SAFE_MINUS(width_p, 1):0] data_o
   );
 
   wire unused = reset_i;
 
-  if (data_width_p == 0)
+  if (width_p == 0)
   begin: z
     wire unused0 = &{clk_i, v_i, w_i, addr_i, data_i, write_mask_i};
     assign data_o = '0;
@@ -77,7 +77,7 @@ module bsg_mem_1rw_sync_mask_write_byte #(parameter `BSG_INV_PARAM(els_p)
    * BRAM and URAM inference based on depth and width parameterizations.
    */
 
-    logic [data_width_p-1:0] mem [els_p-1:0];
+    logic [width_p-1:0] mem [els_p-1:0];
     logic [write_mask_width_lp-1:0] write_enable;
 
   /* In order to synthesize into a byte masked BRAM/URAM, follow instruction in

--- a/hard/ultrascale_plus/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
+++ b/hard/ultrascale_plus/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.sv
@@ -85,11 +85,11 @@ endgenerate
 
 endmodule
 
- module bsg_mem_1rw_sync_mask_write_byte #(parameter `BSG_INV_PARAM(data_width_p)
+ module bsg_mem_1rw_sync_mask_write_byte #(parameter `BSG_INV_PARAM(width_p)
                            , parameter `BSG_INV_PARAM(els_p)
                            , parameter latch_last_read_p=0
                            , parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
-                           , parameter write_mask_width_lp = data_width_p>>3
+                           , parameter write_mask_width_lp = width_p>>3
                            , parameter enable_clock_gating_p=0
                            , parameter harden_p=1
                            )
@@ -100,11 +100,11 @@ endmodule
     ,input w_i
 
     ,input [addr_width_lp-1:0]       addr_i
-    ,input [`BSG_SAFE_MINUS(data_width_p, 1):0]        data_i
+    ,input [`BSG_SAFE_MINUS(width_p, 1):0]        data_i
      // for each bit set in the mask, a byte is written
     ,input [`BSG_SAFE_MINUS(write_mask_width_lp, 1):0] write_mask_i
 
-    ,output logic [`BSG_SAFE_MINUS(data_width_p, 1):0] data_o
+    ,output logic [`BSG_SAFE_MINUS(width_p, 1):0] data_o
    );
 
      bytewrite_ram_1b #(


### PR DESCRIPTION
Currently, only bsg_mem_1rw_sync_mask_write_byte and friends use data_width_p while other memories use width_p. This makes scripted parsing harder and instantiation more confusing

This PR fixes this discrepancy and standardizes width_p as bsg_mem parameter name