### PR TITLE
Fixing ununsized concat in BSG_WIDTH

### DIFF
--- a/bsg_misc/bsg_defines.sv
+++ b/bsg_misc/bsg_defines.sv
@@ -47,7 +47,7 @@
 // maps 0/1 --> 1 instead of to 0
 `define BSG_SAFE_CLOG2(x) ( (((x)==1) || ((x)==0))? 1 : $clog2((x)))
 `define BSG_IS_POW2(x) ( (1 << $clog2(x)) == (x))
-`define BSG_WIDTH(x) ( ((x)==0)? 1 : $clog2(x) + (`BSG_IS_POW2(x) ? 1 : 0))
+`define BSG_WIDTH(x) ( $clog2(x) + (`BSG_IS_POW2(x) ? 1 : 0))
 `define BSG_SAFE_MINUS(x, y) (((x)<(y))) ? 0 : ((x)-(y))
 
 // these "SAFE" shift functions handle a common problem that shifts default to 32 bits wide even

--- a/bsg_misc/bsg_defines.sv
+++ b/bsg_misc/bsg_defines.sv
@@ -47,7 +47,7 @@
 // maps 1 --> 1 instead of to 0
 `define BSG_SAFE_CLOG2(x) ( (((x)==1) || ((x)==0))? 1 : $clog2((x)))
 `define BSG_IS_POW2(x) ( (1 << $clog2(x)) == (x))
-`define BSG_WIDTH(x) (((x) == 0) ? 0 : ($clog2(x) + ((((x) & ((x) - 1)) == 0) ? 1 : 0)))
+`define BSG_WIDTH(x) (((x) == 0) ? 1 : ($clog2(x) + ((((x) & ((x) - 1)) == 0) ? 1 : 0)))
 `define BSG_SAFE_MINUS(x, y) (((x)<(y))) ? 0 : ((x)-(y))
 
 // these "SAFE" shift functions handle a common problem that shifts default to 32 bits wide even

--- a/bsg_misc/bsg_defines.sv
+++ b/bsg_misc/bsg_defines.sv
@@ -47,7 +47,7 @@
 // maps 1 --> 1 instead of to 0
 `define BSG_SAFE_CLOG2(x) ( (((x)==1) || ((x)==0))? 1 : $clog2((x)))
 `define BSG_IS_POW2(x) ( (1 << $clog2(x)) == (x))
-`define BSG_WIDTH(x) ($clog2(($bits(x)+1)'(x)+1))
+`define BSG_WIDTH(x) (((x) == 0) ? 0 : ($clog2(x) + ((((x) & ((x) - 1)) == 0) ? 1 : 0)))
 `define BSG_SAFE_MINUS(x, y) (((x)<(y))) ? 0 : ((x)-(y))
 
 // these "SAFE" shift functions handle a common problem that shifts default to 32 bits wide even

--- a/bsg_misc/bsg_defines.sv
+++ b/bsg_misc/bsg_defines.sv
@@ -47,7 +47,7 @@
 // maps 1 --> 1 instead of to 0
 `define BSG_SAFE_CLOG2(x) ( (((x)==1) || ((x)==0))? 1 : $clog2((x)))
 `define BSG_IS_POW2(x) ( (1 << $clog2(x)) == (x))
-`define BSG_WIDTH(x) ($clog2({1'b0, x}+1))
+`define BSG_WIDTH(x) ($clog2(($bits(x)+1)'(x)+1))
 `define BSG_SAFE_MINUS(x, y) (((x)<(y))) ? 0 : ((x)-(y))
 
 // these "SAFE" shift functions handle a common problem that shifts default to 32 bits wide even

--- a/bsg_misc/bsg_defines.sv
+++ b/bsg_misc/bsg_defines.sv
@@ -44,10 +44,10 @@
 `endif
 
 
-// maps 1 --> 1 instead of to 0
+// maps 0/1 --> 1 instead of to 0
 `define BSG_SAFE_CLOG2(x) ( (((x)==1) || ((x)==0))? 1 : $clog2((x)))
 `define BSG_IS_POW2(x) ( (1 << $clog2(x)) == (x))
-`define BSG_WIDTH(x) (((x) == 0) ? 1 : ($clog2(x) + ((((x) & ((x) - 1)) == 0) ? 1 : 0)))
+`define BSG_WIDTH(x) ( ((x)==0)? 1 : $clog2(x) + (`BSG_IS_POW2(x) ? 1 : 0))
 `define BSG_SAFE_MINUS(x, y) (((x)<(y))) ? 0 : ((x)-(y))
 
 // these "SAFE" shift functions handle a common problem that shifts default to 32 bits wide even


### PR DESCRIPTION

```
credit_counter_width_p=`BSG_WIDTH(32)
...
xmvlog: *E,NONOWD (bsg_manycore/v/bsg_manycore_endpoint_standard.sv,37|44): Illegal use of a constant without an explicit width specification [4.1.14(IEEE)].
```

Basically '32' is an integer literal which is usually evaluated to 32b width but by strict IEEE is unsized. This could be patched in all usages of BSG_WIDTH by doing e.g. 32'd32, but this solution should fix the compilation error and maintain the overflow property from 0e8460329e1af3fac7536c24187b6886165c4aa6