### PR TITLE
bsg_dmc: fix CALR ldst_tick using wrong bank state

### DIFF
--- a/bsg_dmc/bsg_dmc_controller.sv
+++ b/bsg_dmc/bsg_dmc_controller.sv
@@ -382,7 +382,18 @@ module bsg_dmc_controller
   always_ff @(posedge dfi_clk_i) begin
     if(dfi_clk_sync_rst_i)
       ldst_tick <= 0;
-    else if(cstate == IDLE && (nstate == LDST || nstate == CALR)) begin
+    else if(cstate == IDLE && nstate == CALR) begin
+      // CALR always targets bank 0, row 0; use that bank's open state, not the
+      // user command's bank, to avoid issuing ACT to an already-open bank or
+      // READ to an inactive bank.
+      if(open_bank[0] && open_row[0] == '0)
+        ldst_tick <= 1;
+      else if(open_bank[0])
+        ldst_tick <= 3;
+      else
+        ldst_tick <= 2;
+    end
+    else if(cstate == IDLE && nstate == LDST) begin
       if(open_bank[bank_addr] && open_row[bank_addr] == row_addr)
         ldst_tick <= 1;
       else if(open_bank[bank_addr])


### PR DESCRIPTION
Hi there!

CALR always reads bank 0, row 0, but its ldst_tick setup used the bank/row from the user-command AFIFO head. If a non-zero-bank user command was pending when calibration fired, CALR could issue ACT to an already-open bank 0 or READ to inactive bank 0.

This PR splits the CALR and LDST setup paths so CALR checks open_bank[0] / open_row[0], matching its actual target.

Thanks!
Flavien