### PR TITLE
Add BSG_SAFE_WIDTH and fix zero-maximum counter elaboration

### DIFF
--- a/bsg_misc/bsg_counter_clear_up.sv
+++ b/bsg_misc/bsg_counter_clear_up.sv
@@ -9,8 +9,10 @@ module bsg_counter_clear_up #(parameter `BSG_INV_PARAM(max_val_p)
 			      // this originally had an "invalid" default value of -1
 			      // which is a bad choice for a counter
 			     ,parameter init_val_p   = `BSG_UNDEFINED_IN_SIM('0)
+                             // Maximum zero still needs one bit for a legal register and casts.
+                             // The safe helper preserves BSG_WIDTH's full-range maximum handling.
                              ,parameter ptr_width_lp =
-                             `BSG_WIDTH(max_val_p)
+                             `BSG_SAFE_WIDTH(max_val_p)
 			     ,parameter disable_overflow_warning_p = 0
                              )
    (input  clk_i

--- a/bsg_misc/bsg_defines.sv
+++ b/bsg_misc/bsg_defines.sv
@@ -48,6 +48,8 @@
 `define BSG_SAFE_CLOG2(x) ( (((x)==1) || ((x)==0))? 1 : $clog2((x)))
 `define BSG_IS_POW2(x) ( (1 << $clog2(x)) == (x))
 `define BSG_WIDTH(x) ( $clog2(x) + (`BSG_IS_POW2(x) ? 1 : 0))
+// Bits for an inclusive maximum x >= 0, with at least one storage bit.
+`define BSG_SAFE_WIDTH(x) (`BSG_MAX(1, `BSG_WIDTH(x)))
 `define BSG_SAFE_MINUS(x, y) (((x)<(y))) ? 0 : ((x)-(y))
 
 // these "SAFE" shift functions handle a common problem that shifts default to 32 bits wide even

--- a/testing/bsg_misc/bsg_counter_clear_up/Makefile
+++ b/testing/bsg_misc/bsg_counter_clear_up/Makefile
@@ -1,0 +1,12 @@
+TOP = ../../..
+BSG_TESTME_FILES = bsg_counter_clear_up.sv
+BSG_TESTME_DIR = $(TOP)/bsg_misc
+BSG_MISC_FILES = bsg_defines.sv
+BSG_TEST_FILES = bsg_nonsynth_clock_gen.sv
+TEST_MAIN = test_bsg.sv
+TEST_MODULE = test_bsg
+
+CYCLE_TIME_P = 10
+scan_params = CYCLE_TIME_P
+
+include ../../Makefile.sim

--- a/testing/bsg_misc/bsg_counter_clear_up/test_bsg.sv
+++ b/testing/bsg_misc/bsg_counter_clear_up/test_bsg.sv
@@ -1,0 +1,91 @@
+`include "bsg_defines.sv"
+
+// Test reset, hold, increment, clear, and simultaneous clear/increment.
+// Maxima 0..8 cover singleton and power-of-two boundaries. Wide maxima check
+// that sizing does not overflow max_val_p+1 or truncate the highest count bit.
+// Check both macros explicitly: only BSG_SAFE_WIDTH maps maximum zero to one.
+module counter_test
+  #(parameter max_val_p = 0
+    , parameter expected_width_p = 1
+    , parameter init_val_p = (max_val_p == 0) ? 0 : max_val_p-1
+    )
+  (input clk_i
+   , output bit done_o
+   );
+
+  bit reset, clear, up;
+  logic [expected_width_p-1:0] count;
+
+  bsg_counter_clear_up #(.max_val_p(max_val_p), .init_val_p(init_val_p)) dut
+    (.clk_i(clk_i), .reset_i(reset), .clear_i(clear), .up_i(up), .count_o(count));
+
+  task automatic step(input bit reset_v, clear_v, up_v,
+                      input logic [expected_width_p-1:0] expected);
+    @(negedge clk_i);
+    reset = reset_v;
+    clear = clear_v;
+    up = up_v;
+    @(posedge clk_i);
+    #1;
+    if (count !== expected)
+      $fatal(1, "max=%h reset/clear/up=%b%b%b expected=%h actual=%h",
+             max_val_p, reset_v, clear_v, up_v, expected, count);
+    reset = 0;
+    clear = 0;
+    up = 0;
+  endtask
+
+  initial begin
+    if (`BSG_SAFE_WIDTH(max_val_p) != expected_width_p)
+      $fatal(1, "BSG_SAFE_WIDTH mismatch for max=%h", max_val_p);
+    if (`BSG_WIDTH(max_val_p) != ((max_val_p == 0) ? 0 : expected_width_p))
+      $fatal(1, "BSG_WIDTH semantics changed for max=%h", max_val_p);
+    if ($bits(dut.count_o) != expected_width_p)
+      $fatal(1, "max=%h expected width=%0d actual=%0d",
+             max_val_p, expected_width_p, $bits(dut.count_o));
+    step(1, 0, 0, expected_width_p'(init_val_p));
+    step(0, 0, 0, expected_width_p'(init_val_p));
+    if (max_val_p != 0) begin
+      step(0, 0, 1, expected_width_p'(max_val_p));
+      step(0, 0, 0, expected_width_p'(max_val_p));
+    end
+    step(0, 1, 0, '0);
+    if (max_val_p != 0) begin
+      step(0, 1, 1, expected_width_p'(1));
+      step(0, 0, 0, expected_width_p'(1));
+    end
+    step(1, 1, 0, expected_width_p'(init_val_p));
+    step(0, 1, 0, '0);
+    done_o = 1;
+  end
+endmodule
+
+module test_bsg;
+  wire clk;
+  wire [12:0] done;
+  bsg_nonsynth_clock_gen #(.cycle_time_p(`CYCLE_TIME_P)) clock_gen (.o(clk));
+
+  for (genvar i = 0; i <= 8; i++) begin: small_max
+    localparam width_lp = (i < 2) ? 1 : (i < 4) ? 2 : (i < 8) ? 3 : 4;
+    counter_test #(.max_val_p(i), .expected_width_p(width_lp)) t
+      (.clk_i(clk), .done_o(done[i]));
+  end
+  counter_test #(.max_val_p(32'h7fffffff), .expected_width_p(31)) signed_boundary
+    (.clk_i(clk), .done_o(done[9]));
+  counter_test #(.max_val_p(32'h80000000), .expected_width_p(32)) high_bit
+    (.clk_i(clk), .done_o(done[10]));
+  counter_test #(.max_val_p(32'hffffffff), .expected_width_p(32)) full32
+    (.clk_i(clk), .done_o(done[11]));
+  counter_test #(.max_val_p(64'hffffffffffffffff), .expected_width_p(64)) full64
+    (.clk_i(clk), .done_o(done[12]));
+
+  initial begin
+    wait (&done);
+    $display("PASS: counter widths and behavior for 13 parameter cases");
+    $finish;
+  end
+  initial begin
+    #(`CYCLE_TIME_P*100);
+    $fatal(1, "counter test timed out");
+  end
+endmodule


### PR DESCRIPTION
`bsg_counter_clear_up` currently derives a zero-bit width when `max_val_p=0`, causing zero-size casts to fail elaboration. This occurs in `bsg_cache_to_test_dram` when one DRAM request covers a cache line: its counter maximum is `num_req_lp-1=0`.

Add `BSG_SAFE_WIDTH(x)` as `max(1, BSG_WIDTH(x))` and use it for the counter's default width. This preserves `BSG_WIDTH(0)=0` and its full-range maximum handling, consistent with the semantic-compatibility decision in #741. The counter's sequencing is unchanged.

Validation on Verilator 5.050:

- Added a self-checking regression for maxima 0–8, `32'h7fffffff`, `32'h80000000`, `32'hffffffff`, and `64'hffffffffffffffff`. All 13 pass width, reset, hold, increment and clear checks; the test also checks both macros' distinct zero behavior.
- The same test with the original counter fails elaboration on zero-size casts.
- HammerBlade's 2×2, 4-way, 8-word-line HBM profile now builds execution and profiling models. Cold/warm vector_add N=4096 passes in both modes after a separate Replicant channel-count correction; the counter fix alone does not repair that profile's host DMA mapping mismatch.

Run the unit regression from `testing/bsg_misc/bsg_counter_clear_up` with:

```sh
make SIMULATOR=verilator SHELL=/bin/bash '.SHELLFLAGS=-e -o pipefail -c'
```

VCS, Xcelium and Design Compiler were not run.
